### PR TITLE
feat(frontend): home screen & session management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Écran d'accueil** : sélection de 5 joueurs (avec chips, recherche, création inline), démarrage/reprise de session, liste des sessions récentes
+- **Hook `useSessions`** : récupération des sessions via TanStack Query
+- **Hook `useCreateSession`** : mutation POST avec conversion des IDs en IRIs et invalidation du cache
+- **Composant `PlayerSelector`** : sélection contrôlée de joueurs avec chips, limite à 5, création inline via modal
+- **Composant `SessionList`** : liste cliquable des sessions récentes avec noms des joueurs, date et badge "En cours"
+- **Page `SessionPage`** : stub pour l'écran de session (à venir — issue #8)
+- **Route `/sessions/:id`** : navigation vers une session spécifique
+- **Types `Session` et `SessionPlayer`** : interfaces TypeScript pour les réponses API
 - **Gestion des joueurs** : écran complet avec liste, recherche par nom, ajout via formulaire modal, gestion des doublons (erreur 422)
 - **Hook `usePlayers`** : récupération des joueurs via TanStack Query avec filtrage côté client
 - **Hook `useCreatePlayer`** : mutation POST avec invalidation du cache et propagation des erreurs API
@@ -24,7 +32,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 - **SearchInput** : champ de recherche avec debounce configurable et bouton clear
 - **Hooks utilitaires** : `useAnimatedCounter` (animation rAF), `useDebounce` (délai configurable)
 - **Documentation** : guide utilisateur (`docs/user-guide.md`) et référence développeur (`docs/frontend-usage.md`)
-- **Tests frontend** : 61 tests (12 fichiers) couvrant tous les composants et hooks
+- **Tests frontend** : 117 tests (20 fichiers) couvrant tous les composants, hooks et pages
 - **Initialisation du projet** : CLAUDE.md, README.md, CHANGELOG.md, document de conception
 - **Document de conception** : architecture complète et design UI de l'application de scores au Tarot
 - **Projet GitHub** : 12 issues créées et organisées sur le tableau Tarot - Roadmap

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Layout from "./components/Layout";
 import { ThemeProvider } from "./hooks/useTheme";
 import Home from "./pages/Home";
 import Players from "./pages/Players";
+import SessionPage from "./pages/SessionPage";
 import Stats from "./pages/Stats";
 
 const queryClient = new QueryClient();
@@ -18,6 +19,7 @@ export default function App() {
             <Route element={<Layout />}>
               <Route path="/" element={<Home />} />
               <Route path="/players" element={<Players />} />
+              <Route path="/sessions/:id" element={<SessionPage />} />
               <Route path="/stats" element={<Stats />} />
             </Route>
           </Routes>

--- a/frontend/src/__tests__/components/PlayerSelector.test.tsx
+++ b/frontend/src/__tests__/components/PlayerSelector.test.tsx
@@ -1,0 +1,245 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import PlayerSelector from "../../components/PlayerSelector";
+import * as useCreatePlayerModule from "../../hooks/useCreatePlayer";
+import * as usePlayersModule from "../../hooks/usePlayers";
+import { renderWithProviders } from "../test-utils";
+
+vi.mock("../../hooks/usePlayers");
+vi.mock("../../hooks/useCreatePlayer");
+
+const mockPlayers = [
+  { createdAt: "2025-01-15T10:00:00+00:00", id: 1, name: "Alice" },
+  { createdAt: "2025-01-16T10:00:00+00:00", id: 2, name: "Bob" },
+  { createdAt: "2025-01-17T10:00:00+00:00", id: 3, name: "Charlie" },
+  { createdAt: "2025-01-18T10:00:00+00:00", id: 4, name: "Diana" },
+  { createdAt: "2025-01-19T10:00:00+00:00", id: 5, name: "Eve" },
+  { createdAt: "2025-01-20T10:00:00+00:00", id: 6, name: "Frank" },
+];
+
+function setupMocks(overrides?: {
+  createPlayer?: Partial<ReturnType<typeof useCreatePlayerModule.useCreatePlayer>>;
+  usePlayers?: Partial<ReturnType<typeof usePlayersModule.usePlayers>>;
+}) {
+  const mutate = vi.fn();
+  const reset = vi.fn();
+
+  vi.mocked(usePlayersModule.usePlayers).mockReturnValue({
+    data: mockPlayers,
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdateCount: 0,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    fetchStatus: "idle",
+    isError: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isInitialLoading: false,
+    isLoading: false,
+    isLoadingError: false,
+    isPaused: false,
+    isPending: false,
+    isPlaceholderData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true,
+    players: mockPlayers,
+    promise: Promise.resolve(mockPlayers),
+    refetch: vi.fn(),
+    status: "success",
+    ...overrides?.usePlayers,
+  } as unknown as ReturnType<typeof usePlayersModule.usePlayers>);
+
+  vi.mocked(useCreatePlayerModule.useCreatePlayer).mockReturnValue({
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate,
+    mutateAsync: vi.fn(),
+    reset,
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+    ...overrides?.createPlayer,
+  } as unknown as ReturnType<typeof useCreatePlayerModule.useCreatePlayer>);
+
+  return { mutate, reset };
+}
+
+describe("PlayerSelector", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders player list", () => {
+    setupMocks();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PlayerSelector onSelectionChange={onChange} selectedPlayerIds={[]} />,
+    );
+
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.getByText("Frank")).toBeInTheDocument();
+  });
+
+  it("displays selection count", () => {
+    setupMocks();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PlayerSelector onSelectionChange={onChange} selectedPlayerIds={[1, 2]} />,
+    );
+
+    expect(screen.getByText("2/5 joueurs sélectionnés")).toBeInTheDocument();
+  });
+
+  it("calls onSelectionChange when a player is clicked to select", async () => {
+    setupMocks();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PlayerSelector onSelectionChange={onChange} selectedPlayerIds={[]} />,
+    );
+
+    await userEvent.click(screen.getByText("Alice"));
+
+    expect(onChange).toHaveBeenCalledWith([1]);
+  });
+
+  it("calls onSelectionChange when a player is clicked to deselect", async () => {
+    setupMocks();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PlayerSelector onSelectionChange={onChange} selectedPlayerIds={[1, 2]} />,
+    );
+
+    // Click Alice in the player list (not the chip) — get all "Alice" texts, the last one is in the list
+    const allAlice = screen.getAllByText("Alice");
+    await userEvent.click(allAlice[allAlice.length - 1]);
+
+    expect(onChange).toHaveBeenCalledWith([2]);
+  });
+
+  it("disables unselected players when 5 are already selected", () => {
+    setupMocks();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PlayerSelector
+        onSelectionChange={onChange}
+        selectedPlayerIds={[1, 2, 3, 4, 5]}
+      />,
+    );
+
+    // Frank (id=6) should be disabled
+    const frankButton = screen.getByText("Frank").closest("button");
+    expect(frankButton).toBeDisabled();
+  });
+
+  it("allows deselecting when 5 are selected", async () => {
+    setupMocks();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PlayerSelector
+        onSelectionChange={onChange}
+        selectedPlayerIds={[1, 2, 3, 4, 5]}
+      />,
+    );
+
+    // Click Alice in the player list (not the chip)
+    const allAlice = screen.getAllByText("Alice");
+    await userEvent.click(allAlice[allAlice.length - 1]);
+
+    expect(onChange).toHaveBeenCalledWith([2, 3, 4, 5]);
+  });
+
+  it("shows selected player chips at the top", () => {
+    setupMocks();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PlayerSelector onSelectionChange={onChange} selectedPlayerIds={[1, 3]} />,
+    );
+
+    // Should have avatars for selected players in chips area
+    const chipArea = screen.getByTestId("selected-chips");
+    expect(chipArea).toBeInTheDocument();
+  });
+
+  it("deselects player when chip is clicked", async () => {
+    setupMocks();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PlayerSelector onSelectionChange={onChange} selectedPlayerIds={[1, 2]} />,
+    );
+
+    const chipArea = screen.getByTestId("selected-chips");
+    const removeButtons = chipArea.querySelectorAll("button");
+    // Click the first chip (Alice)
+    await userEvent.click(removeButtons[0]);
+
+    expect(onChange).toHaveBeenCalledWith([2]);
+  });
+
+  it("passes search term to usePlayers", async () => {
+    setupMocks();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PlayerSelector onSelectionChange={onChange} selectedPlayerIds={[]} />,
+    );
+
+    const searchInput = screen.getByPlaceholderText("Rechercher un joueur…");
+    await userEvent.type(searchInput, "ali");
+
+    await waitFor(() => {
+      expect(usePlayersModule.usePlayers).toHaveBeenCalledWith("ali");
+    });
+  });
+
+  it("shows create player button", () => {
+    setupMocks();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PlayerSelector onSelectionChange={onChange} selectedPlayerIds={[]} />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Ajouter un joueur" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens modal when create button is clicked", async () => {
+    setupMocks();
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PlayerSelector onSelectionChange={onChange} selectedPlayerIds={[]} />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Ajouter un joueur" }),
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Nom du joueur")).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    setupMocks({
+      usePlayers: { isPending: true, players: [] },
+    });
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PlayerSelector onSelectionChange={onChange} selectedPlayerIds={[]} />,
+    );
+
+    expect(screen.getByText("Chargement…")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/SessionList.test.tsx
+++ b/frontend/src/__tests__/components/SessionList.test.tsx
@@ -1,0 +1,129 @@
+import { screen } from "@testing-library/react";
+import SessionList from "../../components/SessionList";
+import * as useSessionsModule from "../../hooks/useSessions";
+import { renderWithProviders } from "../test-utils";
+
+vi.mock("../../hooks/useSessions");
+
+const mockSessions = [
+  {
+    createdAt: "2025-02-01T14:00:00+00:00",
+    id: 1,
+    isActive: true,
+    players: [
+      { name: "Alice" },
+      { name: "Bob" },
+      { name: "Charlie" },
+      { name: "Diana" },
+      { name: "Eve" },
+    ],
+  },
+  {
+    createdAt: "2025-01-28T10:00:00+00:00",
+    id: 2,
+    isActive: false,
+    players: [
+      { name: "Alice" },
+      { name: "Bob" },
+      { name: "Charlie" },
+      { name: "Frank" },
+      { name: "Grace" },
+    ],
+  },
+];
+
+function setupMocks(overrides?: {
+  useSessions?: Partial<ReturnType<typeof useSessionsModule.useSessions>>;
+}) {
+  vi.mocked(useSessionsModule.useSessions).mockReturnValue({
+    data: mockSessions,
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdateCount: 0,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    fetchStatus: "idle",
+    isError: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isInitialLoading: false,
+    isLoading: false,
+    isLoadingError: false,
+    isPaused: false,
+    isPending: false,
+    isPlaceholderData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true,
+    promise: Promise.resolve(mockSessions),
+    refetch: vi.fn(),
+    sessions: mockSessions,
+    status: "success",
+    ...overrides?.useSessions,
+  } as unknown as ReturnType<typeof useSessionsModule.useSessions>);
+}
+
+describe("SessionList", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders session cards with player names", () => {
+    setupMocks();
+    renderWithProviders(<SessionList />);
+
+    expect(
+      screen.getByText("Alice, Bob, Charlie, Diana, Eve"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Alice, Bob, Charlie, Frank, Grace"),
+    ).toBeInTheDocument();
+  });
+
+  it("displays formatted dates in fr-FR", () => {
+    setupMocks();
+    renderWithProviders(<SessionList />);
+
+    // 2025-02-01 should be formatted as French date
+    expect(screen.getByText("01/02/2025")).toBeInTheDocument();
+    expect(screen.getByText("28/01/2025")).toBeInTheDocument();
+  });
+
+  it("shows 'En cours' badge for active sessions", () => {
+    setupMocks();
+    renderWithProviders(<SessionList />);
+
+    const badges = screen.getAllByText("En cours");
+    expect(badges).toHaveLength(1);
+  });
+
+  it("renders links to session pages", () => {
+    setupMocks();
+    renderWithProviders(<SessionList />);
+
+    const links = screen.getAllByRole("link");
+    expect(links[0]).toHaveAttribute("href", "/sessions/1");
+    expect(links[1]).toHaveAttribute("href", "/sessions/2");
+  });
+
+  it("shows loading state", () => {
+    setupMocks({
+      useSessions: { isPending: true, sessions: [] },
+    });
+    renderWithProviders(<SessionList />);
+
+    expect(screen.getByText("Chargement…")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no sessions", () => {
+    setupMocks({
+      useSessions: { sessions: [] },
+    });
+    renderWithProviders(<SessionList />);
+
+    expect(screen.getByText("Aucune session")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/hooks/useCreateSession.test.ts
+++ b/frontend/src/__tests__/hooks/useCreateSession.test.ts
@@ -1,0 +1,114 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import { useCreateSession } from "../../hooks/useCreateSession";
+import * as api from "../../services/api";
+import { createTestQueryClient } from "../test-utils";
+
+vi.mock("../../services/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  const w = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper: w };
+}
+
+describe("useCreateSession", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends POST to /sessions with player IRIs", async () => {
+    const created = {
+      createdAt: "2025-02-01T14:00:00+00:00",
+      id: 1,
+      isActive: true,
+      players: [
+        { name: "Alice" },
+        { name: "Bob" },
+        { name: "Charlie" },
+        { name: "Diana" },
+        { name: "Eve" },
+      ],
+    };
+    vi.mocked(api.apiFetch).mockResolvedValue(created);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCreateSession(), { wrapper });
+
+    await act(() => result.current.mutateAsync([1, 2, 3, 4, 5]));
+
+    expect(api.apiFetch).toHaveBeenCalledWith("/sessions", {
+      body: JSON.stringify({
+        players: [
+          "/api/players/1",
+          "/api/players/2",
+          "/api/players/3",
+          "/api/players/4",
+          "/api/players/5",
+        ],
+      }),
+      method: "POST",
+    });
+  });
+
+  it("invalidates sessions query on success", async () => {
+    const created = {
+      createdAt: "2025-02-01T14:00:00+00:00",
+      id: 1,
+      isActive: true,
+      players: [{ name: "Alice" }],
+    };
+    vi.mocked(api.apiFetch).mockResolvedValue(created);
+    const { queryClient, wrapper } = createWrapper();
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateSession(), { wrapper });
+
+    await act(() => result.current.mutateAsync([1, 2, 3, 4, 5]));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["sessions"] });
+  });
+
+  it("returns the created session", async () => {
+    const created = {
+      createdAt: "2025-02-01T14:00:00+00:00",
+      id: 42,
+      isActive: true,
+      players: [],
+    };
+    vi.mocked(api.apiFetch).mockResolvedValue(created);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCreateSession(), { wrapper });
+
+    const session = await act(() => result.current.mutateAsync([1, 2, 3, 4, 5]));
+
+    expect(session.id).toBe(42);
+  });
+
+  it("propagates API errors", async () => {
+    const apiError = new api.ApiError(
+      { detail: "Server error" },
+      "API error: 500",
+      500,
+    );
+    vi.mocked(api.apiFetch).mockRejectedValue(apiError);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCreateSession(), { wrapper });
+
+    act(() => result.current.mutate([1, 2, 3, 4, 5]));
+
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(api.ApiError);
+    });
+  });
+});

--- a/frontend/src/__tests__/hooks/useSessions.test.ts
+++ b/frontend/src/__tests__/hooks/useSessions.test.ts
@@ -1,0 +1,69 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import { useSessions } from "../../hooks/useSessions";
+import * as api from "../../services/api";
+import { createTestQueryClient } from "../test-utils";
+
+vi.mock("../../services/api");
+
+const mockSessions = [
+  {
+    createdAt: "2025-02-01T14:00:00+00:00",
+    id: 1,
+    isActive: true,
+    players: [
+      { name: "Alice" },
+      { name: "Bob" },
+      { name: "Charlie" },
+      { name: "Diana" },
+      { name: "Eve" },
+    ],
+  },
+  {
+    createdAt: "2025-01-28T10:00:00+00:00",
+    id: 2,
+    isActive: false,
+    players: [
+      { name: "Alice" },
+      { name: "Bob" },
+      { name: "Charlie" },
+      { name: "Frank" },
+      { name: "Grace" },
+    ],
+  },
+];
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = createTestQueryClient();
+  return createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useSessions", () => {
+  beforeEach(() => {
+    vi.mocked(api.apiFetch).mockResolvedValue({
+      member: mockSessions,
+      totalItems: 2,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches sessions from /sessions", async () => {
+    const { result } = renderHook(() => useSessions(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(api.apiFetch).toHaveBeenCalledWith("/sessions");
+    expect(result.current.sessions).toEqual(mockSessions);
+  });
+
+  it("returns empty array while loading", () => {
+    const { result } = renderHook(() => useSessions(), { wrapper });
+
+    expect(result.current.sessions).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/pages/Home.test.tsx
+++ b/frontend/src/__tests__/pages/Home.test.tsx
@@ -1,0 +1,270 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Home from "../../pages/Home";
+import * as useCreatePlayerModule from "../../hooks/useCreatePlayer";
+import * as useCreateSessionModule from "../../hooks/useCreateSession";
+import * as usePlayersModule from "../../hooks/usePlayers";
+import * as useSessionsModule from "../../hooks/useSessions";
+import { renderWithProviders } from "../test-utils";
+
+vi.mock("../../hooks/useCreatePlayer");
+vi.mock("../../hooks/useCreateSession");
+vi.mock("../../hooks/usePlayers");
+vi.mock("../../hooks/useSessions");
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockPlayers = [
+  { createdAt: "2025-01-15T10:00:00+00:00", id: 1, name: "Alice" },
+  { createdAt: "2025-01-16T10:00:00+00:00", id: 2, name: "Bob" },
+  { createdAt: "2025-01-17T10:00:00+00:00", id: 3, name: "Charlie" },
+  { createdAt: "2025-01-18T10:00:00+00:00", id: 4, name: "Diana" },
+  { createdAt: "2025-01-19T10:00:00+00:00", id: 5, name: "Eve" },
+  { createdAt: "2025-01-20T10:00:00+00:00", id: 6, name: "Frank" },
+];
+
+const mockSessions = [
+  {
+    createdAt: "2025-02-01T14:00:00+00:00",
+    id: 1,
+    isActive: true,
+    players: [
+      { name: "Alice" },
+      { name: "Bob" },
+      { name: "Charlie" },
+      { name: "Diana" },
+      { name: "Eve" },
+    ],
+  },
+];
+
+function setupMocks(overrides?: {
+  createPlayer?: Partial<ReturnType<typeof useCreatePlayerModule.useCreatePlayer>>;
+  createSession?: Partial<ReturnType<typeof useCreateSessionModule.useCreateSession>>;
+  usePlayers?: Partial<ReturnType<typeof usePlayersModule.usePlayers>>;
+  useSessions?: Partial<ReturnType<typeof useSessionsModule.useSessions>>;
+}) {
+  const createPlayerMutate = vi.fn();
+  const createSessionMutate = vi.fn();
+
+  vi.mocked(usePlayersModule.usePlayers).mockReturnValue({
+    data: mockPlayers,
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdateCount: 0,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    fetchStatus: "idle",
+    isError: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isInitialLoading: false,
+    isLoading: false,
+    isLoadingError: false,
+    isPaused: false,
+    isPending: false,
+    isPlaceholderData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true,
+    players: mockPlayers,
+    promise: Promise.resolve(mockPlayers),
+    refetch: vi.fn(),
+    status: "success",
+    ...overrides?.usePlayers,
+  } as unknown as ReturnType<typeof usePlayersModule.usePlayers>);
+
+  vi.mocked(useCreatePlayerModule.useCreatePlayer).mockReturnValue({
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate: createPlayerMutate,
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+    ...overrides?.createPlayer,
+  } as unknown as ReturnType<typeof useCreatePlayerModule.useCreatePlayer>);
+
+  vi.mocked(useSessionsModule.useSessions).mockReturnValue({
+    data: mockSessions,
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdateCount: 0,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    fetchStatus: "idle",
+    isError: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isInitialLoading: false,
+    isLoading: false,
+    isLoadingError: false,
+    isPaused: false,
+    isPending: false,
+    isPlaceholderData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true,
+    promise: Promise.resolve(mockSessions),
+    refetch: vi.fn(),
+    sessions: mockSessions,
+    status: "success",
+    ...overrides?.useSessions,
+  } as unknown as ReturnType<typeof useSessionsModule.useSessions>);
+
+  vi.mocked(useCreateSessionModule.useCreateSession).mockReturnValue({
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate: createSessionMutate,
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+    ...overrides?.createSession,
+  } as unknown as ReturnType<typeof useCreateSessionModule.useCreateSession>);
+
+  return { createPlayerMutate, createSessionMutate };
+}
+
+describe("Home page", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockNavigate.mockReset();
+  });
+
+  it("renders page title", () => {
+    setupMocks();
+    renderWithProviders(<Home />);
+
+    expect(screen.getByText("Nouvelle session")).toBeInTheDocument();
+  });
+
+  it("renders player selector", () => {
+    setupMocks();
+    renderWithProviders(<Home />);
+
+    expect(screen.getByText("0/5 joueurs sélectionnés")).toBeInTheDocument();
+  });
+
+  it("renders start button disabled when less than 5 players selected", () => {
+    setupMocks();
+    renderWithProviders(<Home />);
+
+    const startButton = screen.getByRole("button", { name: "Démarrer" });
+    expect(startButton).toBeDisabled();
+  });
+
+  it("enables start button when 5 players are selected", async () => {
+    setupMocks();
+    renderWithProviders(<Home />);
+
+    // Select 5 players
+    await userEvent.click(screen.getByText("Alice"));
+    await userEvent.click(screen.getByText("Bob"));
+    await userEvent.click(screen.getByText("Charlie"));
+    await userEvent.click(screen.getByText("Diana"));
+    await userEvent.click(screen.getByText("Eve"));
+
+    const startButton = screen.getByRole("button", { name: "Démarrer" });
+    expect(startButton).toBeEnabled();
+  });
+
+  it("calls createSession.mutate with selected player IDs", async () => {
+    const { createSessionMutate } = setupMocks();
+    renderWithProviders(<Home />);
+
+    // Select 5 players
+    await userEvent.click(screen.getByText("Alice"));
+    await userEvent.click(screen.getByText("Bob"));
+    await userEvent.click(screen.getByText("Charlie"));
+    await userEvent.click(screen.getByText("Diana"));
+    await userEvent.click(screen.getByText("Eve"));
+
+    await userEvent.click(screen.getByRole("button", { name: "Démarrer" }));
+
+    expect(createSessionMutate).toHaveBeenCalledWith(
+      [1, 2, 3, 4, 5],
+      expect.anything(),
+    );
+  });
+
+  it("navigates to session page on success", async () => {
+    const { createSessionMutate } = setupMocks();
+    // Make mutate call onSuccess callback immediately
+    createSessionMutate.mockImplementation((_ids: number[], options?: { onSuccess?: (data: unknown) => void }) => {
+      options?.onSuccess?.({ id: 42 });
+    });
+
+    renderWithProviders(<Home />);
+
+    // Select 5 players
+    await userEvent.click(screen.getByText("Alice"));
+    await userEvent.click(screen.getByText("Bob"));
+    await userEvent.click(screen.getByText("Charlie"));
+    await userEvent.click(screen.getByText("Diana"));
+    await userEvent.click(screen.getByText("Eve"));
+
+    await userEvent.click(screen.getByRole("button", { name: "Démarrer" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/sessions/42");
+  });
+
+  it("disables start button when mutation is pending", () => {
+    setupMocks({
+      createSession: { isPending: true },
+    });
+    renderWithProviders(<Home />);
+
+    const startButton = screen.getByRole("button", { name: "Démarrer" });
+    expect(startButton).toBeDisabled();
+  });
+
+  it("shows error message when mutation fails", () => {
+    setupMocks({
+      createSession: {
+        error: new Error("Network error"),
+        isError: true,
+      },
+    });
+    renderWithProviders(<Home />);
+
+    expect(
+      screen.getByText("Erreur lors de la création de la session."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders sessions list section", () => {
+    setupMocks();
+    renderWithProviders(<Home />);
+
+    expect(screen.getByText("Sessions récentes")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/PlayerSelector.tsx
+++ b/frontend/src/components/PlayerSelector.tsx
@@ -1,0 +1,211 @@
+import { Plus } from "lucide-react";
+import { type FormEvent, useCallback, useMemo, useState } from "react";
+import { useCreatePlayer } from "../hooks/useCreatePlayer";
+import { usePlayers } from "../hooks/usePlayers";
+import { ApiError } from "../services/api";
+import { Modal, PlayerAvatar, SearchInput } from "./ui";
+
+const MAX_PLAYERS = 5;
+
+interface PlayerSelectorProps {
+  onSelectionChange: (ids: number[]) => void;
+  selectedPlayerIds: number[];
+}
+
+export default function PlayerSelector({
+  onSelectionChange,
+  selectedPlayerIds,
+}: PlayerSelectorProps) {
+  const [search, setSearch] = useState("");
+  const [modalOpen, setModalOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+
+  const { players: allPlayers } = usePlayers();
+  const { isPending, players } = usePlayers(search);
+  const createPlayer = useCreatePlayer();
+
+  const selectedPlayers = useMemo(
+    () =>
+      selectedPlayerIds
+        .map((id) => allPlayers.find((p) => p.id === id))
+        .filter(Boolean) as typeof allPlayers,
+    [allPlayers, selectedPlayerIds],
+  );
+
+  const isFull = selectedPlayerIds.length >= MAX_PLAYERS;
+
+  const togglePlayer = useCallback(
+    (playerId: number) => {
+      if (selectedPlayerIds.includes(playerId)) {
+        onSelectionChange(selectedPlayerIds.filter((id) => id !== playerId));
+      } else if (!isFull) {
+        onSelectionChange([...selectedPlayerIds, playerId]);
+      }
+    },
+    [isFull, onSelectionChange, selectedPlayerIds],
+  );
+
+  const removePlayer = useCallback(
+    (playerId: number) => {
+      onSelectionChange(selectedPlayerIds.filter((id) => id !== playerId));
+    },
+    [onSelectionChange, selectedPlayerIds],
+  );
+
+  const openModal = useCallback(() => {
+    createPlayer.reset();
+    setNewName("");
+    setModalOpen(true);
+  }, [createPlayer]);
+
+  const closeModal = useCallback(() => {
+    setModalOpen(false);
+  }, []);
+
+  const handleSubmit = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      const trimmed = newName.trim();
+      if (!trimmed) return;
+      createPlayer.mutate(trimmed, {
+        onSuccess: (player) => {
+          closeModal();
+          if (!isFull) {
+            onSelectionChange([...selectedPlayerIds, player.id]);
+          }
+        },
+      });
+    },
+    [closeModal, createPlayer, isFull, newName, onSelectionChange, selectedPlayerIds],
+  );
+
+  const isDuplicate =
+    createPlayer.isError &&
+    createPlayer.error instanceof ApiError &&
+    createPlayer.error.status === 422;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Chips des joueurs sélectionnés */}
+      <div className="flex items-center gap-2" data-testid="selected-chips">
+        {selectedPlayers.map((player) => (
+          <button
+            className="flex items-center gap-1 rounded-full bg-accent-100 py-1 pl-1 pr-2 text-sm font-medium text-accent-700 transition-colors hover:bg-accent-200"
+            key={player.id}
+            onClick={() => removePlayer(player.id)}
+            type="button"
+          >
+            <PlayerAvatar name={player.name} playerId={player.id} size="sm" />
+            <span>{player.name}</span>
+          </button>
+        ))}
+        {Array.from({ length: MAX_PLAYERS - selectedPlayerIds.length }).map(
+          (_, i) => (
+            <div
+              className="flex size-8 items-center justify-center rounded-full border-2 border-dashed border-surface-border"
+              key={`empty-${i}`}
+            />
+          ),
+        )}
+      </div>
+
+      <p className="text-sm text-text-muted">
+        {selectedPlayerIds.length}/{MAX_PLAYERS} joueurs sélectionnés
+      </p>
+
+      {/* Recherche */}
+      <SearchInput
+        onSearch={setSearch}
+        placeholder="Rechercher un joueur…"
+      />
+
+      {/* Liste des joueurs */}
+      {isPending && (
+        <p className="py-4 text-center text-text-muted">Chargement…</p>
+      )}
+
+      {!isPending && players.length === 0 && (
+        <p className="py-4 text-center text-text-muted">
+          Aucun joueur trouvé
+        </p>
+      )}
+
+      {!isPending && players.length > 0 && (
+        <ul className="flex flex-col gap-1">
+          {players.map((player) => {
+            const isSelected = selectedPlayerIds.includes(player.id);
+            const isDisabled = isFull && !isSelected;
+
+            return (
+              <li key={player.id}>
+                <button
+                  className={`flex w-full items-center gap-3 rounded-lg p-2 text-left transition-colors ${
+                    isSelected
+                      ? "bg-accent-50 ring-2 ring-accent-500"
+                      : "hover:bg-surface-secondary"
+                  } ${isDisabled ? "cursor-not-allowed opacity-40" : ""}`}
+                  disabled={isDisabled}
+                  onClick={() => togglePlayer(player.id)}
+                  type="button"
+                >
+                  <PlayerAvatar
+                    name={player.name}
+                    playerId={player.id}
+                    size="sm"
+                  />
+                  <span className="font-medium text-text-primary">
+                    {player.name}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {/* Bouton créer joueur */}
+      <button
+        aria-label="Ajouter un joueur"
+        className="flex items-center gap-2 rounded-lg border border-dashed border-surface-border p-2 text-sm text-text-muted transition-colors hover:border-accent-400 hover:text-accent-500"
+        onClick={openModal}
+        type="button"
+      >
+        <Plus size={16} />
+        <span>Nouveau joueur</span>
+      </button>
+
+      {/* Modal création joueur */}
+      <Modal onClose={closeModal} open={modalOpen} title="Nouveau joueur">
+        <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+          <div>
+            <input
+              className="w-full rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-text-primary placeholder:text-text-muted focus:border-accent-400 focus:outline-none focus:ring-1 focus:ring-accent-400"
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="Nom du joueur"
+              required
+              type="text"
+              value={newName}
+            />
+            {isDuplicate && (
+              <p className="mt-1 text-sm text-red-500">
+                Ce nom est déjà utilisé.
+              </p>
+            )}
+            {createPlayer.isError && !isDuplicate && (
+              <p className="mt-1 text-sm text-red-500">
+                Erreur lors de la création.
+              </p>
+            )}
+          </div>
+          <button
+            className="rounded-lg bg-accent-500 px-4 py-2 font-medium text-white transition-colors hover:bg-accent-600 disabled:opacity-50"
+            disabled={createPlayer.isPending}
+            type="submit"
+          >
+            Ajouter
+          </button>
+        </form>
+      </Modal>
+    </div>
+  );
+}

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -1,0 +1,41 @@
+import { Link } from "react-router-dom";
+import { useSessions } from "../hooks/useSessions";
+
+export default function SessionList() {
+  const { isPending, sessions } = useSessions();
+
+  if (isPending) {
+    return <p className="py-4 text-center text-text-muted">Chargement…</p>;
+  }
+
+  if (sessions.length === 0) {
+    return <p className="py-4 text-center text-text-muted">Aucune session</p>;
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {sessions.map((session) => (
+        <li key={session.id}>
+          <Link
+            className="block rounded-lg bg-surface-secondary p-3 transition-colors hover:bg-surface-tertiary"
+            to={`/sessions/${session.id}`}
+          >
+            <div className="flex items-center justify-between">
+              <p className="font-medium text-text-primary">
+                {session.players.map((p) => p.name).join(", ")}
+              </p>
+              {session.isActive && (
+                <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                  En cours
+                </span>
+              )}
+            </div>
+            <p className="mt-1 text-xs text-text-muted">
+              {new Date(session.createdAt).toLocaleDateString("fr-FR")}
+            </p>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/hooks/useCreateSession.ts
+++ b/frontend/src/hooks/useCreateSession.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "../services/api";
+import type { Session } from "../types/api";
+
+export function useCreateSession() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (playerIds: number[]) =>
+      apiFetch<Session>("/sessions", {
+        body: JSON.stringify({
+          players: playerIds.map((id) => `/api/players/${id}`),
+        }),
+        method: "POST",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+    },
+  });
+}

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "../services/api";
+import type { HydraCollection, Session } from "../types/api";
+
+export function useSessions() {
+  const query = useQuery({
+    queryFn: () => apiFetch<HydraCollection<Session>>("/sessions"),
+    queryKey: ["sessions"],
+    select: (data) => data.member,
+  });
+
+  return {
+    ...query,
+    sessions: query.data ?? [],
+  };
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,8 +1,63 @@
+import { useCallback, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import PlayerSelector from "../components/PlayerSelector";
+import SessionList from "../components/SessionList";
+import { useCreateSession } from "../hooks/useCreateSession";
+import type { Session } from "../types/api";
+
+const REQUIRED_PLAYERS = 5;
+
 export default function Home() {
+  const [selectedPlayerIds, setSelectedPlayerIds] = useState<number[]>([]);
+  const createSession = useCreateSession();
+  const navigate = useNavigate();
+
+  const canStart =
+    selectedPlayerIds.length === REQUIRED_PLAYERS && !createSession.isPending;
+
+  const handleStart = useCallback(() => {
+    if (!canStart) return;
+    createSession.mutate(selectedPlayerIds, {
+      onSuccess: (session: Session) => {
+        navigate(`/sessions/${session.id}`);
+      },
+    });
+  }, [canStart, createSession, navigate, selectedPlayerIds]);
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold">Tarot</h1>
-      <p className="text-gray-600">Sélectionnez 5 joueurs pour démarrer une session</p>
+    <div className="flex flex-col gap-6 p-4">
+      <section>
+        <h1 className="mb-4 text-2xl font-bold text-text-primary">
+          Nouvelle session
+        </h1>
+
+        <PlayerSelector
+          onSelectionChange={setSelectedPlayerIds}
+          selectedPlayerIds={selectedPlayerIds}
+        />
+
+        {createSession.isError && (
+          <p className="mt-2 text-sm text-red-500">
+            Erreur lors de la création de la session.
+          </p>
+        )}
+
+        <button
+          className="mt-4 w-full rounded-lg bg-accent-500 py-3 font-semibold text-white transition-colors hover:bg-accent-600 disabled:opacity-50"
+          disabled={!canStart}
+          onClick={handleStart}
+          type="button"
+        >
+          Démarrer
+        </button>
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-text-primary">
+          Sessions récentes
+        </h2>
+        <SessionList />
+      </section>
     </div>
   );
 }

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -1,0 +1,14 @@
+import { useParams } from "react-router-dom";
+
+export default function SessionPage() {
+  const { id } = useParams<{ id: string }>();
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold text-text-primary">
+        Session #{id}
+      </h1>
+      <p className="mt-2 text-text-muted">À venir</p>
+    </div>
+  );
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -8,3 +8,14 @@ export interface Player {
   id: number;
   name: string;
 }
+
+export interface Session {
+  createdAt: string;
+  id: number;
+  isActive: boolean;
+  players: SessionPlayer[];
+}
+
+export interface SessionPlayer {
+  name: string;
+}


### PR DESCRIPTION
## Résumé

Implémentation de l'écran d'accueil (issue #7) : sélection de 5 joueurs, démarrage/reprise de session et liste des sessions récentes.

### Ajouts

- **`PlayerSelector`** : composant contrôlé de sélection de joueurs avec chips, recherche, création inline via modal, limite à 5 joueurs
- **`SessionList`** : liste cliquable des sessions récentes (noms joueurs, date fr-FR, badge « En cours »)
- **Page `Home`** : assemblage PlayerSelector + bouton Démarrer + SessionList avec navigation vers `/sessions/:id`
- **`useSessions`** : hook TanStack Query pour récupérer les sessions
- **`useCreateSession`** : hook mutation POST avec conversion des IDs en IRIs API Platform
- **Types `Session` / `SessionPlayer`** : interfaces TypeScript mirroring API responses
- **`SessionPage`** : page stub pour l'écran de session (issue #8)
- **Route `/sessions/:id`** ajoutée dans `App.tsx`
- Documentation et changelog mis à jour

### Tests

- 33 nouveaux tests (useSessions, useCreateSession, PlayerSelector, SessionList, Home)
- Total : **117 tests** sur 20 fichiers — tous verts
- Build production réussi

fixes #7