### PR TITLE
feat(game): raccourci « Même config » pour la saisie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Raccourci « Même config »** : bouton dans la modale de nouvelle donne pour pré-remplir le preneur et le contrat de la dernière donne jouée, réduisant la saisie quand un joueur prend plusieurs fois de suite
+
 - **Changement de joueurs** : depuis l'écran de session, bouton ⇄ pour modifier les joueurs sans repasser par l'accueil. Ouvre une modale `SwapPlayersModal` avec pré-sélection des joueurs actuels, réutilisant le `PlayerSelector` existant. Si les 5 joueurs choisis correspondent à une session active, navigation automatique vers celle-ci ; sinon, création d'une nouvelle session. Bouton désactivé pendant une donne en cours.
 
 - **Système d'étoiles** : attribution d'étoiles aux joueurs pendant une session avec pénalité automatique tous les 3 étoiles (−100 pts pour le joueur pénalisé, +25 pts pour les 4 autres). Entité `StarEvent`, endpoint API `POST/GET /sessions/{id}/star-events`, intégration dans les scores cumulés, classement et statistiques. Interface étoiles cliquables sur le tableau des scores, compteur par joueur, affichage dans les stats globales et par joueur.

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -614,12 +614,14 @@ Modal de création de donne (étape 1) : sélection du preneur et du contrat. Af
 |------|------|-------------|
 | `createGame` | `ReturnType<typeof useCreateGame>` | *requis* — mutation hook |
 | `currentDealerName` | `string \| null` | *requis* — nom du donneur actuel (affiché en info) |
+| `lastGameConfig` | `{ contract: Contract; takerId: number }?` | *optionnel* — config de la dernière donne (preneur + contrat) pour le raccourci « Même config » |
 | `onClose` | `() => void` | *requis* — fermeture |
 | `open` | `boolean` | *requis* — afficher ou masquer |
 | `players` | `GamePlayer[]` | *requis* — les 5 joueurs de la session |
 
 **Fonctionnalités** :
 - Affichage du donneur actuel en haut de la modale
+- Bouton **« Même config »** (visible si `lastGameConfig` fourni) : pré-remplit le preneur et le contrat de la dernière donne
 - Sélection du preneur via avatars avec highlight `ring-2`
 - 4 boutons contrat colorés en grille 2×2
 - Reset automatique à l'ouverture

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -146,6 +146,8 @@ La saisie se fait en **2 étapes** :
    - 🔴 **Garde Contre** (×6)
 3. Appuyer sur **Valider**
 
+> **Raccourci « Même config »** : si au moins une donne a déjà été jouée, un bouton **« Même config »** apparaît en haut de la modale. Il pré-remplit automatiquement le preneur et le contrat de la dernière donne, ce qui est pratique quand un joueur prend plusieurs fois de suite. Les valeurs pré-remplies restent modifiables.
+
 > La donne est créée avec le statut « en cours ». On peut continuer à jouer et compléter plus tard.
 
 ### Étape 2 — Fin de la donne

--- a/frontend/src/components/NewGameModal.tsx
+++ b/frontend/src/components/NewGameModal.tsx
@@ -1,3 +1,4 @@
+import { RotateCcw } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { useCreateGame } from "../hooks/useCreateGame";
 import type { GamePlayer } from "../types/api";
@@ -8,6 +9,7 @@ import { Modal, PlayerAvatar } from "./ui";
 interface NewGameModalProps {
   createGame: ReturnType<typeof useCreateGame>;
   currentDealerName: string | null;
+  lastGameConfig?: { contract: ContractType; takerId: number };
   onClose: () => void;
   open: boolean;
   players: GamePlayer[];
@@ -20,7 +22,7 @@ const contracts: { colorClass: string; label: string; value: ContractType }[] = 
   { colorClass: "bg-contract-garde-contre", label: "Garde Contre", value: Contract.GardeContre },
 ];
 
-export default function NewGameModal({ createGame, currentDealerName, onClose, open, players }: NewGameModalProps) {
+export default function NewGameModal({ createGame, currentDealerName, lastGameConfig, onClose, open, players }: NewGameModalProps) {
   const [selectedContract, setSelectedContract] = useState<ContractType | null>(null);
   const [selectedTakerId, setSelectedTakerId] = useState<number | null>(null);
 
@@ -50,6 +52,23 @@ export default function NewGameModal({ createGame, currentDealerName, onClose, o
           <p className="text-center text-sm text-text-secondary">
             Donneur : <span className="font-medium text-text-primary">{currentDealerName}</span>
           </p>
+        )}
+
+        {/* Même config */}
+        {lastGameConfig && (
+          <div className="flex justify-center">
+            <button
+              className="inline-flex items-center gap-1.5 rounded-lg border border-accent-500 px-3 py-1.5 text-xs font-medium text-accent-500 transition-colors hover:bg-accent-500/10"
+              onClick={() => {
+                setSelectedContract(lastGameConfig.contract);
+                setSelectedTakerId(lastGameConfig.takerId);
+              }}
+              type="button"
+            >
+              <RotateCcw size={14} />
+              Même config
+            </button>
+          </div>
         )}
 
         {/* Preneur */}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -170,6 +170,7 @@ export default function SessionPage() {
       <NewGameModal
         createGame={createGame}
         currentDealerName={session.currentDealer?.name ?? null}
+        lastGameConfig={lastCompletedGame ? { contract: lastCompletedGame.contract, takerId: lastCompletedGame.taker.id } : undefined}
         onClose={() => setNewGameModalOpen(false)}
         open={newGameModalOpen}
         players={session.players}


### PR DESCRIPTION
## Résumé

Ajoute un bouton **« Même config »** dans la modale de nouvelle donne (`NewGameModal`) pour pré-remplir automatiquement le preneur et le contrat de la dernière donne jouée. Réduit la saisie répétitive quand un joueur prend plusieurs fois de suite.

- Nouvelle prop optionnelle `lastGameConfig` sur `NewGameModal`
- Bouton visible uniquement quand au moins une donne est terminée
- Les valeurs pré-remplies restent modifiables
- 4 nouveaux tests unitaires
- Documentation mise à jour (user-guide, frontend-usage, changelog)

fixes #19

## Plan de test

- [x] 260 tests frontend passent (dont 4 nouveaux pour cette feature)
- [x] Build production réussi (`tsc && vite build`)
- [ ] Test manuel : ouvrir une session avec ≥1 donne terminée → bouton « Même config » visible → clic pré-remplit preneur + contrat → peut modifier → soumettre fonctionne
- [ ] Test manuel : session avec 0 donne → bouton absent