### PR TITLE
feat(build): cible chrome64 pour compatibilité Smart TV

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,11 @@
     "vite-plugin-pwa": "^1.2.0",
     "vitest": "^4.0.18"
   },
+  "browserslist": [
+    "chrome >= 64",
+    "last 2 versions",
+    "not dead"
+  ],
   "dependencies": {
     "@tanstack/react-query": "^5.90.20",
     "@vitejs/plugin-react": "^5.1.3",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -31,6 +31,9 @@ export default defineConfig({
       },
     }),
   ],
+  build: {
+    target: "chrome64",
+  },
   server: {
     host: "0.0.0.0",
     port: 5173,


### PR DESCRIPTION
## Résumé

- Ajoute `build.target: "chrome64"` dans `vite.config.ts` pour transpiler les syntaxes ES2020+ (optional chaining `?.`, nullish coalescing `??`) incompatibles avec les navigateurs embarqués des Smart TV
- Ajoute le champ `browserslist` dans `package.json` pour documentation (Tizen 5.0+ / webOS 5.0+)

fixes #29 (sous-issue 1/4)

## Vérification

- [x] `npm run build` réussit
- [x] `npm test` — 263 tests passent
- [x] Bundle vérifié : `?.` et `??` sont transpilés

🤖 Generated with [Claude Code](https://claude.com/claude-code)