### PR TITLE
feat(session): changement de joueurs depuis une session en cours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Changement de joueurs** : depuis l'écran de session, bouton ⇄ pour modifier les joueurs sans repasser par l'accueil. Ouvre une modale `SwapPlayersModal` avec pré-sélection des joueurs actuels, réutilisant le `PlayerSelector` existant. Si les 5 joueurs choisis correspondent à une session active, navigation automatique vers celle-ci ; sinon, création d'une nouvelle session. Bouton désactivé pendant une donne en cours.
+
 - **Système d'étoiles** : attribution d'étoiles aux joueurs pendant une session avec pénalité automatique tous les 3 étoiles (−100 pts pour le joueur pénalisé, +25 pts pour les 4 autres). Entité `StarEvent`, endpoint API `POST/GET /sessions/{id}/star-events`, intégration dans les scores cumulés, classement et statistiques. Interface étoiles cliquables sur le tableau des scores, compteur par joueur, affichage dans les stats globales et par joueur.
 
 - **Rotation du donneur** : attribution automatique du premier donneur à la création de session (premier joueur alphabétique), copie sur chaque donne, rotation au joueur suivant après complétion d'une donne, icône de cartes sur le scoreboard et affichage dans la modale de saisie et l'historique des donnes

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -468,12 +468,14 @@ const { isPending, sessions } = useSessions();
 - Bandeau « donne en cours » (`InProgressBanner`) si une donne est au statut `in_progress`
 - Historique des donnes terminées (`GameList`) en ordre anti-chronologique
 - Bouton FAB (+) pour démarrer une nouvelle donne (désactivé si donne en cours)
+- Bouton de changement de joueurs (icône ⇄) dans le header (désactivé si donne en cours)
 - Bouton retour vers l'accueil
 - États : chargement, session introuvable
 
-**Hooks utilisés** : `useSession`, `useAddStar`, `useCreateGame`, `useCompleteGame`, `useDeleteGame`, `useNavigate`
+**Hooks utilisés** : `useSession`, `useAddStar`, `useCreateGame`, `useCreateSession` (via SwapPlayersModal), `useCompleteGame`, `useDeleteGame`, `useNavigate`
 
 **Modales** :
+- `SwapPlayersModal` : changement de joueurs avec navigation vers la session résultante
 - `NewGameModal` : sélection preneur + contrat (étape 1)
 - `CompleteGameModal` : complétion ou modification d'une donne (étape 2)
 - `DeleteGameModal` : confirmation de suppression de la dernière donne
@@ -580,6 +582,27 @@ Modal de confirmation de suppression d'une donne. Appelle `useDeleteGame` en int
 - Bouton « Annuler » (ferme la modal) et « Supprimer » (lance la suppression)
 - Bouton « Supprimer » désactivé pendant la suppression
 - Affichage d'erreur si la suppression échoue
+
+### `SwapPlayersModal`
+
+**Fichier** : `components/SwapPlayersModal.tsx`
+
+Modal de changement de joueurs depuis une session en cours. Réutilise `PlayerSelector` et `useCreateSession`.
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `currentPlayerIds` | `number[]` | *requis* — IDs des 5 joueurs actuels (pré-sélection) |
+| `onClose` | `() => void` | *requis* — fermeture |
+| `onSwap` | `(session: Session) => void` | *requis* — callback avec la session créée/retrouvée |
+| `open` | `boolean` | *requis* — afficher ou masquer |
+
+**Fonctionnalités** :
+- Pré-remplit le `PlayerSelector` avec les joueurs actuels
+- Texte explicatif sur le comportement de reprise de session
+- Bouton « Confirmer » désactivé si ≠ 5 joueurs ou mutation en cours
+- Appelle `useCreateSession` (find-or-create) au clic sur Confirmer
+- Reset automatique de la sélection et de l'état d'erreur à l'ouverture
+- Affichage d'erreur si la mutation échoue
 
 ### `NewGameModal`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -110,6 +110,19 @@ Liste des donnes jouées (la plus récente en premier), montrant pour chaque don
 - Le contrat (badge coloré)
 - Le résultat (gain/perte du preneur)
 
+### Modifier les joueurs
+
+Depuis l'écran de session, il est possible de **changer un ou plusieurs joueurs** sans repasser par l'accueil :
+
+1. Appuyer sur le bouton **⇄** (flèches) à droite du titre « Session #X »
+2. La modale de sélection s'ouvre avec les **5 joueurs actuels** pré-sélectionnés
+3. Désélectionner le(s) joueur(s) à remplacer et sélectionner le(s) nouveau(x)
+4. Appuyer sur **Confirmer**
+
+> **Session intelligente** : si une session active existe déjà avec les 5 joueurs choisis, l'application y navigue directement. Sinon, une nouvelle session est créée.
+
+> **Note** : le bouton est **désactivé** tant qu'une donne est en cours. Terminez ou supprimez la donne avant de modifier les joueurs.
+
 ### Actions
 
 - **Bouton + (FAB)** : démarrer une nouvelle donne (désactivé si une donne est en cours)

--- a/frontend/src/__tests__/components/SwapPlayersModal.test.tsx
+++ b/frontend/src/__tests__/components/SwapPlayersModal.test.tsx
@@ -1,0 +1,237 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SwapPlayersModal from "../../components/SwapPlayersModal";
+import * as useCreatePlayerModule from "../../hooks/useCreatePlayer";
+import * as useCreateSessionModule from "../../hooks/useCreateSession";
+import * as usePlayersModule from "../../hooks/usePlayers";
+import type { Player, Session } from "../../types/api";
+import { renderWithProviders } from "../test-utils";
+
+vi.mock("../../hooks/useCreatePlayer");
+vi.mock("../../hooks/useCreateSession");
+vi.mock("../../hooks/usePlayers");
+
+const mockPlayers: Player[] = [
+  { createdAt: "2025-01-01", id: 1, name: "Alice" },
+  { createdAt: "2025-01-01", id: 2, name: "Bob" },
+  { createdAt: "2025-01-01", id: 3, name: "Charlie" },
+  { createdAt: "2025-01-01", id: 4, name: "Diana" },
+  { createdAt: "2025-01-01", id: 5, name: "Eve" },
+  { createdAt: "2025-01-01", id: 6, name: "Frank" },
+];
+
+const currentPlayerIds = [1, 2, 3, 4, 5];
+
+function setupMocks(overrides?: {
+  createSession?: Partial<ReturnType<typeof useCreateSessionModule.useCreateSession>>;
+}) {
+  const createSessionMutate = vi.fn();
+  const createSessionReset = vi.fn();
+
+  vi.mocked(usePlayersModule.usePlayers).mockReturnValue({
+    data: { member: mockPlayers, totalItems: mockPlayers.length },
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdateCount: 0,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    fetchStatus: "idle",
+    isError: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isInitialLoading: false,
+    isLoading: false,
+    isLoadingError: false,
+    isPaused: false,
+    isPending: false,
+    isPlaceholderData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true,
+    players: mockPlayers,
+    promise: Promise.resolve({ member: mockPlayers, totalItems: mockPlayers.length }),
+    refetch: vi.fn(),
+    status: "success",
+  } as unknown as ReturnType<typeof usePlayersModule.usePlayers>);
+
+  vi.mocked(useCreatePlayerModule.useCreatePlayer).mockReturnValue({
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+  } as unknown as ReturnType<typeof useCreatePlayerModule.useCreatePlayer>);
+
+  vi.mocked(useCreateSessionModule.useCreateSession).mockReturnValue({
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate: createSessionMutate,
+    mutateAsync: vi.fn(),
+    reset: createSessionReset,
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+    ...overrides?.createSession,
+  } as unknown as ReturnType<typeof useCreateSessionModule.useCreateSession>);
+
+  return { createSessionMutate, createSessionReset };
+}
+
+describe("SwapPlayersModal", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders title when open", () => {
+    setupMocks();
+    renderWithProviders(
+      <SwapPlayersModal
+        currentPlayerIds={currentPlayerIds}
+        onClose={vi.fn()}
+        onSwap={vi.fn()}
+        open={true}
+      />,
+    );
+
+    expect(screen.getByText("Modifier les joueurs")).toBeInTheDocument();
+  });
+
+  it("pre-fills PlayerSelector with current players", () => {
+    setupMocks();
+    renderWithProviders(
+      <SwapPlayersModal
+        currentPlayerIds={currentPlayerIds}
+        onClose={vi.fn()}
+        onSwap={vi.fn()}
+        open={true}
+      />,
+    );
+
+    const chips = screen.getByTestId("selected-chips");
+    expect(chips).toHaveTextContent("Alice");
+    expect(chips).toHaveTextContent("Bob");
+    expect(chips).toHaveTextContent("Charlie");
+    expect(chips).toHaveTextContent("Diana");
+    expect(chips).toHaveTextContent("Eve");
+  });
+
+  it("disables Confirmer button when less than 5 players selected", async () => {
+    setupMocks();
+    renderWithProviders(
+      <SwapPlayersModal
+        currentPlayerIds={currentPlayerIds}
+        onClose={vi.fn()}
+        onSwap={vi.fn()}
+        open={true}
+      />,
+    );
+
+    // Remove one player by clicking its chip
+    const chips = screen.getByTestId("selected-chips");
+    const aliceChip = chips.querySelector("button");
+    await userEvent.click(aliceChip!);
+
+    expect(screen.getByRole("button", { name: "Confirmer" })).toBeDisabled();
+  });
+
+  it("calls createSession.mutate with selected IDs on confirm", async () => {
+    const { createSessionMutate } = setupMocks();
+    renderWithProviders(
+      <SwapPlayersModal
+        currentPlayerIds={currentPlayerIds}
+        onClose={vi.fn()}
+        onSwap={vi.fn()}
+        open={true}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Confirmer" }));
+
+    expect(createSessionMutate).toHaveBeenCalledWith(
+      currentPlayerIds,
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+
+  it("calls onSwap when mutation succeeds", async () => {
+    const onSwap = vi.fn();
+    const { createSessionMutate } = setupMocks();
+
+    createSessionMutate.mockImplementation(
+      (_ids: number[], options: { onSuccess: (s: Session) => void }) => {
+        options.onSuccess({ createdAt: "2025-01-01", id: 99, isActive: true, players: [] });
+      },
+    );
+
+    renderWithProviders(
+      <SwapPlayersModal
+        currentPlayerIds={currentPlayerIds}
+        onClose={vi.fn()}
+        onSwap={onSwap}
+        open={true}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Confirmer" }));
+
+    expect(onSwap).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 99 }),
+    );
+  });
+
+  it("shows error message when mutation fails", async () => {
+    setupMocks({
+      createSession: {
+        error: new Error("Erreur serveur"),
+        isError: true,
+      },
+    });
+
+    renderWithProviders(
+      <SwapPlayersModal
+        currentPlayerIds={currentPlayerIds}
+        onClose={vi.fn()}
+        onSwap={vi.fn()}
+        open={true}
+      />,
+    );
+
+    expect(screen.getByText("Erreur serveur")).toBeInTheDocument();
+  });
+
+  it("renders nothing when open is false", () => {
+    setupMocks();
+    const { container } = renderWithProviders(
+      <SwapPlayersModal
+        currentPlayerIds={currentPlayerIds}
+        onClose={vi.fn()}
+        onSwap={vi.fn()}
+        open={false}
+      />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/frontend/src/__tests__/pages/SessionPage.test.tsx
+++ b/frontend/src/__tests__/pages/SessionPage.test.tsx
@@ -4,7 +4,10 @@ import SessionPage from "../../pages/SessionPage";
 import * as useAddStarModule from "../../hooks/useAddStar";
 import * as useCompleteGameModule from "../../hooks/useCompleteGame";
 import * as useCreateGameModule from "../../hooks/useCreateGame";
+import * as useCreatePlayerModule from "../../hooks/useCreatePlayer";
+import * as useCreateSessionModule from "../../hooks/useCreateSession";
 import * as useDeleteGameModule from "../../hooks/useDeleteGame";
+import * as usePlayersModule from "../../hooks/usePlayers";
 import * as useSessionModule from "../../hooks/useSession";
 import { renderWithProviders } from "../test-utils";
 import type { SessionDetail } from "../../types/api";
@@ -12,7 +15,10 @@ import type { SessionDetail } from "../../types/api";
 vi.mock("../../hooks/useAddStar");
 vi.mock("../../hooks/useCompleteGame");
 vi.mock("../../hooks/useCreateGame");
+vi.mock("../../hooks/useCreatePlayer");
+vi.mock("../../hooks/useCreateSession");
 vi.mock("../../hooks/useDeleteGame");
+vi.mock("../../hooks/usePlayers");
 vi.mock("../../hooks/useSession");
 
 const mockNavigate = vi.fn();
@@ -181,6 +187,73 @@ function setupMocks(overrides?: {
     submittedAt: 0,
     variables: undefined,
   } as unknown as ReturnType<typeof useDeleteGameModule.useDeleteGame>);
+
+  vi.mocked(useCreateSessionModule.useCreateSession).mockReturnValue({
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+  } as unknown as ReturnType<typeof useCreateSessionModule.useCreateSession>);
+
+  vi.mocked(usePlayersModule.usePlayers).mockReturnValue({
+    data: { member: [], totalItems: 0 },
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdateCount: 0,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    fetchStatus: "idle",
+    isError: false,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isInitialLoading: false,
+    isLoading: false,
+    isLoadingError: false,
+    isPaused: false,
+    isPending: false,
+    isPlaceholderData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true,
+    players: [],
+    promise: Promise.resolve({ member: [], totalItems: 0 }),
+    refetch: vi.fn(),
+    status: "success",
+  } as unknown as ReturnType<typeof usePlayersModule.usePlayers>);
+
+  vi.mocked(useCreatePlayerModule.useCreatePlayer).mockReturnValue({
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: "idle",
+    submittedAt: 0,
+    variables: undefined,
+  } as unknown as ReturnType<typeof useCreatePlayerModule.useCreatePlayer>);
 
   return { createGameMutate };
 }
@@ -368,5 +441,38 @@ describe("SessionPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "Annuler" }));
 
     expect(screen.getByText("Supprimer la donne")).toBeInTheDocument();
+  });
+
+  it("renders swap players button", () => {
+    setupMocks();
+    renderWithProviders(<SessionPage />);
+
+    expect(
+      screen.getByRole("button", { name: "Modifier les joueurs" }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables swap players button when a game is in progress", () => {
+    setupMocks({
+      useSession: { data: mockSessionWithInProgress, session: mockSessionWithInProgress },
+    });
+    renderWithProviders(<SessionPage />);
+
+    expect(
+      screen.getByRole("button", { name: "Modifier les joueurs" }),
+    ).toBeDisabled();
+  });
+
+  it("opens SwapPlayersModal when swap button is clicked", async () => {
+    setupMocks();
+    renderWithProviders(<SessionPage />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Modifier les joueurs" }),
+    );
+
+    expect(
+      screen.getByText("Modifier les joueurs", { selector: "h2" }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/SwapPlayersModal.tsx
+++ b/frontend/src/components/SwapPlayersModal.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { useCreateSession } from "../hooks/useCreateSession";
+import type { Session } from "../types/api";
+import PlayerSelector from "./PlayerSelector";
+import { Modal } from "./ui";
+
+interface SwapPlayersModalProps {
+  currentPlayerIds: number[];
+  onClose: () => void;
+  onSwap: (session: Session) => void;
+  open: boolean;
+}
+
+export default function SwapPlayersModal({
+  currentPlayerIds,
+  onClose,
+  onSwap,
+  open,
+}: SwapPlayersModalProps) {
+  const [selectedPlayerIds, setSelectedPlayerIds] = useState<number[]>(currentPlayerIds);
+  const createSession = useCreateSession();
+
+  useEffect(() => {
+    if (open) {
+      setSelectedPlayerIds(currentPlayerIds);
+      createSession.reset();
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function handleConfirm() {
+    createSession.mutate(selectedPlayerIds, { onSuccess: onSwap });
+  }
+
+  return (
+    <Modal onClose={onClose} open={open} title="Modifier les joueurs">
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-text-secondary">
+          Sélectionnez 5 joueurs pour la nouvelle session. Si une session active existe avec ces
+          joueurs, elle sera reprise.
+        </p>
+
+        <PlayerSelector
+          onSelectionChange={setSelectedPlayerIds}
+          selectedPlayerIds={selectedPlayerIds}
+        />
+
+        {createSession.isError && (
+          <p className="text-center text-sm text-score-negative">
+            {createSession.error?.message ?? "Erreur inconnue"}
+          </p>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            className="flex-1 rounded-xl bg-surface-secondary py-3 text-sm font-semibold text-text-secondary transition-colors"
+            onClick={onClose}
+            type="button"
+          >
+            Annuler
+          </button>
+          <button
+            className="flex-1 rounded-xl bg-accent-500 py-3 text-sm font-semibold text-white transition-colors disabled:opacity-40"
+            disabled={selectedPlayerIds.length !== 5 || createSession.isPending}
+            onClick={handleConfirm}
+            type="button"
+          >
+            Confirmer
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -1,3 +1,4 @@
+import { ArrowLeftRight } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import CompleteGameModal from "../components/CompleteGameModal";
@@ -7,6 +8,7 @@ import InProgressBanner from "../components/InProgressBanner";
 import NewGameModal from "../components/NewGameModal";
 import Scoreboard from "../components/Scoreboard";
 import ScoreEvolutionChart from "../components/ScoreEvolutionChart";
+import SwapPlayersModal from "../components/SwapPlayersModal";
 import { FAB } from "../components/ui";
 import { useAddStar } from "../hooks/useAddStar";
 import { useCreateGame } from "../hooks/useCreateGame";
@@ -51,6 +53,7 @@ export default function SessionPage() {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [newGameModalOpen, setNewGameModalOpen] = useState(false);
+  const [swapModalOpen, setSwapModalOpen] = useState(false);
 
   if (isPending) {
     return (
@@ -92,6 +95,15 @@ export default function SessionPage() {
         <h1 className="text-lg font-bold text-text-primary">
           Session #{session.id}
         </h1>
+        <button
+          aria-label="Modifier les joueurs"
+          className="ml-auto rounded-lg p-1 text-text-secondary disabled:opacity-40"
+          disabled={!!inProgressGame}
+          onClick={() => setSwapModalOpen(true)}
+          type="button"
+        >
+          <ArrowLeftRight size={20} />
+        </button>
       </div>
 
       <Scoreboard
@@ -191,6 +203,19 @@ export default function SessionPage() {
           sessionId={sessionId}
         />
       )}
+
+      <SwapPlayersModal
+        currentPlayerIds={session.players.map((p) => p.id)}
+        onClose={() => setSwapModalOpen(false)}
+        onSwap={(newSession) => {
+          if (newSession.id !== sessionId) {
+            navigate(`/sessions/${newSession.id}`);
+          } else {
+            setSwapModalOpen(false);
+          }
+        }}
+        open={swapModalOpen}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Résumé

- Ajout d'un bouton ⇄ (`ArrowLeftRight`) dans le header de `SessionPage` pour modifier les joueurs d'une session sans repasser par l'accueil
- Nouveau composant `SwapPlayersModal` avec pré-sélection des joueurs actuels, réutilisant `PlayerSelector` et `useCreateSession`
- Navigation automatique vers la session résultante (existante ou nouvelle) grâce au find-or-create backend
- Bouton désactivé lorsqu'une donne est en cours
- Documentation utilisateur et développeur mise à jour

fixes #16

## Tests

- 7 tests unitaires pour `SwapPlayersModal` (titre, pré-remplissage, bouton désactivé, mutation, callback, erreur, fermeture)
- 3 tests ajoutés à `SessionPage` (affichage bouton, désactivé pendant donne en cours, ouverture modale)
- **256 tests passent** (39 fichiers)