### PR TITLE
feat(game): suppression d'une donne

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Suppression d'une donne** : suppression de la dernière donne (en cours ou complétée) avec modal de confirmation, recalcul automatique des scores, bouton « Supprimer » dans l'historique et « Annuler » sur le bandeau donne en cours
 - **Statistiques globales** : écran `/stats` avec classement des joueurs (score total, taux de victoire), métriques clés (total donnes/sessions) et répartition des contrats en barres horizontales
 - **Statistiques par joueur** : écran `/stats/player/:id` avec métriques (donnes jouées, score moyen, meilleur/pire), répartition des rôles, contrats pris et graphique d'évolution des scores récents
 - **Évolution des scores en session** : graphique linéaire dans `SessionPage` montrant les scores cumulés de chaque joueur au fil des donnes (visible à partir de 2 donnes terminées)

--- a/backend/src/Entity/Game.php
+++ b/backend/src/Entity/Game.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Link;
@@ -26,6 +27,10 @@ use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ApiResource(
     operations: [
+        new Delete(
+            validate: true,
+            validationContext: ['groups' => ['Default', 'game:delete']],
+        ),
         new Get(),
         new Patch(
             processor: GameCompleteProcessor::class,
@@ -46,7 +51,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
     ],
     normalizationContext: ['groups' => ['game:read']],
 )]
-#[OnlyLastGameEditable(groups: ['game:patch'])]
+#[OnlyLastGameEditable(groups: ['game:delete', 'game:patch'])]
 #[ORM\Entity]
 #[PlayersBelongToSession(groups: ['game:patch'])]
 class Game

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -265,6 +265,27 @@ completeGame.mutate({
 | `isError` | `boolean` | `true` si erreur |
 | `error` | `ApiError \| null` | Détails de l'erreur |
 
+### `useDeleteGame`
+
+**Fichier** : `hooks/useDeleteGame.ts`
+
+Mutation pour supprimer une donne. Envoie un DELETE et invalide le cache session en cas de succès.
+
+```ts
+const deleteGame = useDeleteGame(gameId, sessionId);
+
+deleteGame.mutate(undefined, {
+  onSuccess: () => closeModal(),
+});
+```
+
+| Retour | Type | Description |
+|--------|------|-------------|
+| `mutate` | `() => void` | Lance la suppression |
+| `isPending` | `boolean` | `true` pendant la requête |
+| `isError` | `boolean` | `true` si erreur (ex. pas la dernière donne 422) |
+| `error` | `ApiError \| null` | Détails de l'erreur |
+
 ### `useGlobalStats`
 
 **Fichier** : `hooks/useGlobalStats.ts`
@@ -429,11 +450,12 @@ const { isPending, sessions } = useSessions();
 - Bouton retour vers l'accueil
 - États : chargement, session introuvable
 
-**Hooks utilisés** : `useSession`, `useCreateGame`, `useCompleteGame`, `useNavigate`
+**Hooks utilisés** : `useSession`, `useCreateGame`, `useCompleteGame`, `useDeleteGame`, `useNavigate`
 
 **Modales** :
 - `NewGameModal` : sélection preneur + contrat (étape 1)
 - `CompleteGameModal` : complétion ou modification d'une donne (étape 2)
+- `DeleteGameModal` : confirmation de suppression de la dernière donne
 
 ---
 
@@ -490,11 +512,12 @@ Bandeau horizontal scrollable affichant les 5 joueurs avec avatar, nom et score 
 
 **Fichier** : `components/InProgressBanner.tsx`
 
-Bandeau pour une donne en cours, affichant le preneur, le contrat et un bouton « Compléter ».
+Bandeau pour une donne en cours, affichant le preneur, le contrat, un bouton « Compléter » et un bouton optionnel « Annuler ».
 
 | Prop | Type | Description |
 |------|------|-------------|
 | `game` | `Game` | *requis* — la donne en cours |
+| `onCancel` | `() => void` | *optionnel* — action au clic sur « Annuler » (suppression). Le bouton n'apparaît que si fourni. |
 | `onComplete` | `() => void` | *requis* — action au clic sur « Compléter » |
 
 ### `GameList`
@@ -506,12 +529,32 @@ Liste des donnes terminées en ordre anti-chronologique (position décroissante)
 | Prop | Type | Description |
 |------|------|-------------|
 | `games` | `Game[]` | *requis* — donnes terminées |
+| `onDeleteLast` | `() => void` | *requis* — action pour supprimer la dernière donne |
 | `onEditLast` | `() => void` | *requis* — action pour modifier la dernière donne |
 
 **Fonctionnalités** :
 - Chaque carte : avatar preneur, nom, badge contrat, « avec [partenaire] » ou « Seul », score du preneur
-- Bouton « Modifier » uniquement sur la dernière donne (position la plus élevée)
+- Boutons « Modifier » et « Supprimer » uniquement sur la dernière donne (position la plus élevée)
 - État vide : « Aucune donne jouée »
+
+### `DeleteGameModal`
+
+**Fichier** : `components/DeleteGameModal.tsx`
+
+Modal de confirmation de suppression d'une donne. Appelle `useDeleteGame` en interne.
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `game` | `Game` | *requis* — donne à supprimer |
+| `onClose` | `() => void` | *requis* — fermeture |
+| `open` | `boolean` | *requis* — afficher ou masquer |
+| `sessionId` | `number` | *requis* — ID de la session |
+
+**Fonctionnalités** :
+- Message de confirmation
+- Bouton « Annuler » (ferme la modal) et « Supprimer » (lance la suppression)
+- Bouton « Supprimer » désactivé pendant la suppression
+- Affichage d'erreur si la suppression échoue
 
 ### `NewGameModal`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -145,6 +145,15 @@ Seule la **dernière donne** de la session est modifiable. Pour la modifier :
 2. Modifier les paramètres souhaités (partenaire, oudlers, points, bonus)
 3. Appuyer sur **Valider** → les scores sont recalculés
 
+### Supprimer la dernière donne
+
+Seule la **dernière donne** peut être supprimée (erreur de saisie, donne annulée). Deux cas :
+
+- **Donne terminée** : appuyer sur le bouton **« Supprimer »** (en rouge) à côté de la dernière donne dans l'historique
+- **Donne en cours** : appuyer sur le bouton **« Annuler »** dans le bandeau de donne en cours
+
+Dans les deux cas, une **confirmation** est demandée. Après suppression, les scores cumulés de la session sont automatiquement recalculés.
+
 ---
 
 ## Consulter les statistiques

--- a/frontend/src/__tests__/components/DeleteGameModal.test.tsx
+++ b/frontend/src/__tests__/components/DeleteGameModal.test.tsx
@@ -1,0 +1,120 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DeleteGameModal from "../../components/DeleteGameModal";
+import * as useDeleteGameModule from "../../hooks/useDeleteGame";
+import { renderWithProviders } from "../test-utils";
+import type { Game } from "../../types/api";
+
+vi.mock("../../hooks/useDeleteGame");
+
+const mockGame: Game = {
+  chelem: "none",
+  contract: "garde",
+  createdAt: "2025-02-01T14:00:00+00:00",
+  id: 1,
+  oudlers: 2,
+  partner: { id: 2, name: "Bob" },
+  petitAuBout: "none",
+  poignee: "none",
+  poigneeOwner: "none",
+  points: 56,
+  position: 2,
+  scoreEntries: [],
+  status: "completed",
+  taker: { id: 1, name: "Alice" },
+};
+
+function setupMock(overrides?: Partial<ReturnType<typeof useDeleteGameModule.useDeleteGame>>) {
+  const mutateFn = vi.fn();
+  vi.mocked(useDeleteGameModule.useDeleteGame).mockReturnValue({
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate: mutateFn,
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+    ...overrides,
+  } as unknown as ReturnType<typeof useDeleteGameModule.useDeleteGame>);
+  return { mutateFn };
+}
+
+describe("DeleteGameModal", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders confirmation message and buttons", () => {
+    setupMock();
+    renderWithProviders(
+      <DeleteGameModal game={mockGame} onClose={() => {}} open={true} sessionId={1} />,
+    );
+
+    expect(screen.getByText("Supprimer la donne")).toBeInTheDocument();
+    expect(screen.getByText(/Êtes-vous sûr/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Annuler" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Supprimer" })).toBeInTheDocument();
+  });
+
+  it("calls mutate when Supprimer is clicked", async () => {
+    const { mutateFn } = setupMock();
+    renderWithProviders(
+      <DeleteGameModal game={mockGame} onClose={() => {}} open={true} sessionId={1} />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Supprimer" }));
+
+    expect(mutateFn).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when Annuler is clicked", async () => {
+    setupMock();
+    const onClose = vi.fn();
+    renderWithProviders(
+      <DeleteGameModal game={mockGame} onClose={onClose} open={true} sessionId={1} />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Annuler" }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows error message when deletion fails", () => {
+    setupMock({
+      error: new Error("API error: 500"),
+      isError: true,
+    });
+    renderWithProviders(
+      <DeleteGameModal game={mockGame} onClose={() => {}} open={true} sessionId={1} />,
+    );
+
+    expect(screen.getByText("API error: 500")).toBeInTheDocument();
+  });
+
+  it("disables Supprimer button when pending", () => {
+    setupMock({ isPending: true });
+    renderWithProviders(
+      <DeleteGameModal game={mockGame} onClose={() => {}} open={true} sessionId={1} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Supprimer" })).toBeDisabled();
+  });
+
+  it("does not render when closed", () => {
+    setupMock();
+    renderWithProviders(
+      <DeleteGameModal game={mockGame} onClose={() => {}} open={false} sessionId={1} />,
+    );
+
+    expect(screen.queryByText("Supprimer la donne")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/GameList.test.tsx
+++ b/frontend/src/__tests__/components/GameList.test.tsx
@@ -49,7 +49,7 @@ const games: Game[] = [
 describe("GameList", () => {
   it("renders games in reverse position order (latest first)", () => {
     renderWithProviders(
-      <GameList games={games} onEditLast={() => {}} />,
+      <GameList games={games} onDeleteLast={() => {}} onEditLast={() => {}} />,
     );
 
     const items = screen.getAllByRole("listitem");
@@ -61,7 +61,7 @@ describe("GameList", () => {
 
   it("shows taker name for each game", () => {
     renderWithProviders(
-      <GameList games={games} onEditLast={() => {}} />,
+      <GameList games={games} onDeleteLast={() => {}} onEditLast={() => {}} />,
     );
 
     expect(screen.getByText("Alice")).toBeInTheDocument();
@@ -70,7 +70,7 @@ describe("GameList", () => {
 
   it("shows partner name or Seul", () => {
     renderWithProviders(
-      <GameList games={games} onEditLast={() => {}} />,
+      <GameList games={games} onDeleteLast={() => {}} onEditLast={() => {}} />,
     );
 
     expect(screen.getByText("avec Bob")).toBeInTheDocument();
@@ -79,7 +79,7 @@ describe("GameList", () => {
 
   it("shows taker score from scoreEntries", () => {
     renderWithProviders(
-      <GameList games={games} onEditLast={() => {}} />,
+      <GameList games={games} onDeleteLast={() => {}} onEditLast={() => {}} />,
     );
 
     // Charlie's score in game 1: +120, Alice's score in game 2: +200
@@ -90,7 +90,7 @@ describe("GameList", () => {
   it("shows edit button only on the last game (highest position)", async () => {
     const onEditLast = vi.fn();
     renderWithProviders(
-      <GameList games={games} onEditLast={onEditLast} />,
+      <GameList games={games} onDeleteLast={() => {}} onEditLast={onEditLast} />,
     );
 
     const editButtons = screen.getAllByRole("button", { name: "Modifier" });
@@ -100,9 +100,22 @@ describe("GameList", () => {
     expect(onEditLast).toHaveBeenCalledOnce();
   });
 
+  it("shows delete button only on the last game and calls onDeleteLast", async () => {
+    const onDeleteLast = vi.fn();
+    renderWithProviders(
+      <GameList games={games} onDeleteLast={onDeleteLast} onEditLast={() => {}} />,
+    );
+
+    const deleteButtons = screen.getAllByRole("button", { name: "Supprimer" });
+    expect(deleteButtons).toHaveLength(1);
+
+    await userEvent.click(deleteButtons[0]);
+    expect(onDeleteLast).toHaveBeenCalledOnce();
+  });
+
   it("renders empty state when no games", () => {
     renderWithProviders(
-      <GameList games={[]} onEditLast={() => {}} />,
+      <GameList games={[]} onDeleteLast={() => {}} onEditLast={() => {}} />,
     );
 
     expect(screen.getByText("Aucune donne jouée")).toBeInTheDocument();

--- a/frontend/src/__tests__/components/InProgressBanner.test.tsx
+++ b/frontend/src/__tests__/components/InProgressBanner.test.tsx
@@ -59,4 +59,35 @@ describe("InProgressBanner", () => {
 
     expect(onComplete).toHaveBeenCalledOnce();
   });
+
+  it("does not show Annuler button when onCancel is not provided", () => {
+    renderWithProviders(
+      <InProgressBanner game={mockGame} onComplete={() => {}} />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Annuler" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Annuler button when onCancel is provided", () => {
+    renderWithProviders(
+      <InProgressBanner game={mockGame} onCancel={() => {}} onComplete={() => {}} />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Annuler" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onCancel when Annuler button is clicked", async () => {
+    const onCancel = vi.fn();
+    renderWithProviders(
+      <InProgressBanner game={mockGame} onCancel={onCancel} onComplete={() => {}} />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Annuler" }));
+
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
 });

--- a/frontend/src/__tests__/hooks/useDeleteGame.test.ts
+++ b/frontend/src/__tests__/hooks/useDeleteGame.test.ts
@@ -1,0 +1,70 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import { useDeleteGame } from "../../hooks/useDeleteGame";
+import * as api from "../../services/api";
+import { createTestQueryClient } from "../test-utils";
+
+vi.mock("../../services/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  const w = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper: w };
+}
+
+describe("useDeleteGame", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends DELETE request to correct URL", async () => {
+    vi.mocked(api.apiFetch).mockResolvedValue(undefined);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useDeleteGame(7, 42), { wrapper });
+
+    await act(() => result.current.mutateAsync());
+
+    expect(api.apiFetch).toHaveBeenCalledWith("/games/7", {
+      method: "DELETE",
+    });
+  });
+
+  it("invalidates session query on success", async () => {
+    vi.mocked(api.apiFetch).mockResolvedValue(undefined);
+    const { queryClient, wrapper } = createWrapper();
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useDeleteGame(7, 42), { wrapper });
+
+    await act(() => result.current.mutateAsync());
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["session", 42] });
+  });
+
+  it("propagates API errors", async () => {
+    const apiError = new api.ApiError(
+      { detail: "Server error" },
+      "API error: 500",
+      500,
+    );
+    vi.mocked(api.apiFetch).mockRejectedValue(apiError);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useDeleteGame(7, 42), { wrapper });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(api.ApiError);
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/SessionPage.test.tsx
+++ b/frontend/src/__tests__/pages/SessionPage.test.tsx
@@ -3,12 +3,14 @@ import userEvent from "@testing-library/user-event";
 import SessionPage from "../../pages/SessionPage";
 import * as useCompleteGameModule from "../../hooks/useCompleteGame";
 import * as useCreateGameModule from "../../hooks/useCreateGame";
+import * as useDeleteGameModule from "../../hooks/useDeleteGame";
 import * as useSessionModule from "../../hooks/useSession";
 import { renderWithProviders } from "../test-utils";
 import type { SessionDetail } from "../../types/api";
 
 vi.mock("../../hooks/useCompleteGame");
 vi.mock("../../hooks/useCreateGame");
+vi.mock("../../hooks/useDeleteGame");
 vi.mock("../../hooks/useSession");
 
 const mockNavigate = vi.fn();
@@ -138,6 +140,25 @@ function setupMocks(overrides?: {
     submittedAt: 0,
     variables: undefined,
   } as unknown as ReturnType<typeof useCompleteGameModule.useCompleteGame>);
+
+  vi.mocked(useDeleteGameModule.useDeleteGame).mockReturnValue({
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+  } as unknown as ReturnType<typeof useDeleteGameModule.useDeleteGame>);
 
   return { createGameMutate };
 }
@@ -305,5 +326,25 @@ describe("SessionPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "Modifier" }));
 
     expect(screen.getByText("Modifier la donne")).toBeInTheDocument();
+  });
+
+  it("opens delete modal when Supprimer is clicked on last completed game", async () => {
+    setupMocks();
+    renderWithProviders(<SessionPage />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Supprimer" }));
+
+    expect(screen.getByText("Supprimer la donne")).toBeInTheDocument();
+  });
+
+  it("opens delete modal when Annuler is clicked on in-progress game", async () => {
+    setupMocks({
+      useSession: { data: mockSessionWithInProgress, session: mockSessionWithInProgress },
+    });
+    renderWithProviders(<SessionPage />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Annuler" }));
+
+    expect(screen.getByText("Supprimer la donne")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/DeleteGameModal.tsx
+++ b/frontend/src/components/DeleteGameModal.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+import { useDeleteGame } from "../hooks/useDeleteGame";
+import type { Game } from "../types/api";
+import { Modal } from "./ui";
+
+interface DeleteGameModalProps {
+  game: Game;
+  onClose: () => void;
+  open: boolean;
+  sessionId: number;
+}
+
+export default function DeleteGameModal({ game, onClose, open, sessionId }: DeleteGameModalProps) {
+  const deleteGame = useDeleteGame(game.id, sessionId);
+
+  useEffect(() => {
+    if (open) deleteGame.reset();
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function handleConfirm() {
+    deleteGame.mutate(undefined, { onSuccess: () => onClose() });
+  }
+
+  return (
+    <Modal onClose={onClose} open={open} title="Supprimer la donne">
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-text-secondary">
+          Êtes-vous sûr de vouloir supprimer cette donne ? Les scores seront recalculés.
+        </p>
+
+        {deleteGame.isError && (
+          <p className="text-center text-sm text-score-negative">
+            {deleteGame.error?.message ?? "Erreur inconnue"}
+          </p>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            className="flex-1 rounded-xl bg-surface-secondary py-3 text-sm font-semibold text-text-secondary transition-colors"
+            onClick={onClose}
+            type="button"
+          >
+            Annuler
+          </button>
+          <button
+            className="flex-1 rounded-xl bg-red-500 py-3 text-sm font-semibold text-white transition-colors disabled:opacity-40"
+            disabled={deleteGame.isPending}
+            onClick={handleConfirm}
+            type="button"
+          >
+            Supprimer
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -3,10 +3,11 @@ import { ContractBadge, PlayerAvatar, ScoreDisplay } from "./ui";
 
 interface GameListProps {
   games: Game[];
+  onDeleteLast: () => void;
   onEditLast: () => void;
 }
 
-export default function GameList({ games, onEditLast }: GameListProps) {
+export default function GameList({ games, onDeleteLast, onEditLast }: GameListProps) {
   if (games.length === 0) {
     return (
       <p className="py-8 text-center text-sm text-text-muted">
@@ -49,13 +50,22 @@ export default function GameList({ games, onEditLast }: GameListProps) {
             <div className="flex items-center gap-2">
               <ScoreDisplay animated={false} value={takerScore} />
               {game.position === maxPosition && (
-                <button
-                  className="rounded-lg bg-surface-elevated px-2 py-1 text-xs font-medium text-text-secondary"
-                  onClick={onEditLast}
-                  type="button"
-                >
-                  Modifier
-                </button>
+                <>
+                  <button
+                    className="rounded-lg bg-surface-elevated px-2 py-1 text-xs font-medium text-text-secondary"
+                    onClick={onEditLast}
+                    type="button"
+                  >
+                    Modifier
+                  </button>
+                  <button
+                    className="rounded-lg bg-red-500/10 px-2 py-1 text-xs font-medium text-red-500"
+                    onClick={onDeleteLast}
+                    type="button"
+                  >
+                    Supprimer
+                  </button>
+                </>
               )}
             </div>
           </li>

--- a/frontend/src/components/InProgressBanner.tsx
+++ b/frontend/src/components/InProgressBanner.tsx
@@ -3,10 +3,11 @@ import { ContractBadge, PlayerAvatar } from "./ui";
 
 interface InProgressBannerProps {
   game: Game;
+  onCancel?: () => void;
   onComplete: () => void;
 }
 
-export default function InProgressBanner({ game, onComplete }: InProgressBannerProps) {
+export default function InProgressBanner({ game, onCancel, onComplete }: InProgressBannerProps) {
   return (
     <div className="flex items-center gap-3 rounded-xl bg-accent-500/10 p-3">
       <PlayerAvatar name={game.taker.name} playerId={game.taker.id} size="md" />
@@ -16,13 +17,24 @@ export default function InProgressBanner({ game, onComplete }: InProgressBannerP
         </span>
         <ContractBadge contract={game.contract} />
       </div>
-      <button
-        className="rounded-lg bg-accent-500 px-3 py-1.5 text-sm font-medium text-white"
-        onClick={onComplete}
-        type="button"
-      >
-        Compléter
-      </button>
+      <div className="flex gap-2">
+        {onCancel && (
+          <button
+            className="rounded-lg border border-red-500/30 px-3 py-1.5 text-sm font-medium text-red-500"
+            onClick={onCancel}
+            type="button"
+          >
+            Annuler
+          </button>
+        )}
+        <button
+          className="rounded-lg bg-accent-500 px-3 py-1.5 text-sm font-medium text-white"
+          onClick={onComplete}
+          type="button"
+        >
+          Compléter
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/hooks/useDeleteGame.ts
+++ b/frontend/src/hooks/useDeleteGame.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "../services/api";
+
+export function useDeleteGame(gameId: number, sessionId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () =>
+      apiFetch<void>(`/games/${gameId}`, {
+        method: "DELETE",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
+    },
+  });
+}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import CompleteGameModal from "../components/CompleteGameModal";
+import DeleteGameModal from "../components/DeleteGameModal";
 import GameList from "../components/GameList";
 import InProgressBanner from "../components/InProgressBanner";
 import NewGameModal from "../components/NewGameModal";
@@ -36,7 +37,16 @@ export default function SessionPage() {
     [completedGames],
   );
 
+  const lastGame = useMemo(
+    () =>
+      session?.games.length
+        ? session.games.reduce((a, b) => (a.position > b.position ? a : b))
+        : null,
+    [session],
+  );
+
   const [completeModalOpen, setCompleteModalOpen] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [newGameModalOpen, setNewGameModalOpen] = useState(false);
 
@@ -90,6 +100,7 @@ export default function SessionPage() {
       {inProgressGame && (
         <InProgressBanner
           game={inProgressGame}
+          onCancel={() => setDeleteModalOpen(true)}
           onComplete={() => setCompleteModalOpen(true)}
         />
       )}
@@ -112,6 +123,7 @@ export default function SessionPage() {
         </h2>
         <GameList
           games={completedGames}
+          onDeleteLast={() => setDeleteModalOpen(true)}
           onEditLast={() => setEditModalOpen(true)}
         />
       </div>
@@ -160,6 +172,15 @@ export default function SessionPage() {
           onClose={() => setEditModalOpen(false)}
           open={editModalOpen}
           players={session.players}
+          sessionId={sessionId}
+        />
+      )}
+
+      {lastGame && (
+        <DeleteGameModal
+          game={lastGame}
+          onClose={() => setDeleteModalOpen(false)}
+          open={deleteModalOpen}
           sessionId={sessionId}
         />
       )}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -30,5 +30,7 @@ export async function apiFetch<T>(
     throw new ApiError(body, `API error: ${response.status}`, response.status);
   }
 
+  if (response.status === 204) return undefined as T;
+
   return response.json();
 }


### PR DESCRIPTION
## Résumé

- **Backend** : ajout de l'opération `DELETE /api/games/{id}` via API Platform avec validation (`OnlyLastGameEditable`) — seule la dernière donne est supprimable
- **Frontend** : hook `useDeleteGame`, composant `DeleteGameModal` (confirmation), bouton « Supprimer » sur la dernière donne dans `GameList`, bouton « Annuler » sur `InProgressBanner`
- **Fix `apiFetch`** : gestion du 204 No Content (évite le crash sur `response.json()`)
- **Documentation** : CHANGELOG, guide utilisateur et référence développeur mis à jour

fixes #18

## Tests

- 4 nouveaux tests backend (suppression dernière donne, non-dernière interdite, donne en cours, session vide)
- 3 nouveaux tests hook `useDeleteGame`
- 6 nouveaux tests `DeleteGameModal`
- 3 nouveaux tests `InProgressBanner` (bouton Annuler)
- 1 nouveau test `GameList` (bouton Supprimer)
- 2 nouveaux tests `SessionPage` (ouverture modale delete)
- **Total** : 65 backend (199 assertions) ✅ | 246 frontend ✅