### PR TITLE
docs(help): page d'aide in-app et guide de contribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **Page d'aide in-app** : page `/aide` accessible via l'icône ? en haut à droite de chaque écran, reprenant le contenu du guide utilisateur en accordéons dépliables (installation, concepts clés, gestion des joueurs, sessions, saisie, statistiques, étoiles, ELO, Smart TV, thème sombre, règles de calcul), avec lien vers le dépôt GitHub
+- **Guide de contribution** : fichier `CONTRIBUTING.md` à la racine du projet avec prérequis, conventions de code, workflow Git, soumission d'issues et de PRs
+
 ### Fixed
 
 - **DevTools en production** : les React Query DevTools ne sont plus chargées ni affichées en production (lazy import conditionnel sur `import.meta.env.DEV`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Guide de contribution
+
+Merci de votre intérêt pour le projet Tarot ! Ce document explique comment contribuer efficacement.
+
+## Prérequis
+
+- [DDEV](https://ddev.readthedocs.io/) installé et fonctionnel
+- PHP 8.3+
+- Node.js 20+
+- Git
+
+## Installation locale
+
+Suivez les instructions du [README.md](README.md#démarrage-rapide) pour cloner le projet et démarrer l'environnement DDEV.
+
+## Conventions de code
+
+### Général
+
+- **Ordre alphabétique** : assignations constructeur, clés de tableaux associatifs, clés YAML (chaque niveau)
+- **DRY** : extraire à 3+ occurrences (ou 2 si complexe)
+- **Identifiants** : en anglais (variables, fonctions, classes)
+- **Textes** : en français (UI, commentaires, documentation)
+
+### Backend (PHP / Symfony)
+
+- **PHPStan** niveau max — analyse statique stricte
+- **PHP CS Fixer** avec les règles `@Symfony` et `@Symfony:risky`
+- Enums PHP pour tous les ensembles de valeurs fixes
+- Groupes de sérialisation API Platform (pas de DTO custom sauf nécessité)
+
+```bash
+# Vérifier un fichier
+ddev exec bash -c 'cd /var/www/html/backend && vendor/bin/phpstan analyse src/MonFichier.php'
+
+# Corriger le style
+ddev exec bash -c 'cd /var/www/html/backend && vendor/bin/php-cs-fixer fix src/MonFichier.php'
+```
+
+### Frontend (TypeScript / React)
+
+- TypeScript en mode strict
+- Composants fonctionnels uniquement
+- Hooks custom pour les appels API (TanStack Query)
+- Tailwind CSS 4 avec tokens de thème (jamais de couleurs en dur)
+- Icônes via `lucide-react`
+
+## Workflow Git
+
+### Branches
+
+- **Ne jamais pousser sur `main` directement.** Tout passe par une branche + PR.
+- Nommage : `<type>/<numéro-issue>-<description>` (ex. `feat/12-star-system`, `fix/15-score-calc`)
+- Une branche = une issue (correspondance 1:1)
+- Brancher depuis `main`, fusionner vers `main`
+
+### Commits
+
+Format : `<type>(scope): description`
+
+Types : `feat`, `fix`, `chore`, `refactor`, `docs`
+
+Toujours référencer l'issue : ajouter `#N` dans le message ou `fixes #N` pour fermer automatiquement.
+
+### Fusion
+
+Stratégie **squash merge** — un seul commit par issue sur `main`.
+
+## Soumettre une issue
+
+1. **Vérifier les issues existantes** pour éviter les doublons
+2. Utiliser les **labels existants** (`enhancement`, `bug`, etc.)
+3. Décrire clairement le problème ou la fonctionnalité souhaitée
+4. Ajouter des captures d'écran si pertinent
+
+## Soumettre une PR
+
+1. **TDD obligatoire** : écrire les tests d'abord → ils doivent échouer → implémenter → les tests passent
+2. Lancer PHP CS Fixer sur tous les fichiers PHP modifiés avant de committer
+3. Titre de PR au format commit : `<type>(scope): description`
+4. Corps de PR : résumé + `fixes #N`
+5. Vérifier que les tests passent avant de demander une review
+
+## Tests
+
+```bash
+# Backend
+ddev exec bin/phpunit
+
+# Frontend
+ddev exec bash -c 'cd /var/www/html/frontend && npm test'
+
+# Build de production (vérifier l'absence de régression)
+ddev exec bash -c 'cd /var/www/html/frontend && npm run build'
+```

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Les issues et la roadmap sont suivies sur le tableau [Tarot - Roadmap](https://g
 ## Documentation
 
 - [Guide utilisateur](docs/user-guide.md) — comment utiliser l'application
+- [Guide de contribution](CONTRIBUTING.md) — comment contribuer au projet
 - [Guide de déploiement](docs/deployment.md) — héberger sur un VPS OVH
 - [Référence frontend](docs/frontend-usage.md) — composants, hooks et types
 - [Document de conception](docs/plans/2025-02-05-tarot-app-design.md) — architecture et choix de conception

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -405,6 +405,23 @@ const { isPending, sessions } = useSessions();
 
 **Hooks utilisés** : `useCreateSession`, `useNavigate`
 
+### Aide (`Help`)
+
+**Fichier** : `pages/Help.tsx`
+
+Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.md`).
+
+**Route** : `/aide`
+
+**Fonctionnalités** :
+- Section « Installation » toujours visible
+- 11 sections en accordéon dépliable (`AccordionSection`, composant local)
+- Lien vers le dépôt GitHub en bas de page
+- Bouton retour vers l'accueil
+- Accessible via l'icône `CircleHelp` dans le header du `Layout`
+
+**Hooks utilisés** : aucun (contenu statique)
+
 ### Joueurs (`Players`)
 
 **Fichier** : `pages/Players.tsx`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,6 +2,8 @@
 
 Application mobile (PWA) de suivi des scores pour le Tarot à 5 joueurs, conforme aux règles officielles de la FFT.
 
+> **Astuce** : ce guide est aussi accessible directement dans l'application via l'icône **?** en haut à droite de chaque écran (page `/aide`).
+
 ## Table des matières
 
 - [Installation](#installation)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { lazy, Suspense } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Layout from "./components/Layout";
 import { ThemeProvider } from "./hooks/useTheme";
+import Help from "./pages/Help";
 import Home from "./pages/Home";
 import Players from "./pages/Players";
 import PlayerStats from "./pages/PlayerStats";
@@ -27,6 +28,7 @@ export default function App() {
           <Routes>
             <Route element={<Layout />}>
               <Route path="/" element={<Home />} />
+              <Route path="/aide" element={<Help />} />
               <Route path="/players" element={<Players />} />
               <Route path="/sessions/:id" element={<SessionPage />} />
               <Route path="/stats" element={<Stats />} />

--- a/frontend/src/__tests__/components/Layout.test.tsx
+++ b/frontend/src/__tests__/components/Layout.test.tsx
@@ -15,4 +15,11 @@ describe("Layout", () => {
     const wrapper = container.firstElementChild;
     expect(wrapper?.className).toMatch(/bg-surface-secondary/);
   });
+
+  it("renders a help icon link pointing to /aide", () => {
+    renderWithProviders(<Layout />);
+
+    const helpLink = screen.getByRole("link", { name: /aide/i });
+    expect(helpLink).toHaveAttribute("href", "/aide");
+  });
 });

--- a/frontend/src/__tests__/pages/Help.test.tsx
+++ b/frontend/src/__tests__/pages/Help.test.tsx
@@ -1,0 +1,101 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Help from "../../pages/Help";
+import { renderWithProviders } from "../test-utils";
+
+describe("Help", () => {
+  it("renders the page title", () => {
+    renderWithProviders(<Help />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: /aide/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("always shows the Installation section", () => {
+    renderWithProviders(<Help />);
+
+    expect(screen.getByText(/Progressive Web App/)).toBeInTheDocument();
+  });
+
+  it("renders all accordion section headings", () => {
+    renderWithProviders(<Help />);
+
+    const sectionNames = [
+      "Concepts clés",
+      "Gestion des joueurs",
+      "Démarrer une session",
+      "Écran de session",
+      "Saisir une donne",
+      "Consulter les statistiques",
+      "Système d'étoiles",
+      "Classement ELO",
+      "Utilisation sur Smart TV",
+      "Thème sombre",
+      "Règles de calcul des scores",
+    ];
+
+    for (const name of sectionNames) {
+      expect(
+        screen.getByRole("button", { name: new RegExp(name) }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("accordion sections are collapsed by default", () => {
+    renderWithProviders(<Help />);
+
+    const conceptsButton = screen.getByRole("button", {
+      name: /Concepts clés/,
+    });
+    expect(conceptsButton).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("expands an accordion section on click", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Help />);
+
+    const conceptsButton = screen.getByRole("button", {
+      name: /Concepts clés/,
+    });
+    await user.click(conceptsButton);
+
+    expect(conceptsButton).toHaveAttribute("aria-expanded", "true");
+    const panel = document.getElementById(
+      conceptsButton.getAttribute("aria-controls")!,
+    );
+    expect(panel).not.toHaveAttribute("hidden");
+  });
+
+  it("collapses an expanded section on second click", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Help />);
+
+    const conceptsButton = screen.getByRole("button", {
+      name: /Concepts clés/,
+    });
+    await user.click(conceptsButton);
+    expect(conceptsButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(conceptsButton);
+    expect(conceptsButton).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("renders a link to the GitHub repository", () => {
+    renderWithProviders(<Help />);
+
+    const link = screen.getByRole("link", { name: /github/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/Soviann/tarot",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders a back link to home", () => {
+    renderWithProviders(<Help />);
+
+    const backLink = screen.getByRole("link", { name: /retour/i });
+    expect(backLink).toHaveAttribute("href", "/");
+  });
+});

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,9 +1,19 @@
-import { Outlet } from "react-router-dom";
+import { CircleHelp } from "lucide-react";
+import { Link, Outlet } from "react-router-dom";
 import BottomNav from "./BottomNav";
 
 export default function Layout() {
   return (
     <div className="min-h-screen bg-surface-secondary pb-16 text-text-primary lg:pb-20">
+      <header className="flex justify-end p-2 lg:mx-auto lg:max-w-4xl">
+        <Link
+          aria-label="Aide"
+          className="rounded-lg p-1.5 text-text-secondary hover:bg-surface-tertiary"
+          to="/aide"
+        >
+          <CircleHelp className="size-5 lg:size-6" />
+        </Link>
+      </header>
       <main className="animate-fade-in lg:mx-auto lg:max-w-4xl">
         <Outlet />
       </main>

--- a/frontend/src/pages/Help.tsx
+++ b/frontend/src/pages/Help.tsx
@@ -1,0 +1,439 @@
+import { ArrowLeft, ChevronDown, ExternalLink } from "lucide-react";
+import { type ReactNode, useId, useState } from "react";
+import { Link } from "react-router-dom";
+
+function AccordionSection({
+  children,
+  title,
+}: {
+  children: ReactNode;
+  title: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const id = useId();
+
+  return (
+    <div className="rounded-xl bg-surface-primary">
+      <button
+        aria-controls={`${id}-panel`}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between px-4 py-3 text-left font-medium text-text-primary"
+        id={`${id}-header`}
+        onClick={() => setOpen(!open)}
+        type="button"
+      >
+        <span>{title}</span>
+        <ChevronDown
+          className={`size-4 shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+      <div
+        aria-labelledby={`${id}-header`}
+        className="px-4 pb-4 text-sm leading-relaxed text-text-secondary"
+        hidden={!open}
+        id={`${id}-panel`}
+        role="region"
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default function Help() {
+  return (
+    <div className="flex flex-col gap-4 p-4 lg:p-8">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Link
+          aria-label="Retour à l'accueil"
+          className="rounded-lg p-1.5 text-text-secondary hover:bg-surface-tertiary"
+          to="/"
+        >
+          <ArrowLeft className="size-5 lg:size-6" />
+        </Link>
+        <h1 className="text-xl font-bold text-text-primary">Aide</h1>
+      </div>
+
+      {/* Installation — toujours visible */}
+      <section className="rounded-xl bg-surface-primary p-4">
+        <h2 className="mb-2 font-semibold text-text-primary">Installation</h2>
+        <p className="text-sm leading-relaxed text-text-secondary">
+          L'application est une <strong>Progressive Web App</strong> (PWA).
+          Elle s'utilise dans un navigateur mobile et peut être ajoutée à
+          l'écran d'accueil :
+        </p>
+        <ol className="mt-2 list-inside list-decimal text-sm leading-relaxed text-text-secondary">
+          <li>
+            Ouvrir l'application dans <strong>Chrome</strong> (Android) ou{" "}
+            <strong>Safari</strong> (iOS)
+          </li>
+          <li>Appuyer sur le menu du navigateur</li>
+          <li>
+            Sélectionner <strong>« Ajouter à l'écran d'accueil »</strong>
+          </li>
+          <li>L'icône apparaît comme une application native</li>
+        </ol>
+      </section>
+
+      {/* Sections en accordéon */}
+      <AccordionSection title="Concepts clés">
+        <table className="w-full text-left">
+          <tbody>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5 pr-3 font-medium text-text-primary">
+                Joueur
+              </td>
+              <td className="py-1.5">Personne inscrite dans l'application</td>
+            </tr>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5 pr-3 font-medium text-text-primary">
+                Session
+              </td>
+              <td className="py-1.5">
+                Partie regroupant exactement 5 joueurs
+              </td>
+            </tr>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5 pr-3 font-medium text-text-primary">
+                Donne
+              </td>
+              <td className="py-1.5">
+                Un tour de jeu (une « main ») produisant des scores
+              </td>
+            </tr>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5 pr-3 font-medium text-text-primary">
+                Preneur
+              </td>
+              <td className="py-1.5">Le joueur qui a annoncé un contrat</td>
+            </tr>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5 pr-3 font-medium text-text-primary">
+                Partenaire
+              </td>
+              <td className="py-1.5">
+                Le joueur dont le roi a été appelé par le preneur
+              </td>
+            </tr>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5 pr-3 font-medium text-text-primary">
+                Contrat
+              </td>
+              <td className="py-1.5">
+                Petite, Garde, Garde Sans ou Garde Contre
+              </td>
+            </tr>
+            <tr>
+              <td className="py-1.5 pr-3 font-medium text-text-primary">
+                Donneur
+              </td>
+              <td className="py-1.5">
+                Distribue les cartes, tourne automatiquement
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </AccordionSection>
+
+      <AccordionSection title="Gestion des joueurs">
+        <p>
+          Accessible via l'onglet <strong>Joueurs</strong> dans la barre de
+          navigation.
+        </p>
+        <h3 className="mt-3 font-medium text-text-primary">
+          Ajouter un joueur
+        </h3>
+        <ol className="mt-1 list-inside list-decimal">
+          <li>Appuyer sur le bouton + (en bas à droite)</li>
+          <li>Saisir le nom du joueur</li>
+          <li>Valider</li>
+        </ol>
+        <p className="mt-2">
+          Chaque joueur possède un avatar coloré généré automatiquement à
+          partir de ses initiales.
+        </p>
+        <h3 className="mt-3 font-medium text-text-primary">Rechercher</h3>
+        <p className="mt-1">
+          Utiliser la barre de recherche en haut de la liste pour filtrer par
+          nom.
+        </p>
+      </AccordionSection>
+
+      <AccordionSection title="Démarrer une session">
+        <ol className="list-inside list-decimal">
+          <li>
+            Sélectionner <strong>5 joueurs</strong> parmi la liste
+          </li>
+          <li>
+            Appuyer sur <strong>« Démarrer »</strong>
+          </li>
+        </ol>
+        <p className="mt-2">
+          Si une session active existe déjà avec les mêmes 5 joueurs,
+          l'application la reprend automatiquement.
+        </p>
+        <p className="mt-2">
+          Le <strong>donneur</strong> est attribué automatiquement (premier
+          joueur par ordre alphabétique) et tourne après chaque donne.
+        </p>
+      </AccordionSection>
+
+      <AccordionSection title="Écran de session">
+        <h3 className="font-medium text-text-primary">Tableau des scores</h3>
+        <p className="mt-1">
+          Bandeau horizontal avec les 5 joueurs, leur score cumulé (vert =
+          positif, rouge = négatif) et une icône de cartes sur le donneur.
+        </p>
+
+        <h3 className="mt-3 font-medium text-text-primary">Donne en cours</h3>
+        <p className="mt-1">
+          Si une donne est en cours, un bandeau indique le preneur et le
+          contrat avec un bouton « Compléter ».
+        </p>
+
+        <h3 className="mt-3 font-medium text-text-primary">Historique</h3>
+        <p className="mt-1">
+          Liste des donnes jouées montrant le preneur, le partenaire, le
+          contrat et le résultat.
+        </p>
+
+        <h3 className="mt-3 font-medium text-text-primary">
+          Modifier les joueurs
+        </h3>
+        <p className="mt-1">
+          Bouton ⇄ pour changer un ou plusieurs joueurs sans repasser par
+          l'accueil. Désactivé tant qu'une donne est en cours.
+        </p>
+      </AccordionSection>
+
+      <AccordionSection title="Saisir une donne">
+        <h3 className="font-medium text-text-primary">
+          Étape 1 — Début de la donne
+        </h3>
+        <ol className="mt-1 list-inside list-decimal">
+          <li>Sélectionner le preneur</li>
+          <li>Choisir le contrat (Petite ×1, Garde ×2, Garde Sans ×4, Garde Contre ×6)</li>
+          <li>Valider</li>
+        </ol>
+        <p className="mt-2">
+          Le raccourci <strong>« Même config »</strong> pré-remplit le preneur
+          et le contrat de la dernière donne.
+        </p>
+
+        <h3 className="mt-3 font-medium text-text-primary">
+          Étape 2 — Fin de la donne
+        </h3>
+        <ol className="mt-1 list-inside list-decimal">
+          <li>Sélectionner le partenaire (ou « Seul »)</li>
+          <li>Nombre d'oudlers (0 à 3)</li>
+          <li>Points réalisés (0 à 91)</li>
+          <li>Bonus optionnels (poignée, petit au bout, chelem)</li>
+          <li>Vérifier l'aperçu des scores et valider</li>
+        </ol>
+
+        <h3 className="mt-3 font-medium text-text-primary">
+          Modifier / Supprimer
+        </h3>
+        <p className="mt-1">
+          Seule la dernière donne est modifiable ou supprimable. Les scores
+          sont automatiquement recalculés.
+        </p>
+      </AccordionSection>
+
+      <AccordionSection title="Consulter les statistiques">
+        <h3 className="font-medium text-text-primary">Classement global</h3>
+        <p className="mt-1">
+          Métriques (total donnes/sessions), classement par score total et
+          répartition des contrats.
+        </p>
+
+        <h3 className="mt-3 font-medium text-text-primary">
+          Statistiques par joueur
+        </h3>
+        <p className="mt-1">
+          Appuyer sur un joueur pour voir : taux de victoire, score moyen,
+          meilleur/pire score, répartition des rôles, contrats pris et
+          évolution des scores.
+        </p>
+
+        <h3 className="mt-3 font-medium text-text-primary">
+          Graphique de session
+        </h3>
+        <p className="mt-1">
+          Un graphique d'évolution apparaît automatiquement dans l'écran de
+          session dès 2 donnes terminées.
+        </p>
+      </AccordionSection>
+
+      <AccordionSection title="Système d'étoiles">
+        <p>
+          Les étoiles permettent de pénaliser un joueur (retard, mauvaise
+          conduite, etc.).
+        </p>
+        <ul className="mt-2 list-inside list-disc">
+          <li>Appuyer sur la zone d'étoiles sous le score d'un joueur</li>
+          <li>
+            À <strong>3 étoiles</strong> : pénalité automatique (−100 pts pour
+            le joueur, +25 pts pour les 4 autres)
+          </li>
+          <li>Le compteur revient à 0 après chaque pénalité</li>
+        </ul>
+        <p className="mt-2">
+          Les pénalités sont incluses dans les scores cumulés et les
+          statistiques.
+        </p>
+      </AccordionSection>
+
+      <AccordionSection title="Classement ELO">
+        <p>
+          Le système ELO fournit un classement dynamique tenant compte du
+          niveau des adversaires.
+        </p>
+        <ul className="mt-2 list-inside list-disc">
+          <li>Chaque joueur démarre à 1500 ELO</li>
+          <li>
+            Battre des joueurs mieux classés rapporte plus de points
+          </li>
+          <li>
+            Le preneur voit son ELO évoluer plus fortement que le partenaire
+            ou les défenseurs
+          </li>
+        </ul>
+        <p className="mt-2">
+          Visible dans les statistiques globales et sur la fiche de chaque
+          joueur.
+        </p>
+      </AccordionSection>
+
+      <AccordionSection title="Utilisation sur Smart TV">
+        <p>
+          Compatible avec les Smart TV Samsung (Tizen 5.0+) et LG (webOS
+          5.0+).
+        </p>
+        <ul className="mt-2 list-inside list-disc">
+          <li>Ouvrir le navigateur intégré de la TV</li>
+          <li>L'interface s'adapte automatiquement à l'écran large</li>
+          <li>
+            Navigation à la télécommande : flèches + Enter/OK
+          </li>
+          <li>Un anneau bleu indique l'élément focalisé</li>
+        </ul>
+      </AccordionSection>
+
+      <AccordionSection title="Thème sombre">
+        <p>
+          L'application supporte un mode sombre. Utiliser le bouton de bascule
+          dans l'interface pour changer de thème.
+        </p>
+        <p className="mt-2">
+          Le choix est mémorisé automatiquement et persiste entre les visites.
+        </p>
+      </AccordionSection>
+
+      <AccordionSection title="Règles de calcul des scores">
+        <h3 className="font-medium text-text-primary">
+          Points nécessaires pour gagner
+        </h3>
+        <table className="mt-1 w-full text-left">
+          <thead>
+            <tr className="border-b border-surface-border">
+              <th className="py-1.5 font-medium text-text-primary">
+                Oudlers
+              </th>
+              <th className="py-1.5 font-medium text-text-primary">
+                Points requis
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5">0</td>
+              <td className="py-1.5">56</td>
+            </tr>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5">1</td>
+              <td className="py-1.5">51</td>
+            </tr>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5">2</td>
+              <td className="py-1.5">41</td>
+            </tr>
+            <tr>
+              <td className="py-1.5">3</td>
+              <td className="py-1.5">36</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3 className="mt-3 font-medium text-text-primary">Score de base</h3>
+        <p className="mt-1">
+          (|points réalisés − points requis| + 25) × multiplicateur du contrat
+        </p>
+        <p className="mt-1">
+          Petite ×1, Garde ×2, Garde Sans ×4, Garde Contre ×6
+        </p>
+
+        <h3 className="mt-3 font-medium text-text-primary">Bonus</h3>
+        <table className="mt-1 w-full text-left">
+          <tbody>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5">Poignée simple</td>
+              <td className="py-1.5">+20</td>
+            </tr>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5">Poignée double</td>
+              <td className="py-1.5">+30</td>
+            </tr>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5">Poignée triple</td>
+              <td className="py-1.5">+40</td>
+            </tr>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5">Petit au bout</td>
+              <td className="py-1.5">10 × multiplicateur</td>
+            </tr>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5">Chelem annoncé gagné</td>
+              <td className="py-1.5">+400</td>
+            </tr>
+            <tr className="border-b border-surface-border">
+              <td className="py-1.5">Chelem annoncé perdu</td>
+              <td className="py-1.5">−200</td>
+            </tr>
+            <tr>
+              <td className="py-1.5">Chelem non annoncé gagné</td>
+              <td className="py-1.5">+200</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3 className="mt-3 font-medium text-text-primary">
+          Répartition (5 joueurs)
+        </h3>
+        <p className="mt-1">
+          Preneur : base × 2 | Partenaire : base × 1 | Chaque défenseur :
+          base × −1
+        </p>
+        <p className="mt-1">
+          Si le preneur appelle son propre roi : Preneur × 4, chaque
+          défenseur × −1.
+        </p>
+        <p className="mt-2 text-xs text-text-muted">
+          La somme des scores est toujours égale à 0.
+        </p>
+      </AccordionSection>
+
+      {/* Lien GitHub */}
+      <a
+        className="flex items-center justify-center gap-2 rounded-xl bg-surface-primary px-4 py-3 text-sm font-medium text-accent-500 hover:bg-surface-tertiary"
+        href="https://github.com/Soviann/tarot"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <ExternalLink className="size-4" />
+        Voir le projet sur GitHub
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé

- **Page d'aide in-app** (`/aide`) : accessible via l'icône ? (`CircleHelp`) dans le header du Layout, reprenant le contenu du guide utilisateur en sections accordéon dépliables
- **`CONTRIBUTING.md`** : guide de contribution à la racine du projet (prérequis, conventions, workflow Git, tests)
- **Docs** : mise à jour de `frontend-usage.md`, `user-guide.md`, `CHANGELOG.md`, `README.md`

## Détails

### Page d'aide
- Section « Installation » toujours visible (critique pour les nouveaux utilisateurs)
- 11 sections en accordéon : Concepts clés, Gestion des joueurs, Sessions, Saisie, Statistiques, Étoiles, ELO, Smart TV, Thème sombre, Règles de calcul
- Composant `AccordionSection` local à `Help.tsx` (pattern `ChevronDown` + `rotate-180`)
- Lien GitHub en bas de page (`ExternalLink` icon)
- Bouton retour vers l'accueil

### Layout
- Header avec icône `CircleHelp` alignée à droite, lien vers `/aide`

### Tests
- 8 tests pour la page Help (titre, sections, expand/collapse, liens)
- 1 test ajouté au Layout (lien aide)
- Total : 272 tests passent

fixes #40