### PR TITLE
refactor(entity): replace UUIDs with auto-increment IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Identifiants** : remplacement des UUID par des ID auto-incrémentés sur toutes les entités
+
 ### Added
 
 - **Initialisation du projet** : CLAUDE.md, README.md, CHANGELOG.md, document de conception

--- a/backend/migrations/Version20260206184024.php
+++ b/backend/migrations/Version20260206184024.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20260205221539 extends AbstractMigration
+final class Version20260206184024 extends AbstractMigration
 {
     public function getDescription(): string
     {
@@ -20,11 +20,11 @@ final class Version20260205221539 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE game (id BINARY(16) NOT NULL, chelem VARCHAR(255) NOT NULL, contract VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL, oudlers INT DEFAULT NULL, petit_au_bout VARCHAR(255) NOT NULL, poignee VARCHAR(255) NOT NULL, poignee_owner VARCHAR(255) NOT NULL, points DOUBLE PRECISION DEFAULT NULL, position INT NOT NULL, status VARCHAR(255) NOT NULL, partner_id BINARY(16) DEFAULT NULL, session_id BINARY(16) NOT NULL, taker_id BINARY(16) NOT NULL, INDEX IDX_232B318C9393F8FE (partner_id), INDEX IDX_232B318C613FECDF (session_id), INDEX IDX_232B318CB2E74C3 (taker_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
-        $this->addSql('CREATE TABLE player (id BINARY(16) NOT NULL, name VARCHAR(50) NOT NULL, created_at DATETIME NOT NULL, UNIQUE INDEX UNIQ_98197A655E237E06 (name), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
-        $this->addSql('CREATE TABLE score_entry (id BINARY(16) NOT NULL, score INT NOT NULL, game_id BINARY(16) NOT NULL, player_id BINARY(16) NOT NULL, INDEX IDX_926D51F8E48FD905 (game_id), INDEX IDX_926D51F899E6F5DF (player_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
-        $this->addSql('CREATE TABLE session (id BINARY(16) NOT NULL, created_at DATETIME NOT NULL, is_active TINYINT NOT NULL, PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
-        $this->addSql('CREATE TABLE session_player (session_id BINARY(16) NOT NULL, player_id BINARY(16) NOT NULL, INDEX IDX_F772703C613FECDF (session_id), INDEX IDX_F772703C99E6F5DF (player_id), PRIMARY KEY (session_id, player_id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('CREATE TABLE game (id INT AUTO_INCREMENT NOT NULL, chelem VARCHAR(255) NOT NULL, contract VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL, oudlers INT DEFAULT NULL, petit_au_bout VARCHAR(255) NOT NULL, poignee VARCHAR(255) NOT NULL, poignee_owner VARCHAR(255) NOT NULL, points DOUBLE PRECISION DEFAULT NULL, position INT NOT NULL, status VARCHAR(255) NOT NULL, partner_id INT DEFAULT NULL, session_id INT NOT NULL, taker_id INT NOT NULL, INDEX IDX_232B318C9393F8FE (partner_id), INDEX IDX_232B318C613FECDF (session_id), INDEX IDX_232B318CB2E74C3 (taker_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('CREATE TABLE player (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(50) NOT NULL, created_at DATETIME NOT NULL, UNIQUE INDEX UNIQ_98197A655E237E06 (name), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('CREATE TABLE score_entry (id INT AUTO_INCREMENT NOT NULL, score INT NOT NULL, game_id INT NOT NULL, player_id INT NOT NULL, INDEX IDX_926D51F8E48FD905 (game_id), INDEX IDX_926D51F899E6F5DF (player_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('CREATE TABLE session (id INT AUTO_INCREMENT NOT NULL, created_at DATETIME NOT NULL, is_active TINYINT NOT NULL, PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('CREATE TABLE session_player (session_id INT NOT NULL, player_id INT NOT NULL, INDEX IDX_F772703C613FECDF (session_id), INDEX IDX_F772703C99E6F5DF (player_id), PRIMARY KEY (session_id, player_id)) DEFAULT CHARACTER SET utf8mb4');
         $this->addSql('ALTER TABLE game ADD CONSTRAINT FK_232B318C9393F8FE FOREIGN KEY (partner_id) REFERENCES player (id)');
         $this->addSql('ALTER TABLE game ADD CONSTRAINT FK_232B318C613FECDF FOREIGN KEY (session_id) REFERENCES session (id)');
         $this->addSql('ALTER TABLE game ADD CONSTRAINT FK_232B318CB2E74C3 FOREIGN KEY (taker_id) REFERENCES player (id)');

--- a/backend/src/Entity/Game.php
+++ b/backend/src/Entity/Game.php
@@ -22,11 +22,7 @@ use App\Validator\PlayersBelongToSession;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
-use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Serializer\Attribute\Groups;
-use Symfony\Component\Uid\Uuid;
-use Symfony\Component\Uid\UuidV7;
 
 #[ApiResource(
     operations: [
@@ -57,10 +53,9 @@ class Game
 {
     #[Groups(['game:read'])]
     #[ORM\Id]
-    #[ORM\Column(type: UuidType::NAME)]
-    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
-    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
-    private ?Uuid $id = null;
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
 
     #[Groups(['game:read', 'game:complete'])]
     #[ORM\Column(enumType: Chelem::class)]
@@ -124,11 +119,10 @@ class Game
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
-        $this->id = new UuidV7();
         $this->scoreEntries = new ArrayCollection();
     }
 
-    public function getId(): ?Uuid
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/backend/src/Entity/Player.php
+++ b/backend/src/Entity/Player.php
@@ -10,12 +10,8 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
-use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Serializer\Attribute\Groups;
-use Symfony\Component\Uid\Uuid;
-use Symfony\Component\Uid\UuidV7;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
@@ -34,10 +30,9 @@ class Player
 {
     #[Groups(['player:read'])]
     #[ORM\Id]
-    #[ORM\Column(type: UuidType::NAME)]
-    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
-    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
-    private ?Uuid $id = null;
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
 
     #[Assert\NotBlank]
     #[Groups(['game:read', 'player:read', 'player:write', 'score-entry:read', 'session:read'])]
@@ -51,10 +46,9 @@ class Player
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
-        $this->id = new UuidV7();
     }
 
-    public function getId(): ?Uuid
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/backend/src/Entity/ScoreEntry.php
+++ b/backend/src/Entity/ScoreEntry.php
@@ -5,21 +5,16 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
-use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Serializer\Attribute\Groups;
-use Symfony\Component\Uid\Uuid;
-use Symfony\Component\Uid\UuidV7;
 
 #[ORM\Entity]
 class ScoreEntry
 {
     #[Groups(['game:read', 'score-entry:read'])]
     #[ORM\Id]
-    #[ORM\Column(type: UuidType::NAME)]
-    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
-    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
-    private ?Uuid $id = null;
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: Game::class, inversedBy: 'scoreEntries')]
     #[ORM\JoinColumn(nullable: false)]
@@ -34,12 +29,7 @@ class ScoreEntry
     #[ORM\Column]
     private int $score;
 
-    public function __construct()
-    {
-        $this->id = new UuidV7();
-    }
-
-    public function getId(): ?Uuid
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/backend/src/Entity/Session.php
+++ b/backend/src/Entity/Session.php
@@ -13,11 +13,7 @@ use App\State\SessionDetailProvider;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
-use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Serializer\Attribute\Groups;
-use Symfony\Component\Uid\Uuid;
-use Symfony\Component\Uid\UuidV7;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
@@ -37,10 +33,9 @@ class Session
 {
     #[Groups(['session:read'])]
     #[ORM\Id]
-    #[ORM\Column(type: UuidType::NAME)]
-    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
-    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
-    private ?Uuid $id = null;
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
 
     #[Groups(['session:read'])]
     #[ORM\Column(type: 'datetime_immutable')]
@@ -66,7 +61,7 @@ class Session
     /**
      * Scores cumulés par joueur — propriété non persistée, alimentée par SessionDetailProvider.
      *
-     * @var array<array{playerId: string, playerName: string, score: int}>|null
+     * @var array<array{playerId: int, playerName: string, score: int}>|null
      */
     #[Groups(['session:detail'])]
     private ?array $cumulativeScores = null;
@@ -75,11 +70,10 @@ class Session
     {
         $this->createdAt = new \DateTimeImmutable();
         $this->games = new ArrayCollection();
-        $this->id = new UuidV7();
         $this->players = new ArrayCollection();
     }
 
-    public function getId(): ?Uuid
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -151,7 +145,7 @@ class Session
     }
 
     /**
-     * @return array<array{playerId: string, playerName: string, score: int}>|null
+     * @return array<array{playerId: int, playerName: string, score: int}>|null
      */
     public function getCumulativeScores(): ?array
     {
@@ -159,7 +153,7 @@ class Session
     }
 
     /**
-     * @param array<array{playerId: string, playerName: string, score: int}> $cumulativeScores
+     * @param array<array{playerId: int, playerName: string, score: int}> $cumulativeScores
      */
     public function setCumulativeScores(array $cumulativeScores): static
     {

--- a/backend/src/State/GameCreateProcessor.php
+++ b/backend/src/State/GameCreateProcessor.php
@@ -42,7 +42,7 @@ final readonly class GameCreateProcessor implements ProcessorInterface
         $inProgress = $this->em->createQuery(
             'SELECT COUNT(g.id) FROM App\Entity\Game g WHERE g.session = :sessionId AND g.status = :status'
         )
-            ->setParameter('sessionId', $session->getId()?->toBinary())
+            ->setParameter('sessionId', $session->getId())
             ->setParameter('status', GameStatus::InProgress)
             ->getSingleScalarResult();
 
@@ -54,7 +54,7 @@ final readonly class GameCreateProcessor implements ProcessorInterface
         $maxPosition = $this->em->createQuery(
             'SELECT MAX(g.position) FROM App\Entity\Game g WHERE g.session = :sessionId'
         )
-            ->setParameter('sessionId', $session->getId()?->toBinary())
+            ->setParameter('sessionId', $session->getId())
             ->getSingleScalarResult();
 
         $data->setPosition(((int) $maxPosition) + 1);

--- a/backend/src/State/SessionCreateProcessor.php
+++ b/backend/src/State/SessionCreateProcessor.php
@@ -33,7 +33,7 @@ final readonly class SessionCreateProcessor implements ProcessorInterface
         foreach ($data->getPlayers() as $player) {
             $id = $player->getId();
             \assert(null !== $id);
-            $playerIds[] = $id->toBinary();
+            $playerIds[] = $id;
         }
 
         $existing = $this->findActiveSessionWithSamePlayers($playerIds, \count($playerIds));
@@ -46,9 +46,9 @@ final readonly class SessionCreateProcessor implements ProcessorInterface
     }
 
     /**
-     * @param string[] $playerIdBinaries
+     * @param int[] $playerIds
      */
-    private function findActiveSessionWithSamePlayers(array $playerIdBinaries, int $count): ?Session
+    private function findActiveSessionWithSamePlayers(array $playerIds, int $count): ?Session
     {
         $dql = <<<'DQL'
             SELECT s FROM App\Entity\Session s
@@ -62,7 +62,7 @@ final readonly class SessionCreateProcessor implements ProcessorInterface
         /** @var Session[] $candidates */
         $candidates = $this->em->createQuery($dql)
             ->setParameter('count', $count)
-            ->setParameter('playerIds', $playerIdBinaries)
+            ->setParameter('playerIds', $playerIds)
             ->getResult();
 
         // Vérifier qu'une session candidate a exactement le bon nombre de joueurs (pas plus)

--- a/backend/src/State/SessionDetailProvider.php
+++ b/backend/src/State/SessionDetailProvider.php
@@ -38,7 +38,7 @@ final readonly class SessionDetailProvider implements ProviderInterface
     }
 
     /**
-     * @return array<array{playerId: string, playerName: string, score: int}>
+     * @return array<array{playerId: int, playerName: string, score: int}>
      */
     private function computeCumulativeScores(Session $session): array
     {
@@ -52,9 +52,9 @@ final readonly class SessionDetailProvider implements ProviderInterface
             ORDER BY p.name ASC
             DQL;
 
-        /** @var array<array{playerId: string, playerName: string, totalScore: string}> $results */
+        /** @var array<array{playerId: int, playerName: string, totalScore: string}> $results */
         $results = $this->em->createQuery($dql)
-            ->setParameter('session', $session->getId()?->toBinary())
+            ->setParameter('session', $session->getId())
             ->getResult();
 
         return \array_map(static fn (array $row) => [

--- a/backend/src/Validator/OnlyLastGameEditableValidator.php
+++ b/backend/src/Validator/OnlyLastGameEditableValidator.php
@@ -30,7 +30,7 @@ class OnlyLastGameEditableValidator extends ConstraintValidator
         $maxPosition = (int) $this->em->createQuery(
             'SELECT MAX(g.position) FROM App\Entity\Game g WHERE g.session = :sessionId'
         )
-            ->setParameter('sessionId', $value->getSession()->getId()?->toBinary())
+            ->setParameter('sessionId', $value->getSession()->getId())
             ->getSingleScalarResult();
 
         if ($value->getPosition() < $maxPosition) {

--- a/backend/tests/Api/SessionApiTest.php
+++ b/backend/tests/Api/SessionApiTest.php
@@ -42,7 +42,7 @@ class SessionApiTest extends ApiTestCase
     {
         // Créer la session directement pour garantir l'état initial
         $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
-        $sessionId = $session->getId()->toString();
+        $sessionId = $session->getId();
 
         // Récupérer les IRIs des joueurs de la session
         $playerIris = [];


### PR DESCRIPTION
## Summary

- Remplace les UUID (UuidV7 / binary(16)) par des ID auto-incrémentés (INT) sur les 4 entités (Player, Session, Game, ScoreEntry)
- Supprime les appels `->toBinary()` dans les DQL (SessionDetailProvider, SessionCreateProcessor, GameCreateProcessor, OnlyLastGameEditableValidator)
- Met à jour les type hints (`playerId: string` → `playerId: int`) dans Session et SessionDetailProvider
- Régénère la migration from scratch avec CREATE TABLE (INT AUTO_INCREMENT)

## Test plan

- [x] 57 tests PHPUnit passent (35 ScoreCalculator + 22 API)
- [x] PHPStan + CS Fixer passent (hook automatique)
- [x] Migration from scratch sur DB vide

fixes #26