### PR TITLE
fix(home): centrer le texte et les avatars, corriger le débordement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Fixed
 
+- **Accueil — centrage et débordement** : le titre, les avatars sélectionnés et le compteur de joueurs sont maintenant centrés horizontalement ; les chips passent à la ligne (`flex-wrap`) au lieu de déborder de l'écran
 - **DevTools en production** : les React Query DevTools ne sont plus chargées ni affichées en production (lazy import conditionnel sur `import.meta.env.DEV`)
 
 ### Added

--- a/frontend/src/components/PlayerSelector.tsx
+++ b/frontend/src/components/PlayerSelector.tsx
@@ -87,7 +87,7 @@ export default function PlayerSelector({
   return (
     <div className="flex flex-col gap-3">
       {/* Chips des joueurs sélectionnés */}
-      <div className="flex items-center gap-2" data-testid="selected-chips">
+      <div className="flex flex-wrap items-center justify-center gap-2" data-testid="selected-chips">
         {selectedPlayers.map((player) => (
           <button
             className="flex items-center gap-1 rounded-full bg-accent-100 py-1 pl-1 pr-2 text-sm font-medium text-accent-700 transition-colors hover:bg-accent-200"
@@ -109,7 +109,7 @@ export default function PlayerSelector({
         )}
       </div>
 
-      <p className="text-sm text-text-muted">
+      <p className="text-center text-sm text-text-muted">
         {selectedPlayerIds.length}/{MAX_PLAYERS} joueurs sélectionnés
       </p>
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -25,9 +25,9 @@ export default function Home() {
   }, [canStart, createSession, navigate, selectedPlayerIds]);
 
   return (
-    <div className="flex flex-col gap-6 p-4 lg:p-8">
+    <div className="flex flex-col gap-6 overflow-x-hidden p-4 lg:p-8">
       <section>
-        <h1 className="mb-4 text-2xl font-bold text-text-primary">
+        <h1 className="mb-4 text-center text-2xl font-bold text-text-primary">
           Nouvelle session
         </h1>
 


### PR DESCRIPTION
## Résumé

- Centrage horizontal du titre « Nouvelle session », des chips de joueurs sélectionnés et du compteur « x/5 joueurs sélectionnés »
- Ajout de `flex-wrap` sur le conteneur de chips pour éviter le débordement horizontal
- Ajout de `overflow-x-hidden` sur le conteneur de page en filet de sécurité

## Fichiers modifiés

- `frontend/src/pages/Home.tsx` — `text-center` sur le h1, `overflow-x-hidden` sur le conteneur
- `frontend/src/components/PlayerSelector.tsx` — `flex-wrap justify-center` sur les chips, `text-center` sur le compteur

fixes #42