### PR TITLE
feat(tv): cibles tactiles, documentation Smart TV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Compatibilité Smart TV** : support des Smart TV Samsung (Tizen 5.0+) et LG (webOS 5.0+). Build ciblant `chrome64` pour transpiler les syntaxes ES2020+. Mise en page responsive grand écran (`font-size` 20px, contenu centré `max-w-4xl`, graphiques agrandis). Navigation D-pad via `:focus-visible` global avec anneau accent. Cibles tactiles minimales 40px sur les boutons critiques.
+
 - **Classement ELO** : système de rating ELO dynamique entre joueurs, calculé après chaque donne en tenant compte du niveau des adversaires (K-factors différenciés : preneur 40, partenaire 25, défenseur 15). Entité `EloHistory`, service `EloCalculator`, intégration dans les processeurs de complétion et suppression de donne (avec revert automatique). Section « Classement ELO » dans les statistiques globales, carte ELO et graphique d'évolution dans les statistiques par joueur. Composants `EloRanking` et `EloEvolutionChart`.
 
 - **Raccourci « Même config »** : bouton dans la modale de nouvelle donne pour pré-remplir le preneur et le contrat de la dernière donne jouée, réduisant la saisie quand un joueur prend plusieurs fois de suite

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -11,6 +11,7 @@ Il doit être mis à jour à chaque ajout ou modification de composant.
 - [Pages](#pages)
 - [Composants UI](#composants-ui)
 - [Utilitaire de test](#utilitaire-de-test)
+- [Compatibilité TV](#compatibilité-tv)
 
 ---
 
@@ -912,6 +913,47 @@ renderWithProviders(<MonComposant />);
 Le `QueryClientProvider` inclus utilise un `QueryClient` de test (retry désactivé, gcTime infini).
 
 `createTestQueryClient()` est aussi exporté pour les tests de hooks isolés.
+
+---
+
+## Compatibilité TV
+
+L'application est compatible avec les Smart TV Samsung (Tizen 5.0+, Chromium 69) et LG (webOS 5.0+, Chromium 68).
+
+### Cible de build
+
+Le build Vite cible `chrome64` (`vite.config.ts → build.target`) pour transpiler les syntaxes ES2020+ (optional chaining `?.`, nullish coalescing `??`) incompatibles avec les navigateurs embarqués des TV.
+
+Le champ `browserslist` dans `package.json` documente les navigateurs supportés : `chrome >= 64, last 2 versions, not dead`.
+
+### Breakpoint TV
+
+Le breakpoint `lg:` (1024px) sert de seuil pour les styles TV. L'application n'ayant pas d'utilisateurs desktop, `lg:` = TV en pratique.
+
+### Scaling par `font-size`
+
+À partir de `lg:`, la `font-size` racine passe à **20px** (au lieu de 16px par défaut). Comme toutes les classes Tailwind utilisent `rem`, cela scale proportionnellement l'ensemble de l'UI. Les valeurs en pixels (hauteurs de graphiques Recharts, props `size` de lucide-react) doivent être ajustées explicitement avec des classes `lg:`.
+
+```css
+/* frontend/src/index.css */
+@media (min-width: 1024px) {
+  html { font-size: 20px; }
+}
+```
+
+### Focus visible (D-pad)
+
+Une règle `:focus-visible` globale dans `index.css` affiche un anneau accent sur tous les éléments interactifs lors de la navigation clavier/D-pad. Un override en dark mode utilise `accent-300`.
+
+Les boutons critiques ont des cibles minimales de 40px (`min-h-10 min-w-10`) pour être facilement accessibles au D-pad.
+
+### Layout TV
+
+- **Contenu centré** : `lg:mx-auto lg:max-w-4xl` sur le `<main>` (Layout.tsx)
+- **Barre de navigation** : centrée et arrondie (`lg:max-w-4xl lg:rounded-t-xl`)
+- **Graphiques** : wrappers avec hauteur responsive (`h-64 lg:h-96`, etc.)
+- **Scoreboard** : centré sans scroll horizontal (`lg:justify-center lg:overflow-visible`)
+- **Pages** : padding augmenté (`lg:p-8`)
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -13,6 +13,7 @@ Application mobile (PWA) de suivi des scores pour le Tarot à 5 joueurs, conform
 - [Consulter les statistiques](#consulter-les-statistiques)
 - [Système d'étoiles](#système-détoiles)
 - [Classement ELO](#classement-elo)
+- [Utilisation sur Smart TV](#utilisation-sur-smart-tv)
 - [Thème sombre](#thème-sombre)
 - [Règles de calcul des scores](#règles-de-calcul-des-scores)
 
@@ -263,6 +264,30 @@ Le système ELO fournit un **classement dynamique** qui tient compte du niveau d
 
 - La **modification** d'une donne recalcule automatiquement les ELO
 - La **suppression** d'une donne annule ses effets sur les ELO (retour à l'état précédent)
+
+---
+
+## Utilisation sur Smart TV
+
+L'application est compatible avec les **Smart TV** Samsung (Tizen 5.0+) et LG (webOS 5.0+).
+
+### Ouvrir l'application
+
+1. Ouvrir le **navigateur intégré** de la TV (Samsung Internet ou LG Web Browser)
+2. Saisir l'URL de l'application
+3. L'interface s'adapte automatiquement à l'écran large : texte agrandi, contenu centré
+
+### Navigation au D-pad (télécommande)
+
+La navigation se fait entièrement avec les **flèches directionnelles** et le bouton **Enter/OK** de la télécommande :
+
+- **Flèches haut/bas/gauche/droite** : déplacer le focus entre les éléments interactifs (boutons, liens, champs)
+- **Enter/OK** : activer l'élément sélectionné (clic)
+- **Retour** : revenir en arrière (selon le navigateur TV)
+
+Un **anneau bleu** entoure l'élément actuellement focalisé pour indiquer la position du curseur.
+
+> **Astuce** : dans les modales, le focus est piégé à l'intérieur — les flèches ne sortent pas de la modale tant qu'elle est ouverte. Utiliser le bouton de fermeture (✕) ou Échap pour la fermer.
 
 ---
 

--- a/frontend/src/components/InProgressBanner.tsx
+++ b/frontend/src/components/InProgressBanner.tsx
@@ -20,7 +20,7 @@ export default function InProgressBanner({ game, onCancel, onComplete }: InProgr
       <div className="flex gap-2">
         {onCancel && (
           <button
-            className="rounded-lg border border-red-500/30 px-3 py-1.5 text-sm font-medium text-red-500"
+            className="rounded-lg border border-red-500/30 px-3 py-1.5 text-sm font-medium text-red-500 lg:px-4 lg:py-2.5"
             onClick={onCancel}
             type="button"
           >
@@ -28,7 +28,7 @@ export default function InProgressBanner({ game, onCancel, onComplete }: InProgr
           </button>
         )}
         <button
-          className="rounded-lg bg-accent-500 px-3 py-1.5 text-sm font-medium text-white"
+          className="rounded-lg bg-accent-500 px-3 py-1.5 text-sm font-medium text-white lg:px-4 lg:py-2.5"
           onClick={onComplete}
           type="button"
         >

--- a/frontend/src/pages/PlayerStats.tsx
+++ b/frontend/src/pages/PlayerStats.tsx
@@ -41,7 +41,7 @@ export default function PlayerStats() {
       <div className="flex items-center gap-3">
         <button
           aria-label="Retour"
-          className="rounded-lg p-1 text-text-secondary"
+          className="rounded-lg p-1 text-text-secondary lg:p-2"
           onClick={() => navigate("/stats")}
           type="button"
         >

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -74,7 +74,7 @@ export default function SessionPage() {
       <div className="flex items-center gap-2">
         <button
           aria-label="Retour"
-          className="rounded-lg p-1 text-text-secondary"
+          className="rounded-lg p-1 text-text-secondary lg:p-2"
           onClick={() => navigate("/")}
           type="button"
         >
@@ -97,7 +97,7 @@ export default function SessionPage() {
         </h1>
         <button
           aria-label="Modifier les joueurs"
-          className="ml-auto rounded-lg p-1 text-text-secondary disabled:opacity-40"
+          className="ml-auto rounded-lg p-1 text-text-secondary disabled:opacity-40 lg:p-2"
           disabled={!!inProgressGame}
           onClick={() => setSwapModalOpen(true)}
           type="button"


### PR DESCRIPTION
## Résumé

- Cibles tactiles plus grandes sur les boutons InProgressBanner (`lg:px-4 lg:py-2.5`)
- Boutons retour et swap en SessionPage/PlayerStats (`lg:p-2`)
- Section « Utilisation sur Smart TV » dans `docs/user-guide.md` (navigation D-pad, ouverture)
- Section « Compatibilité TV » dans `docs/frontend-usage.md` (build target, breakpoint, scaling, focus-visible, layout)
- Entrée CHANGELOG

fixes #29 (sous-issue 4/4)

## Vérification

- [x] `npm test` — 263 tests passent
- [x] `npm run build` réussit
- [x] Docs relues

🤖 Generated with [Claude Code](https://claude.com/claude-code)