### PR TITLE
feat(star): confirmation modal before star attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Confirmation étoile** : modale de confirmation avant attribution d'une étoile à un joueur, évitant les appuis accidentels. Composant `AddStarModal` avec boutons Annuler/Confirmer.
+
 - **Forcer le donneur** : possibilité de changer manuellement le donneur d'une session en appuyant sur l'icône de cartes du donneur actuel dans le tableau des scores. Modale de sélection parmi les 5 joueurs, opération PATCH `/sessions/{id}` avec validation (le donneur doit appartenir à la session). Hook `useUpdateDealer`, composant `ChangeDealerModal`.
 
 - **Page d'aide in-app** : page `/aide` accessible via l'icône ? en haut à droite de chaque écran, reprenant le contenu du guide utilisateur en accordéons dépliables (installation, concepts clés, gestion des joueurs, sessions, saisie, statistiques, étoiles, ELO, Smart TV, thème sombre, règles de calcul), avec lien vers le dépôt GitHub

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -523,6 +523,7 @@ Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.m
 - `SwapPlayersModal` : changement de joueurs avec navigation vers la session résultante
 - `NewGameModal` : sélection preneur + contrat (étape 1)
 - `CompleteGameModal` : complétion ou modification d'une donne (étape 2)
+- `AddStarModal` : confirmation avant attribution d'étoile à un joueur
 - `DeleteGameModal` : confirmation de suppression de la dernière donne
 
 ---
@@ -630,6 +631,28 @@ Modal de sélection manuelle du donneur parmi les joueurs de la session.
 - Donneur actuel pré-sélectionné
 - Bouton Valider désactivé si le même donneur est sélectionné ou si `isPending`
 - Affichage du nom du joueur sélectionné
+
+### `AddStarModal`
+
+**Fichier** : `components/AddStarModal.tsx`
+
+Modal de confirmation avant d'attribuer une étoile à un joueur. Composant présentationnel (pas de hook interne).
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `errorMessage` | `string?` | Message d'erreur à afficher |
+| `isError` | `boolean` | *requis* — afficher l'erreur |
+| `isPending` | `boolean` | *requis* — désactiver le bouton Confirmer pendant la mutation |
+| `onClose` | `() => void` | *requis* — fermeture |
+| `onConfirm` | `() => void` | *requis* — confirmation de l'attribution |
+| `open` | `boolean` | *requis* — afficher ou masquer |
+| `playerName` | `string` | *requis* — nom du joueur concerné |
+
+**Fonctionnalités** :
+- Message de confirmation avec le nom du joueur
+- Bouton « Annuler » (ferme la modal) et « Confirmer » (couleur accent, non destructif)
+- Bouton « Confirmer » désactivé pendant la mutation
+- Affichage d'erreur si la mutation échoue
 
 ### `DeleteGameModal`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -245,7 +245,8 @@ Le système d'étoiles permet de **pénaliser** un joueur en dehors du jeu de ca
 
 1. Sur l'**écran de session**, repérer le joueur dans le tableau des scores
 2. Appuyer sur la zone d'étoiles (☆☆☆) sous le score du joueur
-3. Une étoile est ajoutée immédiatement
+3. Une modale de **confirmation** s'affiche : « Attribuer une étoile à [nom] ? »
+4. Appuyer sur **Confirmer** pour valider, ou **Annuler** pour revenir sans rien faire
 
 ### Impact sur les scores
 

--- a/frontend/src/__tests__/components/AddStarModal.test.tsx
+++ b/frontend/src/__tests__/components/AddStarModal.test.tsx
@@ -1,0 +1,68 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AddStarModal from "../../components/AddStarModal";
+import { renderWithProviders } from "../test-utils";
+
+describe("AddStarModal", () => {
+  const defaultProps = {
+    isError: false,
+    isPending: false,
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+    open: true,
+    playerName: "Alice",
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders confirmation text with player name", () => {
+    renderWithProviders(<AddStarModal {...defaultProps} />);
+
+    expect(screen.getByText("Confirmer l'étoile")).toBeInTheDocument();
+    expect(screen.getByText(/Attribuer une étoile à Alice/)).toBeInTheDocument();
+  });
+
+  it("calls onClose when Annuler is clicked", async () => {
+    renderWithProviders(<AddStarModal {...defaultProps} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Annuler" }));
+
+    expect(defaultProps.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onConfirm when Confirmer is clicked", async () => {
+    renderWithProviders(<AddStarModal {...defaultProps} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Confirmer" }));
+
+    expect(defaultProps.onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("disables Confirmer button when isPending", () => {
+    renderWithProviders(<AddStarModal {...defaultProps} isPending={true} />);
+
+    expect(screen.getByRole("button", { name: "Confirmer" })).toBeDisabled();
+  });
+
+  it("displays error message when isError", () => {
+    renderWithProviders(
+      <AddStarModal {...defaultProps} errorMessage="Erreur serveur" isError={true} />,
+    );
+
+    expect(screen.getByText("Erreur serveur")).toBeInTheDocument();
+  });
+
+  it("displays default error message when isError without errorMessage", () => {
+    renderWithProviders(<AddStarModal {...defaultProps} isError={true} />);
+
+    expect(screen.getByText("Erreur inconnue")).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    renderWithProviders(<AddStarModal {...defaultProps} open={false} />);
+
+    expect(screen.queryByText("Confirmer l'étoile")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/AddStarModal.tsx
+++ b/frontend/src/components/AddStarModal.tsx
@@ -1,0 +1,55 @@
+import { Modal } from "./ui";
+
+interface AddStarModalProps {
+  errorMessage?: string;
+  isError: boolean;
+  isPending: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  open: boolean;
+  playerName: string;
+}
+
+export default function AddStarModal({
+  errorMessage,
+  isError,
+  isPending,
+  onClose,
+  onConfirm,
+  open,
+  playerName,
+}: AddStarModalProps) {
+  return (
+    <Modal onClose={onClose} open={open} title="Confirmer l'étoile">
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-text-secondary">
+          Attribuer une étoile à {playerName} ?
+        </p>
+
+        {isError && (
+          <p className="text-center text-sm text-score-negative">
+            {errorMessage ?? "Erreur inconnue"}
+          </p>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            className="flex-1 rounded-xl bg-surface-secondary py-3 text-sm font-semibold text-text-secondary transition-colors"
+            onClick={onClose}
+            type="button"
+          >
+            Annuler
+          </button>
+          <button
+            className="flex-1 rounded-xl bg-accent-500 py-3 text-sm font-semibold text-white transition-colors disabled:opacity-40"
+            disabled={isPending}
+            onClick={onConfirm}
+            type="button"
+          >
+            Confirmer
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeftRight } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import AddStarModal from "../components/AddStarModal";
 import ChangeDealerModal from "../components/ChangeDealerModal";
 import CompleteGameModal from "../components/CompleteGameModal";
 import DeleteGameModal from "../components/DeleteGameModal";
@@ -57,6 +58,8 @@ export default function SessionPage() {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [newGameModalOpen, setNewGameModalOpen] = useState(false);
+  const [starModalOpen, setStarModalOpen] = useState(false);
+  const [starPlayerId, setStarPlayerId] = useState<number | null>(null);
   const [swapModalOpen, setSwapModalOpen] = useState(false);
 
   if (isPending) {
@@ -114,7 +117,11 @@ export default function SessionPage() {
         addStarPending={addStar.isPending}
         cumulativeScores={session.cumulativeScores}
         currentDealerId={session.currentDealer?.id ?? null}
-        onAddStar={(playerId) => addStar.mutate(playerId)}
+        onAddStar={(playerId) => {
+          setStarPlayerId(playerId);
+          addStar.reset();
+          setStarModalOpen(true);
+        }}
         onDealerChange={() => setChangeDealerModalOpen(true)}
         players={session.players}
         starEvents={session.starEvents}
@@ -221,6 +228,22 @@ export default function SessionPage() {
           }
         }}
         open={swapModalOpen}
+      />
+
+      <AddStarModal
+        errorMessage={addStar.error?.message}
+        isError={addStar.isError}
+        isPending={addStar.isPending}
+        onClose={() => setStarModalOpen(false)}
+        onConfirm={() => {
+          if (starPlayerId !== null) {
+            addStar.mutate(starPlayerId, {
+              onSuccess: () => setStarModalOpen(false),
+            });
+          }
+        }}
+        open={starModalOpen}
+        playerName={session.players.find((p) => p.id === starPlayerId)?.name ?? ""}
       />
 
       {session.currentDealer && (


### PR DESCRIPTION
## Résumé

- Ajout d'une modale de confirmation (`AddStarModal`) avant l'attribution d'une étoile à un joueur, évitant les appuis accidentels
- Mise à jour de `SessionPage` pour ouvrir la modale au lieu d'appeler directement la mutation
- 7 tests unitaires pour le nouveau composant

fixes #61

## Test plan

- [ ] Taper sur la zone étoile d'un joueur → la modale s'ouvre avec le bon nom
- [ ] Annuler → la modale se ferme, aucune étoile ajoutée
- [ ] Confirmer → l'étoile est ajoutée, la modale se ferme
- [ ] Vérifier que le bouton Confirmer est désactivé pendant la requête
- [ ] `npm test` — 290 tests passent
- [ ] `npm run build` — build sans erreur