### PR TITLE
feat(frontend): score entry form with two-step wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Formulaire de saisie des donnes** : wizard en 2 étapes — NewGameModal (preneur + contrat) et CompleteGameModal (partenaire, oudlers, points, bonus, aperçu scores)
+- **Hook `useCompleteGame`** : mutation PATCH avec `application/merge-patch+json` pour compléter ou modifier une donne, avec invalidation du cache session
+- **Service `calculateScore`** : miroir frontend du ScoreCalculator backend pour aperçu des scores en temps réel (base, poignée, petit au bout, chelem, distribution preneur/partenaire/défenseurs)
+- **Composant `NewGameModal`** : sélection du preneur (avatars) et du contrat (grille colorée 2×2)
+- **Composant `CompleteGameModal`** : formulaire complet avec section bonus repliable, aperçu des scores, mode édition avec pré-remplissage
 - **Écran de session** : tableau des scores cumulés (Scoreboard), bandeau donne en cours (InProgressBanner), historique des donnes (GameList), bouton FAB nouvelle donne, navigation retour
 - **Hook `useSession`** : récupération du détail d'une session (joueurs, donnes, scores cumulés) via TanStack Query
 - **Hook `useCreateGame`** : mutation POST pour créer une nouvelle donne avec invalidation du cache session
@@ -40,7 +45,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 - **SearchInput** : champ de recherche avec debounce configurable et bouton clear
 - **Hooks utilitaires** : `useAnimatedCounter` (animation rAF), `useDebounce` (délai configurable)
 - **Documentation** : guide utilisateur (`docs/user-guide.md`) et référence développeur (`docs/frontend-usage.md`)
-- **Tests frontend** : 117 tests (20 fichiers) couvrant tous les composants, hooks et pages
+- **Tests frontend** : 207 tests (30 fichiers) couvrant tous les composants, hooks, services et pages
 - **Initialisation du projet** : CLAUDE.md, README.md, CHANGELOG.md, document de conception
 - **Document de conception** : architecture complète et design UI de l'application de scores au Tarot
 - **Projet GitHub** : 12 issues créées et organisées sur le tableau Tarot - Roadmap

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -103,7 +103,7 @@ Liste des donnes jouées (la plus récente en premier), montrant pour chaque don
 ### Actions
 
 - **Bouton + (FAB)** : démarrer une nouvelle donne (désactivé si une donne est en cours)
-- **Glisser à gauche** sur la dernière donne : modifier ses paramètres
+- **Modifier** : bouton affiché sur la dernière donne pour modifier ses paramètres
 
 ---
 
@@ -125,7 +125,7 @@ La saisie se fait en **2 étapes** :
 
 ### Étape 2 — Fin de la donne
 
-1. **Sélectionner le partenaire** : appuyer sur l'avatar du joueur appelé, ou **« Soi-même »** si le preneur appelle son propre roi
+1. **Sélectionner le partenaire** : appuyer sur l'avatar du joueur appelé, ou **« Seul »** si le preneur appelle son propre roi
 2. **Nombre d'oudlers** : utiliser le stepper (0 à 3)
 3. **Points réalisés** : saisir le total de points du camp attaquant (0 à 91)
 4. **Bonus** (section dépliable, optionnel) :
@@ -141,9 +141,9 @@ La saisie se fait en **2 étapes** :
 
 Seule la **dernière donne** de la session est modifiable. Pour la modifier :
 
-1. Glisser la carte de la dernière donne vers la gauche
-2. Modifier les paramètres souhaités
-3. Revalider → les scores sont recalculés
+1. Appuyer sur le bouton **« Modifier »** affiché à côté de la dernière donne dans l'historique
+2. Modifier les paramètres souhaités (partenaire, oudlers, points, bonus)
+3. Appuyer sur **Valider** → les scores sont recalculés
 
 ---
 

--- a/frontend/src/__tests__/components/CompleteGameModal.test.tsx
+++ b/frontend/src/__tests__/components/CompleteGameModal.test.tsx
@@ -1,0 +1,332 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CompleteGameModal from "../../components/CompleteGameModal";
+import * as useCompleteGameModule from "../../hooks/useCompleteGame";
+import type { Game } from "../../types/api";
+import { renderWithProviders } from "../test-utils";
+
+vi.mock("../../hooks/useCompleteGame");
+
+const mockPlayers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" },
+  { id: 4, name: "Diana" },
+  { id: 5, name: "Eve" },
+];
+
+const inProgressGame: Game = {
+  chelem: "none",
+  contract: "garde",
+  createdAt: "2025-02-01T14:10:00+00:00",
+  id: 7,
+  oudlers: null,
+  partner: null,
+  petitAuBout: "none",
+  poignee: "none",
+  poigneeOwner: "none",
+  points: null,
+  position: 1,
+  scoreEntries: [],
+  status: "in_progress",
+  taker: { id: 1, name: "Alice" },
+};
+
+const completedGame: Game = {
+  chelem: "none",
+  contract: "garde",
+  createdAt: "2025-02-01T14:10:00+00:00",
+  id: 7,
+  oudlers: 2,
+  partner: { id: 2, name: "Bob" },
+  petitAuBout: "none",
+  poignee: "none",
+  poigneeOwner: "none",
+  points: 45,
+  position: 1,
+  scoreEntries: [
+    { id: 1, player: { id: 1, name: "Alice" }, score: 58 },
+    { id: 2, player: { id: 2, name: "Bob" }, score: 29 },
+    { id: 3, player: { id: 3, name: "Charlie" }, score: -29 },
+    { id: 4, player: { id: 4, name: "Diana" }, score: -29 },
+    { id: 5, player: { id: 5, name: "Eve" }, score: -29 },
+  ],
+  status: "completed",
+  taker: { id: 1, name: "Alice" },
+};
+
+function setupMock(overrides?: Partial<ReturnType<typeof useCompleteGameModule.useCompleteGame>>) {
+  const mutate = vi.fn();
+  vi.mocked(useCompleteGameModule.useCompleteGame).mockReturnValue({
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate,
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+    ...overrides,
+  } as unknown as ReturnType<typeof useCompleteGameModule.useCompleteGame>);
+  return { mutate };
+}
+
+describe("CompleteGameModal", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows taker info in banner", () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    expect(screen.getByRole("img", { name: "Alice" })).toBeInTheDocument();
+    expect(screen.getByText("Garde")).toBeInTheDocument();
+  });
+
+  it("shows 'Compléter la donne' title for in_progress game", () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    expect(screen.getByText("Compléter la donne")).toBeInTheDocument();
+  });
+
+  it("shows 'Modifier la donne' title for completed game", () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={completedGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    expect(screen.getByText("Modifier la donne")).toBeInTheDocument();
+  });
+
+  it("shows partner selection excluding taker", () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    // Taker (Alice) should not be in partner selection
+    const partnerSection = screen.getByText("Partenaire").closest("div")!;
+    // 4 other players + "Seul" button = 5 buttons in partner section
+    expect(partnerSection.querySelectorAll("button").length).toBe(5);
+  });
+
+  it("toggles self-call mode", async () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    const seulButton = screen.getByRole("button", { name: "Seul" });
+    await userEvent.click(seulButton);
+
+    expect(seulButton).toHaveClass("ring-2");
+  });
+
+  it("shows oudlers stepper", () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    expect(screen.getByText("Oudlers")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Augmenter" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Diminuer" })).toBeInTheDocument();
+  });
+
+  it("shows points input with required points indication", () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    expect(screen.getByPlaceholderText("Points")).toBeInTheDocument();
+    // Default oudlers = 0, required = 56
+    expect(screen.getByText("Requis : 56 pts")).toBeInTheDocument();
+  });
+
+  it("updates required points when oudlers change", async () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Augmenter" }));
+    expect(screen.getByText("Requis : 51 pts")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Augmenter" }));
+    expect(screen.getByText("Requis : 41 pts")).toBeInTheDocument();
+  });
+
+  it("hides bonuses section by default", () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    expect(screen.queryByText("Poignée")).not.toBeInTheDocument();
+  });
+
+  it("shows bonuses section when expanded", async () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Bonus/i }));
+
+    expect(screen.getByText("Poignée")).toBeInTheDocument();
+    expect(screen.getByText("Petit au bout")).toBeInTheDocument();
+    expect(screen.getByText("Chelem")).toBeInTheDocument();
+  });
+
+  it("shows score preview when points are entered", async () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    // Select partner and enter points
+    await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+    await userEvent.type(screen.getByPlaceholderText("Points"), "45");
+
+    // Should show score preview (0 oudlers, 45 pts, garde)
+    // requis=56, perdu, base=-(56-45+25)×2=-72
+    await waitFor(() => {
+      expect(screen.getByText(/Contrat chuté/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'Contrat rempli' when attack wins", async () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    // Set 3 oudlers (requis=36) and 45 points → win
+    await userEvent.click(screen.getByRole("button", { name: "Augmenter" }));
+    await userEvent.click(screen.getByRole("button", { name: "Augmenter" }));
+    await userEvent.click(screen.getByRole("button", { name: "Augmenter" }));
+    await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+    await userEvent.type(screen.getByPlaceholderText("Points"), "45");
+
+    await waitFor(() => {
+      expect(screen.getByText(/Contrat rempli/)).toBeInTheDocument();
+    });
+  });
+
+  it("disables validate when points are empty", () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Valider" })).toBeDisabled();
+  });
+
+  it("disables validate when no partner and not self-call", async () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    // Enter points but don't select partner
+    await userEvent.type(screen.getByPlaceholderText("Points"), "45");
+
+    expect(screen.getByRole("button", { name: "Valider" })).toBeDisabled();
+  });
+
+  it("calls mutate with correct payload on submit", async () => {
+    const { mutate } = setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    // Select Bob as partner
+    await userEvent.click(screen.getByRole("img", { name: "Bob" }).closest("button")!);
+    // Set 2 oudlers
+    await userEvent.click(screen.getByRole("button", { name: "Augmenter" }));
+    await userEvent.click(screen.getByRole("button", { name: "Augmenter" }));
+    // Enter points
+    await userEvent.type(screen.getByPlaceholderText("Points"), "45");
+    // Submit
+    await userEvent.click(screen.getByRole("button", { name: "Valider" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      {
+        chelem: "none",
+        oudlers: 2,
+        partnerId: 2,
+        petitAuBout: "none",
+        poignee: "none",
+        poigneeOwner: "none",
+        points: 45,
+        status: "completed",
+      },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+
+  it("sends partnerId as null for self-call", async () => {
+    const { mutate } = setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+    await userEvent.type(screen.getByPlaceholderText("Points"), "45");
+    await userEvent.click(screen.getByRole("button", { name: "Valider" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ partnerId: null }),
+      expect.anything(),
+    );
+  });
+
+  it("pre-fills fields in edit mode (completed game)", () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={completedGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    // Points should be pre-filled
+    expect(screen.getByPlaceholderText("Points")).toHaveValue("45");
+    // Oudlers should show 2
+    const oudlerStatus = screen.getByRole("status");
+    expect(oudlerStatus).toHaveTextContent("2");
+    // Bob should be selected as partner (ring-2)
+    expect(screen.getByRole("img", { name: "Bob" }).closest("button")).toHaveClass("ring-2");
+  });
+
+  it("shows error message when mutation fails", () => {
+    const error = new Error("Server error");
+    setupMock({ error, isError: true });
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    expect(screen.getByText("Server error")).toBeInTheDocument();
+  });
+
+  it("does not render when open is false", () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open={false} players={mockPlayers} sessionId={1} />,
+    );
+
+    expect(screen.queryByText("Compléter la donne")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/NewGameModal.test.tsx
+++ b/frontend/src/__tests__/components/NewGameModal.test.tsx
@@ -1,0 +1,172 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NewGameModal from "../../components/NewGameModal";
+import type { useCreateGame } from "../../hooks/useCreateGame";
+import { renderWithProviders } from "../test-utils";
+
+const mockPlayers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" },
+  { id: 4, name: "Diana" },
+  { id: 5, name: "Eve" },
+];
+
+function createMockCreateGame(
+  overrides?: Partial<ReturnType<typeof useCreateGame>>,
+): ReturnType<typeof useCreateGame> {
+  return {
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+    ...overrides,
+  } as unknown as ReturnType<typeof useCreateGame>;
+}
+
+describe("NewGameModal", () => {
+  it("renders player avatars for all players", () => {
+    const createGame = createMockCreateGame();
+    renderWithProviders(
+      <NewGameModal createGame={createGame} onClose={vi.fn()} open players={mockPlayers} />,
+    );
+
+    for (const player of mockPlayers) {
+      expect(screen.getByRole("img", { name: player.name })).toBeInTheDocument();
+    }
+  });
+
+  it("renders all 4 contract buttons", () => {
+    const createGame = createMockCreateGame();
+    renderWithProviders(
+      <NewGameModal createGame={createGame} onClose={vi.fn()} open players={mockPlayers} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Petite" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Garde" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Garde Sans" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Garde Contre" })).toBeInTheDocument();
+  });
+
+  it("highlights selected player with ring", async () => {
+    const createGame = createMockCreateGame();
+    renderWithProviders(
+      <NewGameModal createGame={createGame} onClose={vi.fn()} open players={mockPlayers} />,
+    );
+
+    const aliceAvatar = screen.getByRole("img", { name: "Alice" });
+    await userEvent.click(aliceAvatar.closest("button")!);
+
+    expect(aliceAvatar.closest("button")).toHaveClass("ring-2");
+  });
+
+  it("highlights selected contract with ring", async () => {
+    const createGame = createMockCreateGame();
+    renderWithProviders(
+      <NewGameModal createGame={createGame} onClose={vi.fn()} open players={mockPlayers} />,
+    );
+
+    const gardeButton = screen.getByRole("button", { name: "Garde" });
+    await userEvent.click(gardeButton);
+
+    expect(gardeButton).toHaveClass("ring-2");
+  });
+
+  it("disables validate button when no player selected", () => {
+    const createGame = createMockCreateGame();
+    renderWithProviders(
+      <NewGameModal createGame={createGame} onClose={vi.fn()} open players={mockPlayers} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Valider" })).toBeDisabled();
+  });
+
+  it("disables validate button when no contract selected", async () => {
+    const createGame = createMockCreateGame();
+    renderWithProviders(
+      <NewGameModal createGame={createGame} onClose={vi.fn()} open players={mockPlayers} />,
+    );
+
+    // Select a player but no contract
+    await userEvent.click(screen.getByRole("img", { name: "Alice" }).closest("button")!);
+
+    expect(screen.getByRole("button", { name: "Valider" })).toBeDisabled();
+  });
+
+  it("enables validate button when player and contract are selected", async () => {
+    const createGame = createMockCreateGame();
+    renderWithProviders(
+      <NewGameModal createGame={createGame} onClose={vi.fn()} open players={mockPlayers} />,
+    );
+
+    await userEvent.click(screen.getByRole("img", { name: "Alice" }).closest("button")!);
+    await userEvent.click(screen.getByRole("button", { name: "Garde" }));
+
+    expect(screen.getByRole("button", { name: "Valider" })).toBeEnabled();
+  });
+
+  it("calls mutate with correct payload on submit", async () => {
+    const mutate = vi.fn();
+    const createGame = createMockCreateGame({ mutate });
+    renderWithProviders(
+      <NewGameModal createGame={createGame} onClose={vi.fn()} open players={mockPlayers} />,
+    );
+
+    await userEvent.click(screen.getByRole("img", { name: "Charlie" }).closest("button")!);
+    await userEvent.click(screen.getByRole("button", { name: "Garde" }));
+    await userEvent.click(screen.getByRole("button", { name: "Valider" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      { contract: "garde", takerId: 3 },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+
+  it("calls onClose when mutation succeeds", async () => {
+    const onClose = vi.fn();
+    const mutate = vi.fn((_data: unknown, opts: { onSuccess?: () => void }) => {
+      opts.onSuccess?.();
+    });
+    const createGame = createMockCreateGame({ mutate: mutate as ReturnType<typeof useCreateGame>["mutate"] });
+    renderWithProviders(
+      <NewGameModal createGame={createGame} onClose={onClose} open players={mockPlayers} />,
+    );
+
+    await userEvent.click(screen.getByRole("img", { name: "Alice" }).closest("button")!);
+    await userEvent.click(screen.getByRole("button", { name: "Petite" }));
+    await userEvent.click(screen.getByRole("button", { name: "Valider" }));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows error message when mutation fails", () => {
+    const error = new Error("Server error");
+    const createGame = createMockCreateGame({ error, isError: true });
+    renderWithProviders(
+      <NewGameModal createGame={createGame} onClose={vi.fn()} open players={mockPlayers} />,
+    );
+
+    expect(screen.getByText("Server error")).toBeInTheDocument();
+  });
+
+  it("does not render when open is false", () => {
+    const createGame = createMockCreateGame();
+    renderWithProviders(
+      <NewGameModal createGame={createGame} onClose={vi.fn()} open={false} players={mockPlayers} />,
+    );
+
+    expect(screen.queryByText("Nouvelle donne")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/hooks/useCompleteGame.test.ts
+++ b/frontend/src/__tests__/hooks/useCompleteGame.test.ts
@@ -1,0 +1,138 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import { useCompleteGame } from "../../hooks/useCompleteGame";
+import * as api from "../../services/api";
+import { createTestQueryClient } from "../test-utils";
+
+vi.mock("../../services/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  const w = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper: w };
+}
+
+describe("useCompleteGame", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends PATCH with merge-patch+json content type", async () => {
+    vi.mocked(api.apiFetch).mockResolvedValue({ id: 7, status: "completed" });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCompleteGame(7, 42), { wrapper });
+
+    await act(() =>
+      result.current.mutateAsync({
+        chelem: "none",
+        oudlers: 2,
+        partnerId: 3,
+        petitAuBout: "none",
+        poignee: "none",
+        poigneeOwner: "none",
+        points: 45,
+        status: "completed",
+      }),
+    );
+
+    expect(api.apiFetch).toHaveBeenCalledWith("/games/7", {
+      body: JSON.stringify({
+        chelem: "none",
+        oudlers: 2,
+        partner: "/api/players/3",
+        petitAuBout: "none",
+        poignee: "none",
+        poigneeOwner: "none",
+        points: 45,
+        status: "completed",
+      }),
+      headers: { "Content-Type": "application/merge-patch+json" },
+      method: "PATCH",
+    });
+  });
+
+  it("sends partner as null for self-call", async () => {
+    vi.mocked(api.apiFetch).mockResolvedValue({ id: 7, status: "completed" });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCompleteGame(7, 42), { wrapper });
+
+    await act(() =>
+      result.current.mutateAsync({
+        chelem: "none",
+        oudlers: 1,
+        partnerId: null,
+        petitAuBout: "none",
+        poignee: "none",
+        poigneeOwner: "none",
+        points: 60,
+        status: "completed",
+      }),
+    );
+
+    const callArgs = vi.mocked(api.apiFetch).mock.calls[0];
+    const body = JSON.parse(callArgs[1]!.body as string);
+    expect(body.partner).toBeNull();
+  });
+
+  it("invalidates session query on success", async () => {
+    vi.mocked(api.apiFetch).mockResolvedValue({ id: 7, status: "completed" });
+    const { queryClient, wrapper } = createWrapper();
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCompleteGame(7, 42), { wrapper });
+
+    await act(() =>
+      result.current.mutateAsync({
+        chelem: "none",
+        oudlers: 2,
+        partnerId: 3,
+        petitAuBout: "none",
+        poignee: "none",
+        poigneeOwner: "none",
+        points: 45,
+        status: "completed",
+      }),
+    );
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["session", 42] });
+  });
+
+  it("propagates API errors", async () => {
+    const apiError = new api.ApiError(
+      { detail: "Server error" },
+      "API error: 500",
+      500,
+    );
+    vi.mocked(api.apiFetch).mockRejectedValue(apiError);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCompleteGame(7, 42), { wrapper });
+
+    act(() =>
+      result.current.mutate({
+        chelem: "none",
+        oudlers: 2,
+        partnerId: 3,
+        petitAuBout: "none",
+        poignee: "none",
+        poigneeOwner: "none",
+        points: 45,
+        status: "completed",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(api.ApiError);
+    });
+  });
+});

--- a/frontend/src/__tests__/services/scoreCalculator.test.ts
+++ b/frontend/src/__tests__/services/scoreCalculator.test.ts
@@ -1,0 +1,258 @@
+import {
+  calculateScore,
+  type ScoreCalculatorInput,
+} from "../../services/scoreCalculator";
+import { Chelem, Contract, Side } from "../../types/enums";
+
+function makeInput(overrides: Partial<ScoreCalculatorInput> = {}): ScoreCalculatorInput {
+  return {
+    chelem: Chelem.None,
+    contract: Contract.Petite,
+    oudlers: 2,
+    partnerId: 2,
+    petitAuBout: Side.None,
+    poignee: "none",
+    points: 45,
+    ...overrides,
+  };
+}
+
+describe("calculateScore", () => {
+  // ---------------------------------------------------------------
+  // Cas de base
+  // ---------------------------------------------------------------
+
+  it("calcule une petite gagnée avec 2 oudlers", () => {
+    // Petite, 2 oudlers, 45 pts → requis=41, base=(45-41+25)×1=29
+    const result = calculateScore(makeInput());
+
+    expect(result.attackWins).toBe(true);
+    expect(result.baseScore).toBe(29);
+    expect(result.takerScore).toBe(58);
+    expect(result.partnerScore).toBe(29);
+    expect(result.defenderScore).toBe(-29);
+  });
+
+  it("calcule une petite perdue sans oudler", () => {
+    // Petite, 0 oudlers, 40 pts → requis=56, base=-(56-40+25)×1=-41
+    const result = calculateScore(makeInput({ oudlers: 0, points: 40 }));
+
+    expect(result.attackWins).toBe(false);
+    expect(result.baseScore).toBe(-41);
+    expect(result.takerScore).toBe(-82);
+    expect(result.defenderScore).toBe(41);
+  });
+
+  it("calcule une garde gagnée avec 1 oudler", () => {
+    // Garde, 1 oudler, 60 pts → requis=51, base=(60-51+25)×2=68
+    const result = calculateScore(makeInput({ contract: Contract.Garde, oudlers: 1, points: 60 }));
+
+    expect(result.attackWins).toBe(true);
+    expect(result.baseScore).toBe(68);
+    expect(result.takerScore).toBe(136);
+  });
+
+  it("calcule une garde sans gagnée avec 3 oudlers", () => {
+    // GardeSans, 3 oudlers, 50 pts → requis=36, base=(50-36+25)×4=156
+    const result = calculateScore(makeInput({ contract: Contract.GardeSans, oudlers: 3, points: 50 }));
+
+    expect(result.baseScore).toBe(156);
+    expect(result.takerScore).toBe(312);
+  });
+
+  it("calcule une garde contre perdue sans oudler", () => {
+    // GardeContre, 0 oudlers, 30 pts → requis=56, base=-(56-30+25)×6=-306
+    const result = calculateScore(makeInput({ contract: Contract.GardeContre, oudlers: 0, points: 30 }));
+
+    expect(result.baseScore).toBe(-306);
+    expect(result.takerScore).toBe(-612);
+  });
+
+  it("calcule les points exacts (juste le contrat)", () => {
+    // Petite, 2 oudlers, 41 pts exactement → base=(0+25)×1=25
+    const result = calculateScore(makeInput({ points: 41 }));
+
+    expect(result.attackWins).toBe(true);
+    expect(result.baseScore).toBe(25);
+  });
+
+  // ---------------------------------------------------------------
+  // Bonus poignée
+  // ---------------------------------------------------------------
+
+  it("ajoute le bonus poignée au camp gagnant (attaque gagne)", () => {
+    // Petite gagnée + poignée simple → +20
+    // base=29, total=29+20=49
+    const result = calculateScore(makeInput({ poignee: "simple" }));
+
+    expect(result.poigneeBonus).toBe(20);
+    expect(result.totalPerPlayer).toBe(49);
+  });
+
+  it("soustrait le bonus poignée quand l'attaque perd", () => {
+    // Petite perdue + poignée double → -30
+    // base=-41, total=-41-30=-71
+    const result = calculateScore(makeInput({ oudlers: 0, poignee: "double", points: 40 }));
+
+    expect(result.poigneeBonus).toBe(-30);
+    expect(result.totalPerPlayer).toBe(-71);
+  });
+
+  // ---------------------------------------------------------------
+  // Petit au bout
+  // ---------------------------------------------------------------
+
+  it("ajoute le petit au bout quand attaque joue et gagne", () => {
+    // Garde, base=68, petit au bout=+10×2=+20, total=88
+    const result = calculateScore(makeInput({
+      contract: Contract.Garde,
+      oudlers: 1,
+      petitAuBout: Side.Attack,
+      points: 60,
+    }));
+
+    expect(result.petitAuBoutBonus).toBe(20);
+    expect(result.totalPerPlayer).toBe(88);
+  });
+
+  it("soustrait le petit au bout quand défense joue et attaque gagne", () => {
+    // Garde, base=68, petit au bout=-10×2=-20, total=48
+    const result = calculateScore(makeInput({
+      contract: Contract.Garde,
+      oudlers: 1,
+      petitAuBout: Side.Defense,
+      points: 60,
+    }));
+
+    expect(result.petitAuBoutBonus).toBe(-20);
+    expect(result.totalPerPlayer).toBe(48);
+  });
+
+  it("soustrait le petit au bout quand attaque joue et perd", () => {
+    // Petite, base=-41, petit au bout=-10×1=-10, total=-51
+    const result = calculateScore(makeInput({
+      oudlers: 0,
+      petitAuBout: Side.Attack,
+      points: 40,
+    }));
+
+    expect(result.petitAuBoutBonus).toBe(-10);
+    expect(result.totalPerPlayer).toBe(-51);
+  });
+
+  it("soustrait le petit au bout quand défense joue et attaque perd", () => {
+    // Petite, base=-41, petit au bout=-10×1=-10, total=-51
+    const result = calculateScore(makeInput({
+      oudlers: 0,
+      petitAuBout: Side.Defense,
+      points: 40,
+    }));
+
+    expect(result.petitAuBoutBonus).toBe(-10);
+    expect(result.totalPerPlayer).toBe(-51);
+  });
+
+  // ---------------------------------------------------------------
+  // Chelem
+  // ---------------------------------------------------------------
+
+  it("ajoute 400 pour un chelem annoncé gagné", () => {
+    // GardeSans, 3 oudlers, 91 pts, chelem annoncé gagné
+    // base=(91-36+25)×4=320, chelem=400, total=720
+    const result = calculateScore(makeInput({
+      chelem: Chelem.AnnouncedWon,
+      contract: Contract.GardeSans,
+      oudlers: 3,
+      points: 91,
+    }));
+
+    expect(result.chelemBonus).toBe(400);
+    expect(result.totalPerPlayer).toBe(720);
+  });
+
+  it("soustrait 200 pour un chelem annoncé perdu", () => {
+    // GardeSans, 3 oudlers, 50 pts, chelem annoncé perdu
+    // base=156, chelem=-200, total=-44
+    const result = calculateScore(makeInput({
+      chelem: Chelem.AnnouncedLost,
+      contract: Contract.GardeSans,
+      oudlers: 3,
+      points: 50,
+    }));
+
+    expect(result.chelemBonus).toBe(-200);
+    expect(result.totalPerPlayer).toBe(-44);
+  });
+
+  it("ajoute 200 pour un chelem non annoncé gagné", () => {
+    // Garde, 3 oudlers, 91 pts, chelem non annoncé gagné
+    // base=(91-36+25)×2=160, chelem=200, total=360
+    const result = calculateScore(makeInput({
+      chelem: Chelem.NotAnnouncedWon,
+      contract: Contract.Garde,
+      oudlers: 3,
+      points: 91,
+    }));
+
+    expect(result.chelemBonus).toBe(200);
+    expect(result.totalPerPlayer).toBe(360);
+  });
+
+  // ---------------------------------------------------------------
+  // Distribution : self-call
+  // ---------------------------------------------------------------
+
+  it("distribue ×4 au preneur en self-call", () => {
+    // Petite, 2 oudlers, 45 pts → base=29
+    // preneur=29×4=116, défenseurs=-29
+    const result = calculateScore(makeInput({ partnerId: null }));
+
+    expect(result.takerScore).toBe(116);
+    expect(result.partnerScore).toBe(0);
+    expect(result.defenderScore).toBe(-29);
+  });
+
+  // ---------------------------------------------------------------
+  // Distribution : avec partenaire
+  // ---------------------------------------------------------------
+
+  it("distribue ×2 preneur, ×1 partenaire avec partenaire", () => {
+    // Petite, 2 oudlers, 45 pts → base=29
+    // preneur=58, partenaire=29, défenseurs=-29
+    const result = calculateScore(makeInput());
+
+    expect(result.takerScore).toBe(58);
+    expect(result.partnerScore).toBe(29);
+    expect(result.defenderScore).toBe(-29);
+  });
+
+  // ---------------------------------------------------------------
+  // Invariant : somme = 0
+  // ---------------------------------------------------------------
+
+  it.each([
+    { desc: "petite gagnée avec partenaire", input: makeInput() },
+    { desc: "petite perdue sans oudler", input: makeInput({ oudlers: 0, points: 40 }) },
+    { desc: "garde gagnée", input: makeInput({ contract: Contract.Garde, oudlers: 1, points: 60 }) },
+    { desc: "self-call gagné", input: makeInput({ partnerId: null }) },
+    { desc: "self-call perdu", input: makeInput({ contract: Contract.Garde, oudlers: 0, partnerId: null, points: 30 }) },
+    { desc: "tous les bonus", input: makeInput({
+      chelem: Chelem.None,
+      contract: Contract.Garde,
+      oudlers: 1,
+      petitAuBout: Side.Attack,
+      poignee: "triple",
+      points: 60,
+    }) },
+  ])("somme des scores = 0 pour $desc", ({ input }) => {
+    const result = calculateScore(input);
+
+    const selfCall = input.partnerId === null;
+    const totalTaker = result.takerScore;
+    const totalPartner = selfCall ? 0 : result.partnerScore;
+    const numDefenders = selfCall ? 4 : 3;
+    const sum = totalTaker + totalPartner + numDefenders * result.defenderScore;
+
+    expect(sum).toBe(0);
+  });
+});

--- a/frontend/src/components/CompleteGameModal.tsx
+++ b/frontend/src/components/CompleteGameModal.tsx
@@ -1,0 +1,334 @@
+import { ChevronDown } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useCompleteGame } from "../hooks/useCompleteGame";
+import { calculateScore, REQUIRED_POINTS } from "../services/scoreCalculator";
+import type { Game, GamePlayer } from "../types/api";
+import { Chelem, GameStatus, Poignee, Side } from "../types/enums";
+import type { Chelem as ChelemType, Poignee as PoigneeType, Side as SideType } from "../types/enums";
+import { ContractBadge, Modal, PlayerAvatar, ScoreDisplay, Stepper } from "./ui";
+
+interface CompleteGameModalProps {
+  game: Game;
+  onClose: () => void;
+  open: boolean;
+  players: GamePlayer[];
+  sessionId: number;
+}
+
+const poigneeOptions: { label: string; value: PoigneeType }[] = [
+  { label: "Aucune", value: Poignee.None },
+  { label: "Simple", value: Poignee.Simple },
+  { label: "Double", value: Poignee.Double },
+  { label: "Triple", value: Poignee.Triple },
+];
+
+const petitAuBoutOptions: { label: string; value: SideType }[] = [
+  { label: "Aucun", value: Side.None },
+  { label: "Attaque", value: Side.Attack },
+  { label: "Défense", value: Side.Defense },
+];
+
+const chelemOptions: { label: string; value: ChelemType }[] = [
+  { label: "Aucun", value: Chelem.None },
+  { label: "Annoncé gagné", value: Chelem.AnnouncedWon },
+  { label: "Annoncé perdu", value: Chelem.AnnouncedLost },
+  { label: "Non annoncé gagné", value: Chelem.NotAnnouncedWon },
+];
+
+export default function CompleteGameModal({ game, onClose, open, players, sessionId }: CompleteGameModalProps) {
+  const completeGame = useCompleteGame(game.id, sessionId);
+  const isEditMode = game.status === GameStatus.Completed;
+
+  const [bonusesOpen, setBonusesOpen] = useState(false);
+  const [chelem, setChelem] = useState<ChelemType>(Chelem.None);
+  const [oudlers, setOudlers] = useState(0);
+  const [partnerId, setPartnerId] = useState<number | null>(null);
+  const [petitAuBout, setPetitAuBout] = useState<SideType>(Side.None);
+  const [poignee, setPoignee] = useState<PoigneeType>(Poignee.None);
+  const [poigneeOwner, setPoigneeOwner] = useState<SideType>(Side.None);
+  const [points, setPoints] = useState("");
+  const [selfCall, setSelfCall] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    completeGame.reset();
+    if (isEditMode) {
+      setBonusesOpen(game.chelem !== Chelem.None || game.petitAuBout !== Side.None || game.poignee !== Poignee.None);
+      setChelem(game.chelem);
+      setOudlers(game.oudlers ?? 0);
+      setPartnerId(game.partner?.id ?? null);
+      setPetitAuBout(game.petitAuBout);
+      setPoignee(game.poignee);
+      setPoigneeOwner(game.poigneeOwner);
+      setPoints(game.points !== null ? String(game.points) : "");
+      setSelfCall(game.partner === null);
+    } else {
+      setBonusesOpen(false);
+      setChelem(Chelem.None);
+      setOudlers(0);
+      setPartnerId(null);
+      setPetitAuBout(Side.None);
+      setPoignee(Poignee.None);
+      setPoigneeOwner(Side.None);
+      setPoints("");
+      setSelfCall(false);
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const pointsNum = points === "" ? null : Number(points);
+  const pointsValid = pointsNum !== null && !isNaN(pointsNum) && pointsNum >= 0 && pointsNum <= 91;
+  const hasPartner = selfCall || partnerId !== null;
+  const canSubmit = pointsValid && hasPartner && !completeGame.isPending;
+
+  const scoreResult = useMemo(() => {
+    if (!pointsValid) return null;
+    return calculateScore({
+      chelem,
+      contract: game.contract,
+      oudlers,
+      partnerId: selfCall ? null : partnerId,
+      petitAuBout,
+      poignee,
+      points: pointsNum!,
+    });
+  }, [chelem, game.contract, oudlers, partnerId, petitAuBout, poignee, pointsNum, pointsValid, selfCall]);
+
+  const otherPlayers = players.filter((p) => p.id !== game.taker.id);
+
+  function handleSelfCall() {
+    setSelfCall(true);
+    setPartnerId(null);
+  }
+
+  function handleSelectPartner(id: number) {
+    setSelfCall(false);
+    setPartnerId(id);
+  }
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    completeGame.mutate(
+      {
+        chelem,
+        oudlers,
+        partnerId: selfCall ? null : partnerId,
+        petitAuBout,
+        poignee,
+        poigneeOwner: poignee !== Poignee.None ? poigneeOwner : Side.None,
+        points: pointsNum!,
+        status: GameStatus.Completed,
+      },
+      { onSuccess: () => onClose() },
+    );
+  }
+
+  const title = isEditMode ? "Modifier la donne" : "Compléter la donne";
+
+  return (
+    <Modal onClose={onClose} open={open} title={title}>
+      <div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto">
+        {/* Bandeau info preneur */}
+        <div className="flex items-center gap-3 rounded-xl bg-surface-secondary p-3">
+          <PlayerAvatar name={game.taker.name} playerId={game.taker.id} size="md" />
+          <div className="flex flex-col gap-1">
+            <span className="text-sm font-medium text-text-primary">{game.taker.name}</span>
+            <ContractBadge contract={game.contract} />
+          </div>
+        </div>
+
+        {/* Partenaire */}
+        <div>
+          <h3 className="mb-2 text-sm font-medium text-text-secondary">Partenaire</h3>
+          <div className="flex flex-wrap justify-center gap-2">
+            <button
+              className={`rounded-xl px-3 py-2 text-sm font-medium transition-all ${
+                selfCall ? "ring-2 ring-accent-500 bg-accent-500/10 text-accent-500" : "bg-surface-secondary text-text-secondary"
+              }`}
+              onClick={handleSelfCall}
+              type="button"
+            >
+              Seul
+            </button>
+            {otherPlayers.map((player) => (
+              <button
+                className={`rounded-full p-0.5 transition-all ${
+                  partnerId === player.id ? "ring-2 ring-accent-500" : ""
+                } ${selfCall ? "opacity-40" : ""}`}
+                disabled={selfCall}
+                key={player.id}
+                onClick={() => handleSelectPartner(player.id)}
+                type="button"
+              >
+                <PlayerAvatar name={player.name} playerId={player.id} size="md" />
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Oudlers */}
+        <div className="flex items-center justify-between">
+          <Stepper label="Oudlers" max={3} min={0} onChange={setOudlers} value={oudlers} />
+          <span className="text-sm text-text-muted">
+            Requis : {REQUIRED_POINTS[oudlers]} pts
+          </span>
+        </div>
+
+        {/* Points */}
+        <div>
+          <input
+            className="w-full rounded-xl border border-surface-border bg-surface-primary px-4 py-3 text-center text-lg font-semibold tabular-nums text-text-primary placeholder:text-text-muted focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500"
+            inputMode="numeric"
+            onChange={(e) => setPoints(e.target.value)}
+            pattern="[0-9]*"
+            placeholder="Points"
+            type="text"
+            value={points}
+          />
+        </div>
+
+        {/* Bonus (repliable) */}
+        <div>
+          <button
+            className="flex w-full items-center justify-between rounded-xl bg-surface-secondary px-4 py-3 text-sm font-medium text-text-secondary"
+            onClick={() => setBonusesOpen(!bonusesOpen)}
+            type="button"
+          >
+            <span>Bonus (optionnel)</span>
+            <ChevronDown className={`size-4 transition-transform ${bonusesOpen ? "rotate-180" : ""}`} />
+          </button>
+
+          {bonusesOpen && (
+            <div className="mt-3 flex flex-col gap-4">
+              {/* Poignée */}
+              <div>
+                <h4 className="mb-2 text-sm font-medium text-text-secondary">Poignée</h4>
+                <div className="flex flex-wrap gap-2">
+                  {poigneeOptions.map((opt) => (
+                    <ToggleButton
+                      key={opt.value}
+                      label={opt.label}
+                      onClick={() => {
+                        setPoignee(opt.value);
+                        if (opt.value === Poignee.None) setPoigneeOwner(Side.None);
+                      }}
+                      selected={poignee === opt.value}
+                    />
+                  ))}
+                </div>
+              </div>
+
+              {/* Propriétaire poignée */}
+              {poignee !== Poignee.None && (
+                <div>
+                  <h4 className="mb-2 text-sm font-medium text-text-secondary">Poignée montrée par</h4>
+                  <div className="flex gap-2">
+                    <ToggleButton
+                      label="Attaque"
+                      onClick={() => setPoigneeOwner(Side.Attack)}
+                      selected={poigneeOwner === Side.Attack}
+                    />
+                    <ToggleButton
+                      label="Défense"
+                      onClick={() => setPoigneeOwner(Side.Defense)}
+                      selected={poigneeOwner === Side.Defense}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* Petit au bout */}
+              <div>
+                <h4 className="mb-2 text-sm font-medium text-text-secondary">Petit au bout</h4>
+                <div className="flex flex-wrap gap-2">
+                  {petitAuBoutOptions.map((opt) => (
+                    <ToggleButton
+                      key={opt.value}
+                      label={opt.label}
+                      onClick={() => setPetitAuBout(opt.value)}
+                      selected={petitAuBout === opt.value}
+                    />
+                  ))}
+                </div>
+              </div>
+
+              {/* Chelem */}
+              <div>
+                <h4 className="mb-2 text-sm font-medium text-text-secondary">Chelem</h4>
+                <div className="flex flex-wrap gap-2">
+                  {chelemOptions.map((opt) => (
+                    <ToggleButton
+                      key={opt.value}
+                      label={opt.label}
+                      onClick={() => setChelem(opt.value)}
+                      selected={chelem === opt.value}
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Aperçu des scores */}
+        {scoreResult && (
+          <div className="rounded-xl bg-surface-secondary p-3">
+            <p className={`mb-2 text-center text-sm font-semibold ${scoreResult.attackWins ? "text-score-positive" : "text-score-negative"}`}>
+              {scoreResult.attackWins ? "Contrat rempli \u2713" : "Contrat chuté \u2717"}
+            </p>
+            <div className="flex flex-col gap-1 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-text-secondary">Preneur</span>
+                <ScoreDisplay animated={false} value={scoreResult.takerScore} />
+              </div>
+              {!selfCall && partnerId !== null && (
+                <div className="flex items-center justify-between">
+                  <span className="text-text-secondary">Partenaire</span>
+                  <ScoreDisplay animated={false} value={scoreResult.partnerScore} />
+                </div>
+              )}
+              <div className="flex items-center justify-between">
+                <span className="text-text-secondary">
+                  Défense ({selfCall ? "\u00d74" : "\u00d73"})
+                </span>
+                <ScoreDisplay animated={false} value={scoreResult.defenderScore} />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Erreur */}
+        {completeGame.isError && (
+          <p className="text-center text-sm text-score-negative">
+            {completeGame.error?.message ?? "Erreur inconnue"}
+          </p>
+        )}
+
+        {/* Valider */}
+        <button
+          className="w-full rounded-xl bg-accent-500 py-3 text-sm font-semibold text-white transition-colors disabled:opacity-40"
+          disabled={!canSubmit}
+          onClick={handleSubmit}
+          type="button"
+        >
+          Valider
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+function ToggleButton({ label, onClick, selected }: { label: string; onClick: () => void; selected: boolean }) {
+  return (
+    <button
+      className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-all ${
+        selected
+          ? "bg-accent-500 text-white"
+          : "bg-surface-tertiary text-text-secondary"
+      }`}
+      onClick={onClick}
+      type="button"
+    >
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/components/NewGameModal.tsx
+++ b/frontend/src/components/NewGameModal.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import type { useCreateGame } from "../hooks/useCreateGame";
+import type { GamePlayer } from "../types/api";
+import { Contract } from "../types/enums";
+import type { Contract as ContractType } from "../types/enums";
+import { Modal, PlayerAvatar } from "./ui";
+
+interface NewGameModalProps {
+  createGame: ReturnType<typeof useCreateGame>;
+  onClose: () => void;
+  open: boolean;
+  players: GamePlayer[];
+}
+
+const contracts: { colorClass: string; label: string; value: ContractType }[] = [
+  { colorClass: "bg-contract-petite", label: "Petite", value: Contract.Petite },
+  { colorClass: "bg-contract-garde", label: "Garde", value: Contract.Garde },
+  { colorClass: "bg-contract-garde-sans", label: "Garde Sans", value: Contract.GardeSans },
+  { colorClass: "bg-contract-garde-contre", label: "Garde Contre", value: Contract.GardeContre },
+];
+
+export default function NewGameModal({ createGame, onClose, open, players }: NewGameModalProps) {
+  const [selectedContract, setSelectedContract] = useState<ContractType | null>(null);
+  const [selectedTakerId, setSelectedTakerId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setSelectedContract(null);
+      setSelectedTakerId(null);
+      createGame.reset();
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const canSubmit = selectedTakerId !== null && selectedContract !== null && !createGame.isPending;
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    createGame.mutate(
+      { contract: selectedContract, takerId: selectedTakerId },
+      { onSuccess: () => onClose() },
+    );
+  }
+
+  return (
+    <Modal onClose={onClose} open={open} title="Nouvelle donne">
+      <div className="flex flex-col gap-5">
+        {/* Preneur */}
+        <div>
+          <h3 className="mb-2 text-sm font-medium text-text-secondary">Preneur</h3>
+          <div className="flex justify-center gap-3">
+            {players.map((player) => (
+              <button
+                className={`rounded-full p-0.5 transition-all ${
+                  selectedTakerId === player.id ? "ring-2 ring-accent-500" : ""
+                }`}
+                key={player.id}
+                onClick={() => setSelectedTakerId(player.id)}
+                type="button"
+              >
+                <PlayerAvatar name={player.name} playerId={player.id} size="lg" />
+              </button>
+            ))}
+          </div>
+          {selectedTakerId && (
+            <p className="mt-1 text-center text-sm text-text-secondary">
+              {players.find((p) => p.id === selectedTakerId)?.name}
+            </p>
+          )}
+        </div>
+
+        {/* Contrat */}
+        <div>
+          <h3 className="mb-2 text-sm font-medium text-text-secondary">Contrat</h3>
+          <div className="grid grid-cols-2 gap-2">
+            {contracts.map(({ colorClass, label, value }) => (
+              <button
+                className={`${colorClass} rounded-xl px-4 py-3 text-sm font-semibold text-white transition-all ${
+                  selectedContract === value ? "ring-2 ring-offset-2 ring-offset-surface-primary ring-white" : "opacity-80"
+                }`}
+                key={value}
+                onClick={() => setSelectedContract(value)}
+                type="button"
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Erreur */}
+        {createGame.isError && (
+          <p className="text-center text-sm text-score-negative">
+            {createGame.error?.message ?? "Erreur inconnue"}
+          </p>
+        )}
+
+        {/* Valider */}
+        <button
+          className="w-full rounded-xl bg-accent-500 py-3 text-sm font-semibold text-white transition-colors disabled:opacity-40"
+          disabled={!canSubmit}
+          onClick={handleSubmit}
+          type="button"
+        >
+          Valider
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/hooks/useCompleteGame.ts
+++ b/frontend/src/hooks/useCompleteGame.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "../services/api";
+import type { Game } from "../types/api";
+import type { Chelem, GameStatus, Poignee, Side } from "../types/enums";
+
+export interface CompleteGameInput {
+  chelem: Chelem;
+  oudlers: number;
+  partnerId: number | null;
+  petitAuBout: Side;
+  poignee: Poignee;
+  poigneeOwner: Side;
+  points: number;
+  status: GameStatus;
+}
+
+export function useCompleteGame(gameId: number, sessionId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ partnerId, ...rest }: CompleteGameInput) =>
+      apiFetch<Game>(`/games/${gameId}`, {
+        body: JSON.stringify({
+          chelem: rest.chelem,
+          oudlers: rest.oudlers,
+          partner: partnerId !== null ? `/api/players/${partnerId}` : null,
+          petitAuBout: rest.petitAuBout,
+          poignee: rest.poignee,
+          poigneeOwner: rest.poigneeOwner,
+          points: rest.points,
+          status: rest.status,
+        }),
+        headers: { "Content-Type": "application/merge-patch+json" },
+        method: "PATCH",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
+    },
+  });
+}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -1,7 +1,9 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import CompleteGameModal from "../components/CompleteGameModal";
 import GameList from "../components/GameList";
 import InProgressBanner from "../components/InProgressBanner";
+import NewGameModal from "../components/NewGameModal";
 import Scoreboard from "../components/Scoreboard";
 import { FAB } from "../components/ui";
 import { useCreateGame } from "../hooks/useCreateGame";
@@ -24,6 +26,18 @@ export default function SessionPage() {
     () => session?.games.filter((g) => g.status === GameStatus.Completed) ?? [],
     [session],
   );
+
+  const lastCompletedGame = useMemo(
+    () =>
+      completedGames.length > 0
+        ? completedGames.reduce((a, b) => (a.position > b.position ? a : b))
+        : null,
+    [completedGames],
+  );
+
+  const [completeModalOpen, setCompleteModalOpen] = useState(false);
+  const [editModalOpen, setEditModalOpen] = useState(false);
+  const [newGameModalOpen, setNewGameModalOpen] = useState(false);
 
   if (isPending) {
     return (
@@ -75,9 +89,7 @@ export default function SessionPage() {
       {inProgressGame && (
         <InProgressBanner
           game={inProgressGame}
-          onComplete={() => {
-            // Placeholder — issue #9
-          }}
+          onComplete={() => setCompleteModalOpen(true)}
         />
       )}
 
@@ -87,9 +99,7 @@ export default function SessionPage() {
         </h2>
         <GameList
           games={completedGames}
-          onEditLast={() => {
-            // Placeholder — issue #9
-          }}
+          onEditLast={() => setEditModalOpen(true)}
         />
       </div>
 
@@ -111,10 +121,35 @@ export default function SessionPage() {
             />
           </svg>
         }
-        onClick={() => {
-          // Placeholder — issue #9
-        }}
+        onClick={() => setNewGameModalOpen(true)}
       />
+
+      <NewGameModal
+        createGame={createGame}
+        onClose={() => setNewGameModalOpen(false)}
+        open={newGameModalOpen}
+        players={session.players}
+      />
+
+      {inProgressGame && (
+        <CompleteGameModal
+          game={inProgressGame}
+          onClose={() => setCompleteModalOpen(false)}
+          open={completeModalOpen}
+          players={session.players}
+          sessionId={sessionId}
+        />
+      )}
+
+      {lastCompletedGame && (
+        <CompleteGameModal
+          game={lastCompletedGame}
+          onClose={() => setEditModalOpen(false)}
+          open={editModalOpen}
+          players={session.players}
+          sessionId={sessionId}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/services/scoreCalculator.ts
+++ b/frontend/src/services/scoreCalculator.ts
@@ -1,0 +1,96 @@
+import type { Chelem, Contract, Poignee, Side } from "../types/enums";
+
+export interface ScoreCalculatorInput {
+  chelem: Chelem;
+  contract: Contract;
+  oudlers: number;
+  partnerId: number | null;
+  petitAuBout: Side;
+  poignee: Poignee;
+  points: number;
+}
+
+export interface ScoreResult {
+  attackWins: boolean;
+  baseScore: number;
+  chelemBonus: number;
+  defenderScore: number;
+  partnerScore: number;
+  petitAuBoutBonus: number;
+  poigneeBonus: number;
+  takerScore: number;
+  totalPerPlayer: number;
+}
+
+export const REQUIRED_POINTS: Record<number, number> = { 0: 56, 1: 51, 2: 41, 3: 36 };
+
+const CONTRACT_MULTIPLIER: Record<Contract, number> = {
+  garde: 2,
+  garde_contre: 6,
+  garde_sans: 4,
+  petite: 1,
+};
+
+const POIGNEE_BONUS: Record<Poignee, number> = {
+  double: 30,
+  none: 0,
+  simple: 20,
+  triple: 40,
+};
+
+const CHELEM_BONUS: Record<Chelem, number> = {
+  announced_lost: -200,
+  announced_won: 400,
+  none: 0,
+  not_announced_won: 200,
+};
+
+export function calculateScore(input: ScoreCalculatorInput): ScoreResult {
+  const { chelem, contract, oudlers, partnerId, petitAuBout, poignee, points } = input;
+  const multiplier = CONTRACT_MULTIPLIER[contract];
+  const requiredPoints = REQUIRED_POINTS[oudlers];
+  const attackWins = points >= requiredPoints;
+  const selfCall = partnerId === null;
+
+  // Score de base : (|points - requis| + 25) × multiplicateur
+  let baseScore = (Math.abs(points - requiredPoints) + 25) * multiplier;
+  if (!attackWins) {
+    baseScore = -baseScore;
+  }
+
+  // Bonus poignée : toujours au camp gagnant
+  let poigneeBonus = POIGNEE_BONUS[poignee];
+  if (!attackWins) {
+    poigneeBonus = -poigneeBonus;
+  }
+
+  // Bonus petit au bout : 10 × multiplicateur
+  // Positif uniquement si l'attaque l'a joué ET gagne ; négatif dans les 3 autres cas
+  let petitAuBoutBonus = 0;
+  if (petitAuBout !== "none") {
+    const bonus = 10 * multiplier;
+    petitAuBoutBonus = petitAuBout === "attack" && attackWins ? bonus : -bonus;
+  }
+
+  // Bonus chelem
+  const chelemBonus = CHELEM_BONUS[chelem];
+
+  const totalPerPlayer = baseScore + poigneeBonus + petitAuBoutBonus + chelemBonus;
+
+  // Distribution
+  const takerScore = totalPerPlayer * (selfCall ? 4 : 2);
+  const partnerScore = selfCall ? 0 : totalPerPlayer;
+  const defenderScore = -totalPerPlayer;
+
+  return {
+    attackWins,
+    baseScore,
+    chelemBonus,
+    defenderScore,
+    partnerScore,
+    petitAuBoutBonus,
+    poigneeBonus,
+    takerScore,
+    totalPerPlayer,
+  };
+}


### PR DESCRIPTION
## Summary

- **NewGameModal** (étape 1) : sélection du preneur (avatars avec highlight) + contrat (grille 2×2 colorée)
- **CompleteGameModal** (étape 2) : partenaire/seul, oudlers, points, bonus repliable (poignée, petit au bout, chelem), aperçu temps réel des scores, mode édition pré-rempli
- **calculateScore** : miroir frontend du `ScoreCalculator` backend pour prévisualisation instantanée
- **useCompleteGame** : hook mutation PATCH avec `application/merge-patch+json`
- **SessionPage** : câblage des 3 modales (FAB → new, Compléter → complete, Modifier → edit)
- **Documentation** : frontend-usage.md, user-guide.md, CHANGELOG.md mis à jour

fixes #9

## Test plan

- [ ] 207 tests frontend passent (30 fichiers)
- [ ] Build production réussit
- [ ] Ouvrir une session → cliquer FAB → sélectionner preneur + contrat → valider
- [ ] Vérifier le bandeau "donne en cours"
- [ ] Cliquer "Compléter" → remplir partenaire, oudlers, points → vérifier aperçu → valider
- [ ] Vérifier la donne dans l'historique avec scores
- [ ] Cliquer "Modifier" → modifier les points → valider → scores recalculés