### PR TITLE
feat(home): refonte mobile avec sessions récentes et saisie simplifiée

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Changed
 
+- **Accueil — refonte mobile** : les sessions récentes sont affichées en haut de l'écran pour un accès rapide, la sélection des joueurs est en bas (zone du pouce). Le bouton « Démarrer » est remplacé par un bouton intégré qui apparaît avec animation à la place de la barre de recherche une fois les 5 joueurs sélectionnés. Chaque session affiche les avatars des joueurs et la date relative de la dernière donne (« Aujourd'hui », « Hier », « Il y a X jours »). La liste est limitée à 5 sessions avec un bouton « Voir tout ». L'état vide affiche un message aléatoire engageant. Un message motivant aléatoire est affiché en sous-titre de la section « Nouvelle session ».
+
 - **Accueil — sélection des joueurs** : la liste complète des joueurs n'est plus affichée par défaut. Les joueurs apparaissent uniquement lors d'une recherche via la barre de recherche, simplifiant l'interface.
 
 ### Fixed

--- a/backend/src/Entity/Player.php
+++ b/backend/src/Entity/Player.php
@@ -28,7 +28,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[UniqueEntity('name')]
 class Player
 {
-    #[Groups(['player:read', 'session:detail'])]
+    #[Groups(['player:read', 'session:detail', 'session:read'])]
     #[ORM\Id]
     #[ORM\Column]
     #[ORM\GeneratedValue]

--- a/backend/src/Entity/Session.php
+++ b/backend/src/Entity/Session.php
@@ -127,6 +127,19 @@ class Session
         return $this->createdAt;
     }
 
+    #[Groups(['session:read'])]
+    public function getLastPlayedAt(): \DateTimeImmutable
+    {
+        $latest = $this->createdAt;
+        foreach ($this->games as $game) {
+            if ($game->getCreatedAt() > $latest) {
+                $latest = $game->getCreatedAt();
+            }
+        }
+
+        return $latest;
+    }
+
     public function getCurrentDealer(): ?Player
     {
         return $this->currentDealer;

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -67,10 +67,10 @@ import type { HydraCollection, Player } from "./types/api";
 | `HydraCollection<T>` | `member: T[]`, `totalItems: number` |
 | `Player` | `active: boolean`, `id: number`, `name: string`, `createdAt: string` |
 | `ScoreEntry` | `id: number`, `player: GamePlayer`, `score: number` |
-| `Session` | `id: number`, `createdAt: string`, `isActive: boolean`, `players: SessionPlayer[]` |
+| `Session` | `id: number`, `createdAt: string`, `isActive: boolean`, `lastPlayedAt: string`, `players: SessionPlayer[]` |
 | `SessionDetail` | `id`, `createdAt`, `currentDealer`, `isActive`, `players: GamePlayer[]`, `games: Game[]`, `cumulativeScores: CumulativeScore[]`, `starEvents: StarEvent[]` |
 | `StarEvent` | `id: number`, `createdAt: string`, `player: GamePlayer` |
-| `SessionPlayer` | `name: string` |
+| `SessionPlayer` | `id: number`, `name: string` |
 | `ContractDistributionEntry` | `contract: Contract`, `count: number`, `percentage: number` |
 | `EloHistoryEntry` | `date: string`, `gameId: number`, `ratingAfter: number`, `ratingChange: number` |
 | `EloRankingEntry` | `eloRating: number`, `gamesPlayed: number`, `playerId: number`, `playerName: string` |
@@ -439,14 +439,14 @@ const { isPending, sessions } = useSessions();
 
 **Fichier** : `pages/Home.tsx`
 
-Écran principal : sélection de joueurs, création de session, sessions récentes.
+Écran principal : sessions récentes en haut, sélection de joueurs en bas (zone du pouce).
 
 **Fonctionnalités** :
+- Sessions récentes (`SessionList`) affichées en premier pour un accès rapide
 - Sélection de 5 joueurs via `PlayerSelector` (composant contrôlé)
-- Bouton « Démarrer » (disabled si < 5 joueurs ou mutation en cours)
+- Bouton « Démarrer la session » intégré dans `PlayerSelector` (apparaît quand 5 joueurs sélectionnés, remplace la barre de recherche)
 - Redirection vers `/sessions/:id` après création
 - Message d'erreur si la création échoue
-- Liste des sessions récentes via `SessionList`
 
 **Hooks utilisés** : `useCreateSession`, `useNavigate`
 
@@ -566,12 +566,15 @@ Composant de sélection de joueurs avec limite à 5. Inclut chips, recherche et 
 |------|------|-------------|
 | `selectedPlayerIds` | `number[]` | *requis* — IDs des joueurs sélectionnés |
 | `onSelectionChange` | `(ids: number[]) => void` | *requis* — callback de changement |
+| `onStart` | `() => void` | *optionnel* — callback de démarrage (affiche le bouton « Démarrer la session » quand 5 joueurs sélectionnés) |
+| `isPending` | `boolean` | *optionnel* — désactive le bouton de démarrage pendant la mutation |
 
 **Fonctionnalités** :
 - Chips en haut avec avatar + nom des joueurs sélectionnés (clic = déselection)
 - Placeholders ronds pour les places restantes
 - Compteur « X/5 joueurs sélectionnés »
 - `SearchInput` pour rechercher des joueurs — la liste n'apparaît que lorsqu'un terme de recherche est saisi
+- Quand 5 joueurs sont sélectionnés et `onStart` est fourni : la barre de recherche est remplacée par un bouton « Démarrer la session »
 - Filtre les joueurs inactifs de la liste de sélection (seuls les joueurs actifs sont sélectionnables)
 - Les joueurs déjà sélectionnés restent affichés en chips même s'ils sont inactifs
 - Liste des joueurs (visible uniquement pendant une recherche) : clic = toggle sélection, `ring-2 ring-accent-500` si sélectionné
@@ -591,9 +594,12 @@ Composant de sélection de joueurs avec limite à 5. Inclut chips, recherche et 
 Liste des sessions récentes sous forme de cartes cliquables.
 
 **Fonctionnalités** :
-- Chaque carte : noms des joueurs (jointure « , »), date fr-FR, badge « En cours » si `isActive`
+- Chaque carte : 5 avatars des joueurs (`PlayerAvatar`), date relative de la dernière donne (`formatRelativeDate`), badge « En cours » si `isActive`
+- Dates relatives : « Aujourd'hui », « Hier », « Il y a X jours » (2-7), puis date absolue
+- Limitation à 5 sessions affichées, bouton « Voir les N sessions » pour étendre
+- État vide : message aléatoire engageant avec icône (messages exportés via `EMPTY_STATE_MESSAGES`)
 - Lien vers `/sessions/:id`
-- États : chargement, vide (« Aucune session »), liste
+- États : chargement, vide, liste
 
 **Hooks utilisés** : `useSessions`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -81,19 +81,23 @@ Utiliser la barre de recherche en haut de la liste pour filtrer par nom.
 
 ## Démarrer une session
 
-Depuis l'écran **Accueil** :
+L'écran **Accueil** est organisé pour un usage mobile à une main :
+
+### Sessions récentes
+
+En haut de l'écran, les **sessions récentes** permettent de reprendre rapidement une partie existante. Chaque session affiche les noms des joueurs, la **date de la dernière donne** jouée et un badge « En cours » le cas échéant.
+
+### Nouvelle session
+
+En bas de l'écran, la zone de sélection des joueurs est accessible au pouce :
 
 1. **Rechercher** un joueur dans la barre de recherche — la liste des résultats apparaît en tapant un nom
 2. Sélectionner **5 joueurs** parmi les résultats
    - Utiliser les flèches **↑/↓** pour parcourir la liste, **Entrée** pour sélectionner, **Échap** pour fermer la liste
    - Possibilité d'ajouter un nouveau joueur à la volée avec **« + Ajouter »**
-3. Appuyer sur **« Démarrer »**
+3. Une fois les 5 joueurs sélectionnés, la barre de recherche se transforme en bouton **« Démarrer la session »** — appuyer dessus pour lancer la partie
 
 > **Session intelligente** : si une session active existe déjà avec les mêmes 5 joueurs, l'application la reprend automatiquement au lieu d'en créer une nouvelle.
-
-### Sessions récentes
-
-Les sessions récentes sont affichées sous le formulaire de sélection pour un accès rapide.
 
 ### Donneur
 

--- a/frontend/src/__tests__/services/formatRelativeDate.test.ts
+++ b/frontend/src/__tests__/services/formatRelativeDate.test.ts
@@ -1,0 +1,35 @@
+import { formatRelativeDate } from "../../services/formatRelativeDate";
+
+describe("formatRelativeDate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-02-15T14:00:00"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 'Aujourd'hui' for today", () => {
+    expect(formatRelativeDate("2025-02-15T10:00:00")).toBe("Aujourd'hui");
+  });
+
+  it("returns 'Hier' for yesterday", () => {
+    expect(formatRelativeDate("2025-02-14T22:00:00")).toBe("Hier");
+  });
+
+  it("returns 'Il y a X jours' for 2-7 days ago", () => {
+    expect(formatRelativeDate("2025-02-13T10:00:00")).toBe("Il y a 2 jours");
+    expect(formatRelativeDate("2025-02-08T10:00:00")).toBe("Il y a 7 jours");
+  });
+
+  it("returns absolute date for more than 7 days ago", () => {
+    expect(formatRelativeDate("2025-02-07T10:00:00")).toMatch(/7 févr\. 2025/);
+  });
+
+  it("returns absolute date for dates far in the past", () => {
+    expect(formatRelativeDate("2024-06-15T10:00:00")).toMatch(
+      /15 juin 2024/,
+    );
+  });
+});

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -1,41 +1,94 @@
+import { Layers } from "lucide-react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useSessions } from "../hooks/useSessions";
+import { formatRelativeDate } from "../services/formatRelativeDate";
+import { PlayerAvatar } from "./ui";
+
+export const EMPTY_STATE_MESSAGES = [
+  "Les cartes n'attendent que vous ! Sélectionnez 5 joueurs pour commencer.",
+  "La table est prête, il ne manque plus que les joueurs !",
+  "Aucune session pour l'instant… C'est le moment de distribuer !",
+  "Le tarot, c'est mieux à plusieurs. Lancez votre première session !",
+  "Qui prend ? Créez une session pour le découvrir !",
+  "Petit, Garde ou Garde Sans ? Il n'y a qu'une façon de le savoir…",
+  "Le donneur est prêt. Et vous ?",
+];
+
+const MAX_VISIBLE = 5;
 
 export default function SessionList() {
   const { isPending, sessions } = useSessions();
+  const [expanded, setExpanded] = useState(false);
+
+  const emptyMessage = useMemo(
+    () => EMPTY_STATE_MESSAGES[Math.floor(Math.random() * EMPTY_STATE_MESSAGES.length)],
+    [],
+  );
 
   if (isPending) {
     return <p className="py-4 text-center text-text-muted">Chargement…</p>;
   }
 
   if (sessions.length === 0) {
-    return <p className="py-4 text-center text-text-muted">Aucune session</p>;
+    return (
+      <div
+        className="flex flex-col items-center gap-3 py-8 text-center"
+        data-testid="empty-state"
+      >
+        <Layers className="text-text-muted" size={40} />
+        <p className="text-text-muted">{emptyMessage}</p>
+      </div>
+    );
   }
 
+  const visible = expanded ? sessions : sessions.slice(0, MAX_VISIBLE);
+  const hasMore = sessions.length > MAX_VISIBLE && !expanded;
+
   return (
-    <ul className="flex flex-col gap-2">
-      {sessions.map((session) => (
-        <li key={session.id}>
-          <Link
-            className="block rounded-lg bg-surface-secondary p-3 transition-colors hover:bg-surface-tertiary"
-            to={`/sessions/${session.id}`}
-          >
-            <div className="flex items-center justify-between">
-              <p className="font-medium text-text-primary">
-                {session.players.map((p) => p.name).join(", ")}
-              </p>
-              {session.isActive && (
-                <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
-                  En cours
-                </span>
-              )}
-            </div>
-            <p className="mt-1 text-xs text-text-muted">
-              {new Date(session.createdAt).toLocaleDateString("fr-FR")}
-            </p>
-          </Link>
-        </li>
-      ))}
-    </ul>
+    <div className="flex flex-col gap-2">
+      <ul className="flex flex-col gap-2">
+        {visible.map((session) => (
+          <li key={session.id}>
+            <Link
+              className="block rounded-lg bg-surface-secondary p-3 transition-colors hover:bg-surface-tertiary"
+              to={`/sessions/${session.id}`}
+            >
+              <div className="flex flex-col items-center gap-2">
+                <div className="flex items-center gap-1">
+                  {session.players.map((p) => (
+                    <PlayerAvatar
+                      key={p.id}
+                      name={p.name}
+                      playerId={p.id}
+                      size="sm"
+                    />
+                  ))}
+                </div>
+                <div className="flex items-center gap-2">
+                  <p className="text-xs text-text-muted">
+                    {formatRelativeDate(session.lastPlayedAt)}
+                  </p>
+                  {session.isActive && (
+                    <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                      En cours
+                    </span>
+                  )}
+                </div>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      {hasMore && (
+        <button
+          className="text-center text-sm font-medium text-accent-500 transition-colors hover:text-accent-600"
+          onClick={() => setExpanded(true)}
+          type="button"
+        >
+          Voir les {sessions.length} sessions
+        </button>
+      )}
+    </div>
   );
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import PlayerSelector from "../components/PlayerSelector";
 import SessionList from "../components/SessionList";
@@ -7,10 +7,24 @@ import type { Session } from "../types/api";
 
 const REQUIRED_PLAYERS = 5;
 
+export const MOTIVATIONAL_MESSAGES = [
+  "Les cartes n'attendent que vous !",
+  "La table est prête, il ne manque plus que les joueurs !",
+  "Qui prend ? Créez une session pour le découvrir !",
+  "Petit, Garde ou Garde Sans ? Il n'y a qu'une façon de le savoir…",
+  "Le donneur est prêt. Et vous ?",
+  "Le tarot, c'est mieux à plusieurs. Lancez-vous !",
+];
+
 export default function Home() {
   const [selectedPlayerIds, setSelectedPlayerIds] = useState<number[]>([]);
   const createSession = useCreateSession();
   const navigate = useNavigate();
+
+  const motivationalMessage = useMemo(
+    () => MOTIVATIONAL_MESSAGES[Math.floor(Math.random() * MOTIVATIONAL_MESSAGES.length)],
+    [],
+  );
 
   const canStart =
     selectedPlayerIds.length === REQUIRED_PLAYERS && !createSession.isPending;
@@ -27,12 +41,24 @@ export default function Home() {
   return (
     <div className="flex flex-col gap-6 overflow-x-hidden p-4 lg:p-8">
       <section>
-        <h1 className="mb-4 text-center text-2xl font-bold text-text-primary">
+        <h2 className="mb-4 text-center text-2xl font-bold text-text-primary">
+          Sessions récentes
+        </h2>
+        <SessionList />
+      </section>
+
+      <section>
+        <h2 className="mb-1 text-center text-2xl font-bold text-text-primary">
           Nouvelle session
-        </h1>
+        </h2>
+        <p className="mb-4 text-center text-sm text-text-muted">
+          {motivationalMessage}
+        </p>
 
         <PlayerSelector
+          isPending={createSession.isPending}
           onSelectionChange={setSelectedPlayerIds}
+          onStart={handleStart}
           selectedPlayerIds={selectedPlayerIds}
         />
 
@@ -41,22 +67,6 @@ export default function Home() {
             Erreur lors de la création de la session.
           </p>
         )}
-
-        <button
-          className="mt-4 w-full rounded-lg bg-accent-500 py-3 font-semibold text-white transition-colors hover:bg-accent-600 disabled:opacity-50"
-          disabled={!canStart}
-          onClick={handleStart}
-          type="button"
-        >
-          Démarrer
-        </button>
-      </section>
-
-      <section>
-        <h2 className="mb-3 text-lg font-semibold text-text-primary">
-          Sessions récentes
-        </h2>
-        <SessionList />
       </section>
     </div>
   );

--- a/frontend/src/services/formatRelativeDate.ts
+++ b/frontend/src/services/formatRelativeDate.ts
@@ -1,0 +1,28 @@
+/**
+ * Formate une date ISO en texte relatif français.
+ * - "Aujourd'hui" si même jour
+ * - "Hier" si veille
+ * - "Il y a X jours" si 2-7 jours
+ * - Date absolue "12 janv. 2025" au-delà
+ */
+export function formatRelativeDate(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+
+  // Comparer les jours en local (pas en UTC)
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const target = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const diffDays = Math.round(
+    (today.getTime() - target.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  if (diffDays === 0) return "Aujourd'hui";
+  if (diffDays === 1) return "Hier";
+  if (diffDays >= 2 && diffDays <= 7) return `Il y a ${diffDays} jours`;
+
+  return date.toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -123,6 +123,7 @@ export interface Session {
   createdAt: string;
   id: number;
   isActive: boolean;
+  lastPlayedAt: string;
   players: SessionPlayer[];
 }
 
@@ -144,5 +145,6 @@ export interface StarEvent {
 }
 
 export interface SessionPlayer {
+  id: number;
   name: string;
 }


### PR DESCRIPTION
## Summary

- **Sessions récentes en haut** : affichage des sessions avec avatars des joueurs, date relative (« Aujourd'hui », « Hier », « Il y a X jours ») et badge « En cours ». Limitées à 5 avec bouton « Voir tout ».
- **Saisie simplifiée** : le bouton « Démarrer la session » remplace la barre de recherche avec animation quand 5 joueurs sont sélectionnés. Message motivant aléatoire en sous-titre.
- **État vide engageant** : messages aléatoires sympas quand aucune session n'existe.
- **Backend** : ajout de `lastPlayedAt` (propriété calculée) sur Session, groupe `session:read` sur Player.id pour les avatars.

fixes #73

## Test plan

- [x] 332 tests frontend passent (45 fichiers)
- [x] 97 tests backend passent
- [x] TypeScript compile sans erreur
- [ ] Vérifier visuellement sur mobile : sessions en haut, sélection en bas
- [ ] Vérifier l'animation du bouton Démarrer quand 5 joueurs sélectionnés
- [ ] Vérifier les dates relatives (Aujourd'hui, Hier, Il y a X jours)
- [ ] Vérifier l'état vide (supprimer toutes les sessions)
- [ ] Vérifier le bouton « Voir tout » avec plus de 5 sessions