### PR TITLE
feat(frontend): session screen with scoreboard & game history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,20 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Écran de session** : tableau des scores cumulés (Scoreboard), bandeau donne en cours (InProgressBanner), historique des donnes (GameList), bouton FAB nouvelle donne, navigation retour
+- **Hook `useSession`** : récupération du détail d'une session (joueurs, donnes, scores cumulés) via TanStack Query
+- **Hook `useCreateGame`** : mutation POST pour créer une nouvelle donne avec invalidation du cache session
+- **Composant `Scoreboard`** : bandeau horizontal scrollable avec avatars et scores cumulés colorés
+- **Composant `InProgressBanner`** : carte pour donne en cours avec preneur, contrat et bouton Compléter
+- **Composant `GameList`** : liste des donnes terminées avec preneur, partenaire, contrat, score et bouton modifier
+- **Types `Game`, `GamePlayer`, `ScoreEntry`, `SessionDetail`, `CumulativeScore`** : interfaces TypeScript pour le détail de session
+- **Sérialisation backend** : ajout du groupe `session:detail` sur Player.id/name, Game et ScoreEntry pour que `GET /api/sessions/{id}` retourne les objets imbriqués
 - **Écran d'accueil** : sélection de 5 joueurs (avec chips, recherche, création inline), démarrage/reprise de session, liste des sessions récentes
 - **Hook `useSessions`** : récupération des sessions via TanStack Query
 - **Hook `useCreateSession`** : mutation POST avec conversion des IDs en IRIs et invalidation du cache
 - **Composant `PlayerSelector`** : sélection contrôlée de joueurs avec chips, limite à 5, création inline via modal
 - **Composant `SessionList`** : liste cliquable des sessions récentes avec noms des joueurs, date et badge "En cours"
-- **Page `SessionPage`** : stub pour l'écran de session (à venir — issue #8)
+- **Page `SessionPage`** : écran complet de session avec scoreboard, donne en cours, historique et FAB
 - **Route `/sessions/:id`** : navigation vers une session spécifique
 - **Types `Session` et `SessionPlayer`** : interfaces TypeScript pour les réponses API
 - **Gestion des joueurs** : écran complet avec liste, recherche par nom, ajout via formulaire modal, gestion des doublons (erreur 422)

--- a/backend/src/Entity/Game.php
+++ b/backend/src/Entity/Game.php
@@ -51,55 +51,55 @@ use Symfony\Component\Serializer\Attribute\Groups;
 #[PlayersBelongToSession(groups: ['game:patch'])]
 class Game
 {
-    #[Groups(['game:read'])]
+    #[Groups(['game:read', 'session:detail'])]
     #[ORM\Id]
     #[ORM\Column]
     #[ORM\GeneratedValue]
     private ?int $id = null;
 
-    #[Groups(['game:read', 'game:complete'])]
+    #[Groups(['game:read', 'game:complete', 'session:detail'])]
     #[ORM\Column(enumType: Chelem::class)]
     private Chelem $chelem = Chelem::None;
 
-    #[Groups(['game:read', 'game:create'])]
+    #[Groups(['game:read', 'game:create', 'session:detail'])]
     #[ORM\Column(enumType: Contract::class)]
     private Contract $contract;
 
-    #[Groups(['game:read'])]
+    #[Groups(['game:read', 'session:detail'])]
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $createdAt;
 
-    #[Groups(['game:read', 'game:complete'])]
+    #[Groups(['game:read', 'game:complete', 'session:detail'])]
     #[ORM\Column(nullable: true)]
     private ?int $oudlers = null;
 
-    #[Groups(['game:read', 'game:complete'])]
+    #[Groups(['game:read', 'game:complete', 'session:detail'])]
     #[ORM\ManyToOne(targetEntity: Player::class)]
     #[ORM\JoinColumn(nullable: true)]
     private ?Player $partner = null;
 
-    #[Groups(['game:read', 'game:complete'])]
+    #[Groups(['game:read', 'game:complete', 'session:detail'])]
     #[ORM\Column(enumType: Side::class)]
     private Side $petitAuBout = Side::None;
 
-    #[Groups(['game:read', 'game:complete'])]
+    #[Groups(['game:read', 'game:complete', 'session:detail'])]
     #[ORM\Column(enumType: Poignee::class)]
     private Poignee $poignee = Poignee::None;
 
-    #[Groups(['game:read', 'game:complete'])]
+    #[Groups(['game:read', 'game:complete', 'session:detail'])]
     #[ORM\Column(enumType: Side::class)]
     private Side $poigneeOwner = Side::None;
 
-    #[Groups(['game:read', 'game:complete'])]
+    #[Groups(['game:read', 'game:complete', 'session:detail'])]
     #[ORM\Column(nullable: true)]
     private ?float $points = null;
 
-    #[Groups(['game:read'])]
+    #[Groups(['game:read', 'session:detail'])]
     #[ORM\Column]
     private int $position;
 
     /** @var Collection<int, ScoreEntry> */
-    #[Groups(['game:read'])]
+    #[Groups(['game:read', 'session:detail'])]
     #[ORM\OneToMany(targetEntity: ScoreEntry::class, mappedBy: 'game', cascade: ['persist', 'remove'])]
     private Collection $scoreEntries;
 
@@ -107,11 +107,11 @@ class Game
     #[ORM\JoinColumn(nullable: false)]
     private Session $session;
 
-    #[Groups(['game:read', 'game:complete'])]
+    #[Groups(['game:read', 'game:complete', 'session:detail'])]
     #[ORM\Column(enumType: GameStatus::class)]
     private GameStatus $status = GameStatus::InProgress;
 
-    #[Groups(['game:read', 'game:create'])]
+    #[Groups(['game:read', 'game:create', 'session:detail'])]
     #[ORM\ManyToOne(targetEntity: Player::class)]
     #[ORM\JoinColumn(nullable: false)]
     private Player $taker;

--- a/backend/src/Entity/Player.php
+++ b/backend/src/Entity/Player.php
@@ -28,14 +28,14 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[UniqueEntity('name')]
 class Player
 {
-    #[Groups(['player:read'])]
+    #[Groups(['player:read', 'session:detail'])]
     #[ORM\Id]
     #[ORM\Column]
     #[ORM\GeneratedValue]
     private ?int $id = null;
 
     #[Assert\NotBlank]
-    #[Groups(['game:read', 'player:read', 'player:write', 'score-entry:read', 'session:read'])]
+    #[Groups(['game:read', 'player:read', 'player:write', 'score-entry:read', 'session:detail', 'session:read'])]
     #[ORM\Column(length: 50, unique: true)]
     private string $name;
 

--- a/backend/src/Entity/ScoreEntry.php
+++ b/backend/src/Entity/ScoreEntry.php
@@ -10,7 +10,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 #[ORM\Entity]
 class ScoreEntry
 {
-    #[Groups(['game:read', 'score-entry:read'])]
+    #[Groups(['game:read', 'score-entry:read', 'session:detail'])]
     #[ORM\Id]
     #[ORM\Column]
     #[ORM\GeneratedValue]
@@ -20,12 +20,12 @@ class ScoreEntry
     #[ORM\JoinColumn(nullable: false)]
     private Game $game;
 
-    #[Groups(['game:read', 'score-entry:read'])]
+    #[Groups(['game:read', 'score-entry:read', 'session:detail'])]
     #[ORM\ManyToOne(targetEntity: Player::class)]
     #[ORM\JoinColumn(nullable: false)]
     private Player $player;
 
-    #[Groups(['game:read', 'score-entry:read'])]
+    #[Groups(['game:read', 'score-entry:read', 'session:detail'])]
     #[ORM\Column]
     private int $score;
 

--- a/frontend/src/__tests__/components/GameList.test.tsx
+++ b/frontend/src/__tests__/components/GameList.test.tsx
@@ -1,0 +1,110 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GameList from "../../components/GameList";
+import { renderWithProviders } from "../test-utils";
+import type { Game } from "../../types/api";
+
+const baseGame: Game = {
+  chelem: "none",
+  contract: "garde",
+  createdAt: "2025-02-01T14:00:00+00:00",
+  id: 1,
+  oudlers: 2,
+  partner: { id: 2, name: "Bob" },
+  petitAuBout: "none",
+  poignee: "none",
+  poigneeOwner: "none",
+  points: 56,
+  position: 1,
+  scoreEntries: [
+    { id: 1, player: { id: 3, name: "Charlie" }, score: 120 },
+    { id: 2, player: { id: 2, name: "Bob" }, score: 120 },
+    { id: 3, player: { id: 1, name: "Alice" }, score: -80 },
+    { id: 4, player: { id: 4, name: "Diana" }, score: -80 },
+    { id: 5, player: { id: 5, name: "Eve" }, score: -80 },
+  ],
+  status: "completed",
+  taker: { id: 3, name: "Charlie" },
+};
+
+const games: Game[] = [
+  baseGame,
+  {
+    ...baseGame,
+    contract: "petite",
+    id: 2,
+    partner: null,
+    position: 2,
+    scoreEntries: [
+      { id: 6, player: { id: 1, name: "Alice" }, score: 200 },
+      { id: 7, player: { id: 2, name: "Bob" }, score: -50 },
+      { id: 8, player: { id: 3, name: "Charlie" }, score: -50 },
+      { id: 9, player: { id: 4, name: "Diana" }, score: -50 },
+      { id: 10, player: { id: 5, name: "Eve" }, score: -50 },
+    ],
+    taker: { id: 1, name: "Alice" },
+  },
+];
+
+describe("GameList", () => {
+  it("renders games in reverse position order (latest first)", () => {
+    renderWithProviders(
+      <GameList games={games} onEditLast={() => {}} />,
+    );
+
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    // First rendered should be position 2 (Petite), then position 1 (Garde)
+    expect(items[0]).toHaveTextContent("Petite");
+    expect(items[1]).toHaveTextContent("Garde");
+  });
+
+  it("shows taker name for each game", () => {
+    renderWithProviders(
+      <GameList games={games} onEditLast={() => {}} />,
+    );
+
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Charlie")).toBeInTheDocument();
+  });
+
+  it("shows partner name or Seul", () => {
+    renderWithProviders(
+      <GameList games={games} onEditLast={() => {}} />,
+    );
+
+    expect(screen.getByText("avec Bob")).toBeInTheDocument();
+    expect(screen.getByText("Seul")).toBeInTheDocument();
+  });
+
+  it("shows taker score from scoreEntries", () => {
+    renderWithProviders(
+      <GameList games={games} onEditLast={() => {}} />,
+    );
+
+    // Charlie's score in game 1: +120, Alice's score in game 2: +200
+    expect(screen.getByText("+120")).toBeInTheDocument();
+    expect(screen.getByText("+200")).toBeInTheDocument();
+  });
+
+  it("shows edit button only on the last game (highest position)", async () => {
+    const onEditLast = vi.fn();
+    renderWithProviders(
+      <GameList games={games} onEditLast={onEditLast} />,
+    );
+
+    const editButtons = screen.getAllByRole("button", { name: "Modifier" });
+    expect(editButtons).toHaveLength(1);
+
+    await userEvent.click(editButtons[0]);
+    expect(onEditLast).toHaveBeenCalledOnce();
+  });
+
+  it("renders empty state when no games", () => {
+    renderWithProviders(
+      <GameList games={[]} onEditLast={() => {}} />,
+    );
+
+    expect(screen.getByText("Aucune donne jouée")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/InProgressBanner.test.tsx
+++ b/frontend/src/__tests__/components/InProgressBanner.test.tsx
@@ -1,0 +1,62 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import InProgressBanner from "../../components/InProgressBanner";
+import { renderWithProviders } from "../test-utils";
+import type { Game } from "../../types/api";
+
+const mockGame: Game = {
+  chelem: "none",
+  contract: "garde",
+  createdAt: "2025-02-01T14:00:00+00:00",
+  id: 1,
+  oudlers: null,
+  partner: null,
+  petitAuBout: "none",
+  poignee: "none",
+  poigneeOwner: "none",
+  points: null,
+  position: 1,
+  scoreEntries: [],
+  status: "in_progress",
+  taker: { id: 3, name: "Charlie" },
+};
+
+describe("InProgressBanner", () => {
+  it("renders taker name and avatar", () => {
+    renderWithProviders(
+      <InProgressBanner game={mockGame} onComplete={() => {}} />,
+    );
+
+    expect(screen.getByText("Charlie")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Charlie" })).toBeInTheDocument();
+  });
+
+  it("renders contract badge", () => {
+    renderWithProviders(
+      <InProgressBanner game={mockGame} onComplete={() => {}} />,
+    );
+
+    expect(screen.getByText("Garde")).toBeInTheDocument();
+  });
+
+  it("renders Compléter button", () => {
+    renderWithProviders(
+      <InProgressBanner game={mockGame} onComplete={() => {}} />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Compléter" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onComplete when button is clicked", async () => {
+    const onComplete = vi.fn();
+    renderWithProviders(
+      <InProgressBanner game={mockGame} onComplete={onComplete} />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Compléter" }));
+
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/__tests__/components/Scoreboard.test.tsx
+++ b/frontend/src/__tests__/components/Scoreboard.test.tsx
@@ -1,0 +1,59 @@
+import { screen } from "@testing-library/react";
+import Scoreboard from "../../components/Scoreboard";
+import { renderWithProviders } from "../test-utils";
+
+const players = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" },
+  { id: 4, name: "Diana" },
+  { id: 5, name: "Eve" },
+];
+
+describe("Scoreboard", () => {
+  it("renders all player names", () => {
+    renderWithProviders(
+      <Scoreboard cumulativeScores={[]} players={players} />,
+    );
+
+    for (const player of players) {
+      expect(screen.getByText(player.name)).toBeInTheDocument();
+    }
+  });
+
+  it("renders player avatars", () => {
+    renderWithProviders(
+      <Scoreboard cumulativeScores={[]} players={players} />,
+    );
+
+    const avatars = screen.getAllByRole("img");
+    expect(avatars).toHaveLength(5);
+  });
+
+  it("renders cumulative scores with correct colors", () => {
+    const cumulativeScores = [
+      { playerId: 1, playerName: "Alice", score: 120 },
+      { playerId: 2, playerName: "Bob", score: -30 },
+      { playerId: 3, playerName: "Charlie", score: 0 },
+    ];
+
+    renderWithProviders(
+      <Scoreboard cumulativeScores={cumulativeScores} players={players} />,
+    );
+
+    expect(screen.getByText("+120")).toBeInTheDocument();
+    expect(screen.getByText("-30")).toBeInTheDocument();
+    // Players with 0 or no score should show 0
+    const zeros = screen.getAllByText("0");
+    expect(zeros.length).toBe(3); // Charlie (0), Diana (no entry), Eve (no entry)
+  });
+
+  it("shows 0 for players with no score entry", () => {
+    renderWithProviders(
+      <Scoreboard cumulativeScores={[]} players={players} />,
+    );
+
+    const zeros = screen.getAllByText("0");
+    expect(zeros.length).toBe(5);
+  });
+});

--- a/frontend/src/__tests__/hooks/useCreateGame.test.ts
+++ b/frontend/src/__tests__/hooks/useCreateGame.test.ts
@@ -1,0 +1,80 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import { useCreateGame } from "../../hooks/useCreateGame";
+import * as api from "../../services/api";
+import { createTestQueryClient } from "../test-utils";
+
+vi.mock("../../services/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  const w = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper: w };
+}
+
+describe("useCreateGame", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends POST to /sessions/{sessionId}/games with contract and taker IRI", async () => {
+    const created = { contract: "garde", id: 1, status: "in_progress", taker: { id: 3, name: "Charlie" } };
+    vi.mocked(api.apiFetch).mockResolvedValue(created);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCreateGame(42), { wrapper });
+
+    await act(() =>
+      result.current.mutateAsync({ contract: "garde", takerId: 3 }),
+    );
+
+    expect(api.apiFetch).toHaveBeenCalledWith("/sessions/42/games", {
+      body: JSON.stringify({
+        contract: "garde",
+        taker: "/api/players/3",
+      }),
+      method: "POST",
+    });
+  });
+
+  it("invalidates session query on success", async () => {
+    const created = { contract: "garde", id: 1, status: "in_progress", taker: { id: 3, name: "Charlie" } };
+    vi.mocked(api.apiFetch).mockResolvedValue(created);
+    const { queryClient, wrapper } = createWrapper();
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateGame(42), { wrapper });
+
+    await act(() =>
+      result.current.mutateAsync({ contract: "garde", takerId: 3 }),
+    );
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["session", 42] });
+  });
+
+  it("propagates API errors", async () => {
+    const apiError = new api.ApiError(
+      { detail: "Server error" },
+      "API error: 500",
+      500,
+    );
+    vi.mocked(api.apiFetch).mockRejectedValue(apiError);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCreateGame(42), { wrapper });
+
+    act(() => result.current.mutate({ contract: "garde", takerId: 3 }));
+
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(api.ApiError);
+    });
+  });
+});

--- a/frontend/src/__tests__/hooks/useSession.test.ts
+++ b/frontend/src/__tests__/hooks/useSession.test.ts
@@ -1,0 +1,57 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import { useSession } from "../../hooks/useSession";
+import * as api from "../../services/api";
+import { createTestQueryClient } from "../test-utils";
+
+vi.mock("../../services/api");
+
+const mockSession = {
+  createdAt: "2025-02-01T14:00:00+00:00",
+  cumulativeScores: [
+    { playerId: 1, playerName: "Alice", score: 120 },
+    { playerId: 2, playerName: "Bob", score: -30 },
+  ],
+  games: [],
+  id: 1,
+  isActive: true,
+  players: [
+    { id: 1, name: "Alice" },
+    { id: 2, name: "Bob" },
+    { id: 3, name: "Charlie" },
+    { id: 4, name: "Diana" },
+    { id: 5, name: "Eve" },
+  ],
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = createTestQueryClient();
+  return createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useSession", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches session from /sessions/{id}", async () => {
+    vi.mocked(api.apiFetch).mockResolvedValue(mockSession);
+
+    const { result } = renderHook(() => useSession(1), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(api.apiFetch).toHaveBeenCalledWith("/sessions/1");
+    expect(result.current.session).toEqual(mockSession);
+  });
+
+  it("returns null while loading", () => {
+    vi.mocked(api.apiFetch).mockResolvedValue(mockSession);
+
+    const { result } = renderHook(() => useSession(1), { wrapper });
+
+    expect(result.current.session).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/pages/SessionPage.test.tsx
+++ b/frontend/src/__tests__/pages/SessionPage.test.tsx
@@ -1,0 +1,259 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SessionPage from "../../pages/SessionPage";
+import * as useSessionModule from "../../hooks/useSession";
+import * as useCreateGameModule from "../../hooks/useCreateGame";
+import { renderWithProviders } from "../test-utils";
+import type { SessionDetail } from "../../types/api";
+
+vi.mock("../../hooks/useSession");
+vi.mock("../../hooks/useCreateGame");
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ id: "1" }),
+  };
+});
+
+const mockPlayers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" },
+  { id: 4, name: "Diana" },
+  { id: 5, name: "Eve" },
+];
+
+const mockSession: SessionDetail = {
+  createdAt: "2025-02-01T14:00:00+00:00",
+  cumulativeScores: [
+    { playerId: 1, playerName: "Alice", score: 120 },
+    { playerId: 2, playerName: "Bob", score: -30 },
+  ],
+  games: [
+    {
+      chelem: "none",
+      contract: "garde",
+      createdAt: "2025-02-01T14:10:00+00:00",
+      id: 1,
+      oudlers: 2,
+      partner: { id: 2, name: "Bob" },
+      petitAuBout: "none",
+      poignee: "none",
+      poigneeOwner: "none",
+      points: 56,
+      position: 1,
+      scoreEntries: [
+        { id: 1, player: { id: 1, name: "Alice" }, score: 120 },
+        { id: 2, player: { id: 2, name: "Bob" }, score: 120 },
+        { id: 3, player: { id: 3, name: "Charlie" }, score: -80 },
+        { id: 4, player: { id: 4, name: "Diana" }, score: -80 },
+        { id: 5, player: { id: 5, name: "Eve" }, score: -80 },
+      ],
+      status: "completed",
+      taker: { id: 1, name: "Alice" },
+    },
+  ],
+  id: 1,
+  isActive: true,
+  players: mockPlayers,
+};
+
+function setupMocks(overrides?: {
+  createGame?: Partial<ReturnType<typeof useCreateGameModule.useCreateGame>>;
+  useSession?: Partial<ReturnType<typeof useSessionModule.useSession>>;
+}) {
+  const createGameMutate = vi.fn();
+
+  vi.mocked(useSessionModule.useSession).mockReturnValue({
+    data: mockSession,
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdateCount: 0,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    fetchStatus: "idle",
+    isError: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isInitialLoading: false,
+    isLoading: false,
+    isLoadingError: false,
+    isPaused: false,
+    isPending: false,
+    isPlaceholderData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true,
+    promise: Promise.resolve(mockSession),
+    refetch: vi.fn(),
+    session: mockSession,
+    status: "success",
+    ...overrides?.useSession,
+  } as unknown as ReturnType<typeof useSessionModule.useSession>);
+
+  vi.mocked(useCreateGameModule.useCreateGame).mockReturnValue({
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate: createGameMutate,
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+    ...overrides?.createGame,
+  } as unknown as ReturnType<typeof useCreateGameModule.useCreateGame>);
+
+  return { createGameMutate };
+}
+
+const mockSessionWithInProgress = {
+  ...mockSession,
+  games: [
+    ...mockSession.games,
+    {
+      chelem: "none" as const,
+      contract: "petite" as const,
+      createdAt: "2025-02-01T14:20:00+00:00",
+      id: 2,
+      oudlers: null,
+      partner: null,
+      petitAuBout: "none" as const,
+      poignee: "none" as const,
+      poigneeOwner: "none" as const,
+      points: null,
+      position: 2,
+      scoreEntries: [],
+      status: "in_progress" as const,
+      taker: { id: 3, name: "Charlie" },
+    },
+  ],
+};
+
+describe("SessionPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockNavigate.mockReset();
+  });
+
+  it("shows loading state while fetching", () => {
+    setupMocks({
+      useSession: { isPending: true, session: null },
+    });
+    renderWithProviders(<SessionPage />);
+
+    expect(screen.getByText("Chargement…")).toBeInTheDocument();
+  });
+
+  it("shows not found when session is null after loading", () => {
+    setupMocks({
+      useSession: { isSuccess: true, session: null },
+    });
+    renderWithProviders(<SessionPage />);
+
+    expect(screen.getByText("Session introuvable")).toBeInTheDocument();
+  });
+
+  it("renders scoreboard with player names", () => {
+    setupMocks();
+    renderWithProviders(<SessionPage />);
+
+    for (const player of mockPlayers) {
+      // Player names may appear in both scoreboard and game list
+      const matches = screen.getAllByText(player.name);
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("renders cumulative scores", () => {
+    setupMocks();
+    renderWithProviders(<SessionPage />);
+
+    // +120 appears in scoreboard and game list
+    const positives = screen.getAllByText("+120");
+    expect(positives.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("-30")).toBeInTheDocument();
+  });
+
+  it("does not show in-progress banner when no game in progress", () => {
+    setupMocks();
+    renderWithProviders(<SessionPage />);
+
+    expect(
+      screen.queryByRole("button", { name: "Compléter" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows in-progress banner when a game is in progress", () => {
+    setupMocks({
+      useSession: { data: mockSessionWithInProgress, session: mockSessionWithInProgress },
+    });
+    renderWithProviders(<SessionPage />);
+
+    expect(
+      screen.getByRole("button", { name: "Compléter" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows game history", () => {
+    setupMocks();
+    renderWithProviders(<SessionPage />);
+
+    expect(screen.getByText("Historique des donnes")).toBeInTheDocument();
+    expect(screen.getByText("Garde")).toBeInTheDocument();
+  });
+
+  it("shows FAB button", () => {
+    setupMocks();
+    renderWithProviders(<SessionPage />);
+
+    expect(
+      screen.getByRole("button", { name: "Nouvelle donne" }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables FAB when a game is in progress", () => {
+    setupMocks({
+      useSession: { data: mockSessionWithInProgress, session: mockSessionWithInProgress },
+    });
+    renderWithProviders(<SessionPage />);
+
+    expect(
+      screen.getByRole("button", { name: "Nouvelle donne" }),
+    ).toBeDisabled();
+  });
+
+  it("disables FAB when createGame is pending", () => {
+    setupMocks({
+      createGame: { isPending: true },
+    });
+    renderWithProviders(<SessionPage />);
+
+    expect(
+      screen.getByRole("button", { name: "Nouvelle donne" }),
+    ).toBeDisabled();
+  });
+
+  it("navigates back when back button is clicked", async () => {
+    setupMocks();
+    renderWithProviders(<SessionPage />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Retour" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
+});

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -1,0 +1,66 @@
+import type { Game } from "../types/api";
+import { ContractBadge, PlayerAvatar, ScoreDisplay } from "./ui";
+
+interface GameListProps {
+  games: Game[];
+  onEditLast: () => void;
+}
+
+export default function GameList({ games, onEditLast }: GameListProps) {
+  if (games.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-text-muted">
+        Aucune donne jouée
+      </p>
+    );
+  }
+
+  const maxPosition = Math.max(...games.map((g) => g.position));
+  const sorted = [...games].sort((a, b) => b.position - a.position);
+
+  return (
+    <ul className="space-y-2">
+      {sorted.map((game) => {
+        const takerScore =
+          game.scoreEntries.find((e) => e.player.id === game.taker.id)
+            ?.score ?? 0;
+
+        return (
+          <li
+            className="flex items-center gap-3 rounded-xl bg-surface-card p-3"
+            key={game.id}
+          >
+            <PlayerAvatar
+              name={game.taker.name}
+              playerId={game.taker.id}
+              size="sm"
+            />
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-text-primary">
+                  {game.taker.name}
+                </span>
+                <ContractBadge contract={game.contract} />
+              </div>
+              <span className="text-xs text-text-muted">
+                {game.partner ? `avec ${game.partner.name}` : "Seul"}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <ScoreDisplay animated={false} value={takerScore} />
+              {game.position === maxPosition && (
+                <button
+                  className="rounded-lg bg-surface-elevated px-2 py-1 text-xs font-medium text-text-secondary"
+                  onClick={onEditLast}
+                  type="button"
+                >
+                  Modifier
+                </button>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/frontend/src/components/InProgressBanner.tsx
+++ b/frontend/src/components/InProgressBanner.tsx
@@ -1,0 +1,28 @@
+import type { Game } from "../types/api";
+import { ContractBadge, PlayerAvatar } from "./ui";
+
+interface InProgressBannerProps {
+  game: Game;
+  onComplete: () => void;
+}
+
+export default function InProgressBanner({ game, onComplete }: InProgressBannerProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-xl bg-accent-500/10 p-3">
+      <PlayerAvatar name={game.taker.name} playerId={game.taker.id} size="md" />
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="text-sm font-medium text-text-primary">
+          {game.taker.name}
+        </span>
+        <ContractBadge contract={game.contract} />
+      </div>
+      <button
+        className="rounded-lg bg-accent-500 px-3 py-1.5 text-sm font-medium text-white"
+        onClick={onComplete}
+        type="button"
+      >
+        Compléter
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/Scoreboard.tsx
+++ b/frontend/src/components/Scoreboard.tsx
@@ -1,0 +1,30 @@
+import type { CumulativeScore, GamePlayer } from "../types/api";
+import { PlayerAvatar, ScoreDisplay } from "./ui";
+
+interface ScoreboardProps {
+  cumulativeScores: CumulativeScore[];
+  players: GamePlayer[];
+}
+
+export default function Scoreboard({ cumulativeScores, players }: ScoreboardProps) {
+  const scoreMap = new Map(
+    cumulativeScores.map((s) => [s.playerId, s.score]),
+  );
+
+  return (
+    <div className="flex gap-3 overflow-x-auto pb-2">
+      {players.map((player) => (
+        <div
+          className="flex min-w-16 flex-col items-center gap-1"
+          key={player.id}
+        >
+          <PlayerAvatar name={player.name} playerId={player.id} size="sm" />
+          <span className="max-w-16 truncate text-xs text-text-secondary">
+            {player.name}
+          </span>
+          <ScoreDisplay animated={false} value={scoreMap.get(player.id) ?? 0} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useCreateGame.ts
+++ b/frontend/src/hooks/useCreateGame.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "../services/api";
+import type { Game } from "../types/api";
+import type { Contract } from "../types/enums";
+
+interface CreateGameInput {
+  contract: Contract;
+  takerId: number;
+}
+
+export function useCreateGame(sessionId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ contract, takerId }: CreateGameInput) =>
+      apiFetch<Game>(`/sessions/${sessionId}/games`, {
+        body: JSON.stringify({
+          contract,
+          taker: `/api/players/${takerId}`,
+        }),
+        method: "POST",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
+    },
+  });
+}

--- a/frontend/src/hooks/useSession.ts
+++ b/frontend/src/hooks/useSession.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "../services/api";
+import type { SessionDetail } from "../types/api";
+
+export function useSession(id: number) {
+  const query = useQuery({
+    queryFn: () => apiFetch<SessionDetail>(`/sessions/${id}`),
+    queryKey: ["session", id],
+  });
+
+  return {
+    ...query,
+    session: query.data ?? null,
+  };
+}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -1,14 +1,120 @@
-import { useParams } from "react-router-dom";
+import { useMemo } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import GameList from "../components/GameList";
+import InProgressBanner from "../components/InProgressBanner";
+import Scoreboard from "../components/Scoreboard";
+import { FAB } from "../components/ui";
+import { useCreateGame } from "../hooks/useCreateGame";
+import { useSession } from "../hooks/useSession";
+import { GameStatus } from "../types/enums";
 
 export default function SessionPage() {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const sessionId = Number(id);
+  const { isPending, session } = useSession(sessionId);
+  const createGame = useCreateGame(sessionId);
+
+  const inProgressGame = useMemo(
+    () => session?.games.find((g) => g.status === GameStatus.InProgress) ?? null,
+    [session],
+  );
+
+  const completedGames = useMemo(
+    () => session?.games.filter((g) => g.status === GameStatus.Completed) ?? [],
+    [session],
+  );
+
+  if (isPending) {
+    return (
+      <div className="p-4 text-center text-text-muted">Chargement…</div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="p-4 text-center text-text-muted">
+        Session introuvable
+      </div>
+    );
+  }
 
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold text-text-primary">
-        Session #{id}
-      </h1>
-      <p className="mt-2 text-text-muted">À venir</p>
+    <div className="flex flex-col gap-4 p-4 pb-24">
+      <div className="flex items-center gap-2">
+        <button
+          aria-label="Retour"
+          className="rounded-lg p-1 text-text-secondary"
+          onClick={() => navigate("/")}
+          type="button"
+        >
+          <svg
+            className="size-6"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M15 19l-7-7 7-7"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+        <h1 className="text-lg font-bold text-text-primary">
+          Session #{session.id}
+        </h1>
+      </div>
+
+      <Scoreboard
+        cumulativeScores={session.cumulativeScores}
+        players={session.players}
+      />
+
+      {inProgressGame && (
+        <InProgressBanner
+          game={inProgressGame}
+          onComplete={() => {
+            // Placeholder — issue #9
+          }}
+        />
+      )}
+
+      <div>
+        <h2 className="mb-2 text-sm font-semibold text-text-secondary">
+          Historique des donnes
+        </h2>
+        <GameList
+          games={completedGames}
+          onEditLast={() => {
+            // Placeholder — issue #9
+          }}
+        />
+      </div>
+
+      <FAB
+        aria-label="Nouvelle donne"
+        disabled={!!inProgressGame || createGame.isPending}
+        icon={
+          <svg
+            className="size-6"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 4v16m8-8H4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        }
+        onClick={() => {
+          // Placeholder — issue #9
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,3 +1,33 @@
+import type { Chelem, Contract, GameStatus, Poignee, Side } from "./enums";
+
+export interface CumulativeScore {
+  playerId: number;
+  playerName: string;
+  score: number;
+}
+
+export interface Game {
+  chelem: Chelem;
+  contract: Contract;
+  createdAt: string;
+  id: number;
+  oudlers: number | null;
+  partner: GamePlayer | null;
+  petitAuBout: Side;
+  poignee: Poignee;
+  poigneeOwner: Side;
+  points: number | null;
+  position: number;
+  scoreEntries: ScoreEntry[];
+  status: GameStatus;
+  taker: GamePlayer;
+}
+
+export interface GamePlayer {
+  id: number;
+  name: string;
+}
+
 export interface HydraCollection<T> {
   member: T[];
   totalItems: number;
@@ -9,11 +39,26 @@ export interface Player {
   name: string;
 }
 
+export interface ScoreEntry {
+  id: number;
+  player: GamePlayer;
+  score: number;
+}
+
 export interface Session {
   createdAt: string;
   id: number;
   isActive: boolean;
   players: SessionPlayer[];
+}
+
+export interface SessionDetail {
+  createdAt: string;
+  cumulativeScores: CumulativeScore[];
+  games: Game[];
+  id: number;
+  isActive: boolean;
+  players: GamePlayer[];
 }
 
 export interface SessionPlayer {


### PR DESCRIPTION
## Summary

- **Backend**: ajout du groupe de sérialisation `session:detail` sur Player.id/name, Game et ScoreEntry pour que `GET /api/sessions/{id}` retourne les objets imbriqués (et non des IRIs)
- **Types frontend**: ajout de `Game`, `GamePlayer`, `ScoreEntry`, `SessionDetail`, `CumulativeScore`
- **Hooks**: `useSession(id)` (query) et `useCreateGame(sessionId)` (mutation) avec TDD
- **Composants**: `Scoreboard` (scores cumulés), `InProgressBanner` (donne en cours), `GameList` (historique)
- **Page SessionPage**: remplacement du stub par l'écran complet avec scoreboard, bandeau donne en cours, historique, FAB et navigation retour
- **Docs**: mise à jour de `frontend-usage.md` et `CHANGELOG.md`

Les actions du FAB et du bouton « Compléter » sont des placeholders pour l'issue #9 (saisie de donne).

## Tests

- 147 tests frontend (26 fichiers) — 30 nouveaux tests ajoutés
- 57 tests backend — tous passent après ajout des groupes de sérialisation
- Build frontend OK

fixes #8