### PR TITLE
feat(duration): track game duration and display time statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **Suivi de la durée des donnes** : nouveau champ `completedAt` sur les donnes, renseigné automatiquement à la complétion. Chronomètre en temps réel sur le bandeau de donne en cours. Durée affichée dans l'historique des donnes. Nouvelles statistiques globales (durée moyenne par donne, temps de jeu total) et par joueur. Utilitaire `formatDuration` et hook `useElapsedTime`.
+
 ### Changed
 
 - **CLAUDE.md** : commandes simplifiées avec cibles Makefile au lieu des commandes `ddev exec` verbeuses

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -9,6 +9,7 @@
         "ext-iconv": "*",
         "api-platform/doctrine-orm": "^4.2",
         "api-platform/symfony": "*",
+        "beberlei/doctrineextensions": "^1.5",
         "doctrine/doctrine-bundle": "^2.18",
         "doctrine/doctrine-migrations-bundle": "^3.7",
         "doctrine/orm": "^3.6",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6ba1f8a2ff71eb6e7721db240c32303",
+    "content-hash": "03ceed4a4453d93e947fceb42697ae4a",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -1155,6 +1155,68 @@
                 "source": "https://github.com/api-platform/validator/tree/v4.2.15"
             },
             "time": "2026-01-26T15:45:40+00:00"
+        },
+        {
+            "name": "beberlei/doctrineextensions",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/DoctrineExtensions.git",
+                "reference": "281f1650641c2f438b0a54d8eaa7ba50ac7e3eb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/DoctrineExtensions/zipball/281f1650641c2f438b0a54d8eaa7ba50ac7e3eb6",
+                "reference": "281f1650641c2f438b0a54d8eaa7ba50ac7e3eb6",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/orm": "^2.19 || ^3.0",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.14 || ^2",
+                "doctrine/coding-standard": "^9.0.2 || ^12.0",
+                "nesbot/carbon": "^2.72 || ^3",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.5 || ^9.6",
+                "squizlabs/php_codesniffer": "^3.8",
+                "symfony/cache": "^5.4 || ^6.4 || ^7.0",
+                "symfony/yaml": "^5.4 || ^6.4 || ^7.0",
+                "vimeo/psalm": "^3.18 || ^5.22",
+                "zf1/zend-date": "^1.12",
+                "zf1/zend-registry": "^1.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DoctrineExtensions\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Steve Lacey",
+                    "email": "steve@steve.ly"
+                }
+            ],
+            "description": "A set of extensions to Doctrine 2 that add support for additional query functions available in MySQL, Oracle, PostgreSQL and SQLite.",
+            "keywords": [
+                "database",
+                "doctrine",
+                "orm"
+            ],
+            "support": {
+                "source": "https://github.com/beberlei/DoctrineExtensions/tree/v1.5.0"
+            },
+            "time": "2024-03-03T17:55:15+00:00"
         },
         {
             "name": "doctrine/collections",

--- a/backend/config/packages/doctrine.yaml
+++ b/backend/config/packages/doctrine.yaml
@@ -10,6 +10,9 @@ doctrine:
         use_savepoints: true
     orm:
         auto_generate_proxy_classes: true
+        dql:
+            datetime_functions:
+                TIMESTAMPDIFF: DoctrineExtensions\Query\Mysql\TimestampDiff
         enable_lazy_ghost_objects: true
         report_fields_where_declared: true
         validate_xml_mapping: true

--- a/backend/migrations/Version20260212172632.php
+++ b/backend/migrations/Version20260212172632.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260212172632 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajout de completed_at sur Game pour le suivi de durée';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE game ADD completed_at DATETIME DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE game DROP completed_at');
+    }
+}

--- a/backend/src/Controller/StatisticsController.php
+++ b/backend/src/Controller/StatisticsController.php
@@ -23,10 +23,12 @@ class StatisticsController
     public function global(): JsonResponse
     {
         return new JsonResponse([
+            'averageGameDuration' => $this->statisticsService->getAverageGameDurationSeconds(),
             'contractDistribution' => $this->statisticsService->getContractDistribution(),
             'eloRanking' => $this->statisticsService->getEloRanking(),
             'leaderboard' => $this->statisticsService->getLeaderboard(),
             'totalGames' => $this->statisticsService->getTotalGames(),
+            'totalPlayTime' => $this->statisticsService->getTotalPlayTimeSeconds(),
             'totalSessions' => $this->statisticsService->getTotalSessions(),
             'totalStars' => $this->statisticsService->getTotalStars(),
         ]);

--- a/backend/src/Entity/Game.php
+++ b/backend/src/Entity/Game.php
@@ -68,6 +68,10 @@ class Game
     #[ORM\Column(enumType: Chelem::class)]
     private Chelem $chelem = Chelem::None;
 
+    #[Groups(['game:read', 'session:detail'])]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $completedAt = null;
+
     #[Groups(['game:read', 'game:create', 'session:detail'])]
     #[ORM\Column(enumType: Contract::class)]
     private Contract $contract;
@@ -159,6 +163,18 @@ class Game
     public function setContract(Contract $contract): static
     {
         $this->contract = $contract;
+
+        return $this;
+    }
+
+    public function getCompletedAt(): ?\DateTimeImmutable
+    {
+        return $this->completedAt;
+    }
+
+    public function setCompletedAt(?\DateTimeImmutable $completedAt): static
+    {
+        $this->completedAt = $completedAt;
 
         return $this;
     }

--- a/backend/src/State/GameCompleteProcessor.php
+++ b/backend/src/State/GameCompleteProcessor.php
@@ -45,6 +45,7 @@ final readonly class GameCompleteProcessor implements ProcessorInterface
             $this->computeEloRatings($data);
 
             if (!$wasAlreadyCompleted) {
+                $data->setCompletedAt(new \DateTimeImmutable());
                 $data->getSession()->advanceDealer();
             }
         }

--- a/backend/tests/Api/FullFlowApiTest.php
+++ b/backend/tests/Api/FullFlowApiTest.php
@@ -37,7 +37,7 @@ class FullFlowApiTest extends ApiTestCase
         $sessionId = $sessionData['id'];
 
         // 3. Créer la donne 1 (step 1 : preneur + contrat)
-        $response = $this->client->request('POST', $sessionIri . '/games', [
+        $response = $this->client->request('POST', $sessionIri.'/games', [
             'headers' => ['Content-Type' => 'application/ld+json'],
             'json' => [
                 'contract' => 'petite',
@@ -83,7 +83,7 @@ class FullFlowApiTest extends ApiTestCase
         $this->assertSame(-29, $scoresByName['Eve']);
 
         // 6. Deuxième donne : créer + compléter
-        $response = $this->client->request('POST', $sessionIri . '/games', [
+        $response = $this->client->request('POST', $sessionIri.'/games', [
             'headers' => ['Content-Type' => 'application/ld+json'],
             'json' => [
                 'contract' => 'garde',
@@ -109,7 +109,7 @@ class FullFlowApiTest extends ApiTestCase
         $this->assertSame('completed', $response->toArray()['status']);
 
         // 7. Vérifier que les 2 donnes existent
-        $response = $this->client->request('GET', $sessionIri . '/games');
+        $response = $this->client->request('GET', $sessionIri.'/games');
         $gamesData = $response->toArray();
         $this->assertSame(2, $gamesData['totalItems'], 'Should have 2 games');
 

--- a/backend/tests/Api/StatisticsApiTest.php
+++ b/backend/tests/Api/StatisticsApiTest.php
@@ -41,6 +41,12 @@ class StatisticsApiTest extends ApiTestCase
         $this->assertSame(3, $data['totalGames']);
         $this->assertSame(1, $data['totalSessions']);
 
+        // Duration stats — seed data has no completedAt, so null/0
+        $this->assertArrayHasKey('averageGameDuration', $data);
+        $this->assertArrayHasKey('totalPlayTime', $data);
+        $this->assertNull($data['averageGameDuration']);
+        $this->assertSame(0, $data['totalPlayTime']);
+
         // Leaderboard — sorted by totalScore DESC
         $this->assertCount(5, $data['leaderboard']);
         $first = $data['leaderboard'][0];
@@ -87,6 +93,8 @@ class StatisticsApiTest extends ApiTestCase
         $this->assertSame(0, $data['totalSessions']);
         $this->assertSame([], $data['leaderboard']);
         $this->assertSame([], $data['contractDistribution']);
+        $this->assertNull($data['averageGameDuration']);
+        $this->assertSame(0, $data['totalPlayTime']);
     }
 
     public function testGetPlayerStatistics(): void
@@ -126,6 +134,12 @@ class StatisticsApiTest extends ApiTestCase
         $this->assertArrayHasKey('gamesAsPartner', $data);
         $this->assertArrayHasKey('winRateAsTaker', $data);
         $this->assertArrayHasKey('worstGameScore', $data);
+
+        // Duration stats — seed data has no completedAt
+        $this->assertArrayHasKey('averageGameDurationSeconds', $data);
+        $this->assertArrayHasKey('totalPlayTimeSeconds', $data);
+        $this->assertNull($data['averageGameDurationSeconds']);
+        $this->assertSame(0, $data['totalPlayTimeSeconds']);
     }
 
     public function testGetPlayerStatisticsNotFound(): void
@@ -202,6 +216,12 @@ class StatisticsApiTest extends ApiTestCase
         $response = $this->client->request('GET', '/api/statistics');
         $globalData = $response->toArray();
         $this->assertNotEmpty($globalData['eloRanking']);
+
+        // Duration stats — the API-created game has completedAt set
+        $this->assertIsInt($globalData['averageGameDuration']);
+        $this->assertGreaterThanOrEqual(0, $globalData['averageGameDuration']);
+        $this->assertIsInt($globalData['totalPlayTime']);
+        $this->assertGreaterThanOrEqual(0, $globalData['totalPlayTime']);
     }
 
     public function testEloRevertedAfterGameDeletion(): void

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -133,7 +133,7 @@ En haut de l'écran, un bandeau horizontal scrollable montre les **5 joueurs** a
 
 ### Donne en cours
 
-Si une donne est en cours (étape 1 validée, étape 2 en attente), un bandeau bien visible indique le preneur et le contrat avec un bouton **« Compléter »**.
+Si une donne est en cours (étape 1 validée, étape 2 en attente), un bandeau bien visible indique le preneur, le contrat et un **chronomètre** affichant le temps écoulé depuis le début de la donne, avec un bouton **« Compléter »**.
 
 ### Historique des donnes
 
@@ -141,7 +141,7 @@ Liste des donnes jouées (la plus récente en premier), montrant pour chaque don
 
 - Le preneur et son partenaire
 - Le donneur de la donne
-- Le contrat (badge coloré)
+- Le contrat (badge coloré) et la **durée de la donne** (si disponible)
 - Le résultat (gain/perte du preneur)
 
 ### Modifier les joueurs
@@ -225,7 +225,7 @@ Accessible via l'onglet **Stats** dans la barre de navigation.
 
 L'écran principal des statistiques affiche :
 
-- **Métriques** : nombre total de donnes et de sessions jouées
+- **Métriques** : nombre total de donnes, de sessions jouées, **durée moyenne par donne** et **temps de jeu total** (si des donnes avec suivi de durée existent)
 - **Classement** : tous les joueurs triés par score total décroissant, avec nombre de donnes jouées et taux de victoire en tant que preneur
 - **Répartition des contrats** : graphique à barres horizontales montrant combien de donnes ont été jouées par type de contrat (Petite, Garde, etc.)
 
@@ -235,7 +235,7 @@ Appuyer sur un joueur dans le classement pour voir ses statistiques détaillées
 
 L'écran de détail d'un joueur affiche :
 
-- **Métriques clés** : donnes jouées, taux de victoire (en tant que preneur), score moyen, sessions jouées
+- **Métriques clés** : donnes jouées, taux de victoire (en tant que preneur), score moyen, sessions jouées, **durée moyenne par donne** et **temps de jeu total** (si disponible)
 - **Meilleur et pire score** : les scores extrêmes du joueur
 - **Répartition des rôles** : barre visuelle montrant combien de fois le joueur a été preneur, partenaire ou défenseur
 - **Contrats pris** : graphique à barres des contrats joués en tant que preneur

--- a/frontend/src/__tests__/components/CompleteGameModal.test.tsx
+++ b/frontend/src/__tests__/components/CompleteGameModal.test.tsx
@@ -17,6 +17,7 @@ const mockPlayers = [
 
 const inProgressGame: Game = {
   chelem: "none",
+  completedAt: null,
   contract: "garde",
   createdAt: "2025-02-01T14:10:00+00:00",
   id: 7,
@@ -34,6 +35,7 @@ const inProgressGame: Game = {
 
 const completedGame: Game = {
   chelem: "none",
+  completedAt: "2025-02-01T14:05:00+00:00",
   contract: "garde",
   createdAt: "2025-02-01T14:10:00+00:00",
   id: 7,

--- a/frontend/src/__tests__/components/DeleteGameModal.test.tsx
+++ b/frontend/src/__tests__/components/DeleteGameModal.test.tsx
@@ -9,6 +9,7 @@ vi.mock("../../hooks/useDeleteGame");
 
 const mockGame: Game = {
   chelem: "none",
+  completedAt: "2025-02-01T14:05:00+00:00",
   contract: "garde",
   createdAt: "2025-02-01T14:00:00+00:00",
   id: 1,

--- a/frontend/src/__tests__/components/GameList.test.tsx
+++ b/frontend/src/__tests__/components/GameList.test.tsx
@@ -6,6 +6,7 @@ import type { Game } from "../../types/api";
 
 const baseGame: Game = {
   chelem: "none",
+  completedAt: "2025-02-01T14:05:00+00:00",
   contract: "garde",
   createdAt: "2025-02-01T14:00:00+00:00",
   id: 1,
@@ -111,6 +112,28 @@ describe("GameList", () => {
 
     await userEvent.click(deleteButtons[0]);
     expect(onDeleteLast).toHaveBeenCalledOnce();
+  });
+
+  it("shows duration for completed games with completedAt", () => {
+    renderWithProviders(
+      <GameList games={games} onDeleteLast={() => {}} onEditLast={() => {}} />,
+    );
+
+    // baseGame: createdAt 14:00, completedAt 14:05 → 5min
+    expect(screen.getAllByText("5min").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not show duration for games without completedAt", () => {
+    const gamesWithoutCompletedAt = games.map((g) => ({
+      ...g,
+      completedAt: null,
+    }));
+    renderWithProviders(
+      <GameList games={gamesWithoutCompletedAt} onDeleteLast={() => {}} onEditLast={() => {}} />,
+    );
+
+    // No duration text should appear
+    expect(screen.queryByText(/min/)).not.toBeInTheDocument();
   });
 
   it("renders empty state when no games", () => {

--- a/frontend/src/__tests__/components/InProgressBanner.test.tsx
+++ b/frontend/src/__tests__/components/InProgressBanner.test.tsx
@@ -6,6 +6,7 @@ import type { Game } from "../../types/api";
 
 const mockGame: Game = {
   chelem: "none",
+  completedAt: null,
   contract: "garde",
   createdAt: "2025-02-01T14:00:00+00:00",
   id: 1,
@@ -22,6 +23,20 @@ const mockGame: Game = {
 };
 
 describe("InProgressBanner", () => {
+  it("renders elapsed time since game creation", () => {
+    vi.useFakeTimers();
+    // Set "now" to 5 minutes after createdAt
+    vi.setSystemTime(new Date("2025-02-01T14:05:00+00:00"));
+
+    renderWithProviders(
+      <InProgressBanner game={mockGame} onComplete={() => {}} />,
+    );
+
+    expect(screen.getByText("5min")).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
   it("renders taker name and avatar", () => {
     renderWithProviders(
       <InProgressBanner game={mockGame} onComplete={() => {}} />,

--- a/frontend/src/__tests__/pages/PlayerStats.test.tsx
+++ b/frontend/src/__tests__/pages/PlayerStats.test.tsx
@@ -14,6 +14,7 @@ vi.mock("react-router-dom", async (importOriginal) => ({
 vi.mock("../../hooks/usePlayerStats");
 
 const mockStats = {
+  averageGameDurationSeconds: 480,
   averageScore: 8.6,
   bestGameScore: 240,
   contractDistribution: [
@@ -36,6 +37,7 @@ const mockStats = {
   ],
   sessionsPlayed: 10,
   starPenalties: 0,
+  totalPlayTimeSeconds: 4800,
   totalStars: 0,
   winRateAsTaker: 57.1,
   worstGameScore: -360,
@@ -130,6 +132,20 @@ describe("PlayerStats page", () => {
     expect(screen.getByText("Preneur: 35")).toBeInTheDocument();
     expect(screen.getByText("Partenaire: 20")).toBeInTheDocument();
     expect(screen.getByText("Défenseur: 90")).toBeInTheDocument();
+  });
+
+  it("renders duration metrics", () => {
+    vi.mocked(usePlayerStatsModule.usePlayerStats).mockReturnValue({
+      isPending: false,
+      stats: mockStats,
+    } as ReturnType<typeof usePlayerStatsModule.usePlayerStats>);
+
+    renderWithProviders(<PlayerStats />);
+
+    expect(screen.getByText("Durée moy. / donne")).toBeInTheDocument();
+    expect(screen.getByText("8min")).toBeInTheDocument();
+    expect(screen.getByText("Temps de jeu total")).toBeInTheDocument();
+    expect(screen.getByText("1h 20min")).toBeInTheDocument();
   });
 
   it("navigates back to /stats on back button click", async () => {

--- a/frontend/src/__tests__/pages/SessionPage.test.tsx
+++ b/frontend/src/__tests__/pages/SessionPage.test.tsx
@@ -48,6 +48,7 @@ const mockSession: SessionDetail = {
   games: [
     {
       chelem: "none",
+      completedAt: "2025-02-01T14:05:00+00:00",
       contract: "garde",
       createdAt: "2025-02-01T14:10:00+00:00",
       id: 1,
@@ -264,6 +265,7 @@ const mockSessionWithInProgress = {
     ...mockSession.games,
     {
       chelem: "none" as const,
+      completedAt: null,
       contract: "petite" as const,
       createdAt: "2025-02-01T14:20:00+00:00",
       id: 2,

--- a/frontend/src/__tests__/pages/Stats.test.tsx
+++ b/frontend/src/__tests__/pages/Stats.test.tsx
@@ -13,6 +13,7 @@ vi.mock("react-router-dom", async (importOriginal) => ({
 vi.mock("../../hooks/useGlobalStats");
 
 const mockStats = {
+  averageGameDuration: 480,
   contractDistribution: [
     { contract: "petite" as const, count: 5, percentage: 50.0 },
     { contract: "garde" as const, count: 5, percentage: 50.0 },
@@ -42,6 +43,7 @@ const mockStats = {
     },
   ],
   totalGames: 10,
+  totalPlayTime: 4800,
   totalSessions: 2,
   totalStars: 0,
 };
@@ -112,6 +114,31 @@ describe("Stats page", () => {
     expect(screen.getByText("Classement ELO")).toBeInTheDocument();
     expect(screen.getByText("1520")).toBeInTheDocument();
     expect(screen.getByText("1480")).toBeInTheDocument();
+  });
+
+  it("renders duration stats when available", () => {
+    vi.mocked(useGlobalStatsModule.useGlobalStats).mockReturnValue({
+      isPending: false,
+      stats: mockStats,
+    } as ReturnType<typeof useGlobalStatsModule.useGlobalStats>);
+
+    renderWithProviders(<Stats />);
+
+    expect(screen.getByText("Durée moy. / donne")).toBeInTheDocument();
+    expect(screen.getByText("8min")).toBeInTheDocument();
+    expect(screen.getByText("Temps de jeu total")).toBeInTheDocument();
+    expect(screen.getByText("1h 20min")).toBeInTheDocument();
+  });
+
+  it("does not render duration stats when averageGameDuration is null", () => {
+    vi.mocked(useGlobalStatsModule.useGlobalStats).mockReturnValue({
+      isPending: false,
+      stats: { ...mockStats, averageGameDuration: null, totalPlayTime: 0 },
+    } as ReturnType<typeof useGlobalStatsModule.useGlobalStats>);
+
+    renderWithProviders(<Stats />);
+
+    expect(screen.queryByText("Durée moy. / donne")).not.toBeInTheDocument();
   });
 
   it("navigates to player stats on leaderboard click", async () => {

--- a/frontend/src/__tests__/utils/formatDuration.test.ts
+++ b/frontend/src/__tests__/utils/formatDuration.test.ts
@@ -1,0 +1,39 @@
+import { formatDuration } from "../../utils/formatDuration";
+
+describe("formatDuration", () => {
+  it("formats 0 seconds", () => {
+    expect(formatDuration(0)).toBe("0s");
+  });
+
+  it("formats seconds only", () => {
+    expect(formatDuration(45)).toBe("45s");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(65)).toBe("1min 5s");
+  });
+
+  it("formats exact minutes without seconds", () => {
+    expect(formatDuration(120)).toBe("2min");
+  });
+
+  it("formats hours and minutes", () => {
+    expect(formatDuration(3661)).toBe("1h 1min");
+  });
+
+  it("formats exact hours without minutes", () => {
+    expect(formatDuration(7200)).toBe("2h");
+  });
+
+  it("formats hours only when no remaining minutes", () => {
+    expect(formatDuration(3600)).toBe("1h");
+  });
+
+  it("ignores seconds when hours are present", () => {
+    expect(formatDuration(3665)).toBe("1h 1min");
+  });
+
+  it("handles large values", () => {
+    expect(formatDuration(86400)).toBe("24h");
+  });
+});

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -1,4 +1,5 @@
 import type { Game } from "../types/api";
+import { formatDuration } from "../utils/formatDuration";
 import { ContractBadge, PlayerAvatar, ScoreDisplay } from "./ui";
 
 interface GameListProps {
@@ -25,6 +26,9 @@ export default function GameList({ games, onDeleteLast, onEditLast }: GameListPr
         const takerScore =
           game.scoreEntries.find((e) => e.player.id === game.taker.id)
             ?.score ?? 0;
+        const durationSeconds = game.completedAt
+          ? Math.floor((new Date(game.completedAt).getTime() - new Date(game.createdAt).getTime()) / 1000)
+          : null;
 
         return (
           <li
@@ -53,7 +57,14 @@ export default function GameList({ games, onDeleteLast, onEditLast }: GameListPr
               )}
             </div>
             <div className="flex shrink-0 items-center gap-2">
-              <ScoreDisplay animated={false} value={takerScore} />
+              <div className="flex flex-col items-end">
+                <ScoreDisplay animated={false} value={takerScore} />
+                {durationSeconds !== null && (
+                  <span className="text-xs text-text-muted">
+                    {formatDuration(durationSeconds)}
+                  </span>
+                )}
+              </div>
               {game.position === maxPosition && (
                 <>
                   <button

--- a/frontend/src/components/InProgressBanner.tsx
+++ b/frontend/src/components/InProgressBanner.tsx
@@ -1,5 +1,22 @@
+import { useEffect, useState } from "react";
 import type { Game } from "../types/api";
+import { formatDuration } from "../utils/formatDuration";
 import { ContractBadge, PlayerAvatar } from "./ui";
+
+function useElapsedTime(createdAt: string): number {
+  const [elapsed, setElapsed] = useState(() =>
+    Math.floor((Date.now() - new Date(createdAt).getTime()) / 1000),
+  );
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - new Date(createdAt).getTime()) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [createdAt]);
+
+  return elapsed;
+}
 
 interface InProgressBannerProps {
   game: Game;
@@ -8,6 +25,8 @@ interface InProgressBannerProps {
 }
 
 export default function InProgressBanner({ game, onCancel, onComplete }: InProgressBannerProps) {
+  const elapsed = useElapsedTime(game.createdAt);
+
   return (
     <div className="flex items-center gap-3 rounded-xl bg-accent-500/10 p-3">
       <PlayerAvatar name={game.taker.name} playerId={game.taker.id} size="md" />
@@ -15,7 +34,10 @@ export default function InProgressBanner({ game, onCancel, onComplete }: InProgr
         <span className="text-sm font-medium text-text-primary">
           {game.taker.name}
         </span>
-        <ContractBadge contract={game.contract} />
+        <div className="flex items-center gap-2">
+          <ContractBadge contract={game.contract} />
+          <span className="text-xs text-text-muted">{formatDuration(elapsed)}</span>
+        </div>
       </div>
       <div className="flex gap-2">
         {onCancel && (

--- a/frontend/src/pages/PlayerStats.tsx
+++ b/frontend/src/pages/PlayerStats.tsx
@@ -4,6 +4,7 @@ import EloEvolutionChart from "../components/EloEvolutionChart";
 import ScoreTrendChart from "../components/ScoreTrendChart";
 import { PlayerAvatar, ScoreDisplay } from "../components/ui";
 import { usePlayerStats } from "../hooks/usePlayerStats";
+import { formatDuration } from "../utils/formatDuration";
 
 export default function PlayerStats() {
   const { id } = useParams<{ id: string }>();
@@ -69,6 +70,12 @@ export default function PlayerStats() {
         <MetricCard label="Score moyen" value={String(stats.averageScore)} />
         <MetricCard label="ELO" value={String(stats.eloRating)} />
         <MetricCard label="Sessions" value={String(stats.sessionsPlayed)} />
+        {stats.averageGameDurationSeconds !== null && (
+          <MetricCard label="Durée moy. / donne" value={formatDuration(stats.averageGameDurationSeconds)} />
+        )}
+        {stats.totalPlayTimeSeconds > 0 && (
+          <MetricCard label="Temps de jeu total" value={formatDuration(stats.totalPlayTimeSeconds)} />
+        )}
       </div>
 
       {stats.totalStars > 0 && (

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -3,6 +3,7 @@ import ContractDistributionChart from "../components/ContractDistributionChart";
 import EloRanking from "../components/EloRanking";
 import Leaderboard from "../components/Leaderboard";
 import { useGlobalStats } from "../hooks/useGlobalStats";
+import { formatDuration } from "../utils/formatDuration";
 
 export default function Stats() {
   const navigate = useNavigate();
@@ -48,6 +49,23 @@ export default function Stats() {
           </div>
         )}
       </div>
+
+      {stats.averageGameDuration !== null && (
+        <div className="flex gap-4">
+          <div className="flex-1 rounded-xl bg-surface-elevated p-3 text-center">
+            <span className="block text-2xl font-bold text-text-primary">
+              {formatDuration(stats.averageGameDuration)}
+            </span>
+            <span className="text-xs text-text-muted">Durée moy. / donne</span>
+          </div>
+          <div className="flex-1 rounded-xl bg-surface-elevated p-3 text-center">
+            <span className="block text-2xl font-bold text-text-primary">
+              {formatDuration(stats.totalPlayTime)}
+            </span>
+            <span className="text-xs text-text-muted">Temps de jeu total</span>
+          </div>
+        </div>
+      )}
 
       <section>
         <h2 className="mb-2 text-sm font-semibold text-text-secondary">

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -28,6 +28,7 @@ export interface CumulativeScore {
 
 export interface Game {
   chelem: Chelem;
+  completedAt: string | null;
   contract: Contract;
   createdAt: string;
   dealer: GamePlayer | null;
@@ -50,10 +51,12 @@ export interface GamePlayer {
 }
 
 export interface GlobalStatistics {
+  averageGameDuration: number | null;
   contractDistribution: ContractDistributionEntry[];
   eloRanking: EloRankingEntry[];
   leaderboard: LeaderboardEntry[];
   totalGames: number;
+  totalPlayTime: number;
   totalSessions: number;
   totalStars: number;
 }
@@ -88,6 +91,7 @@ export interface PlayerContractEntry {
 }
 
 export interface PlayerStatistics {
+  averageGameDurationSeconds: number | null;
   averageScore: number;
   bestGameScore: number;
   contractDistribution: PlayerContractEntry[];
@@ -101,6 +105,7 @@ export interface PlayerStatistics {
   recentScores: RecentScoreEntry[];
   sessionsPlayed: number;
   starPenalties: number;
+  totalPlayTimeSeconds: number;
   totalStars: number;
   winRateAsTaker: number;
   worstGameScore: number;

--- a/frontend/src/utils/formatDuration.ts
+++ b/frontend/src/utils/formatDuration.ts
@@ -1,0 +1,20 @@
+/**
+ * Formate une durée en secondes en texte lisible.
+ * - < 1h : "Xmin Xs" (ou "Xs" si < 60s, "Xmin" si 0s)
+ * - >= 1h : "Xh Xmin" (ou "Xh" si 0min)
+ */
+export function formatDuration(totalSeconds: number): string {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}min` : `${hours}h`;
+  }
+
+  if (minutes > 0) {
+    return seconds > 0 ? `${minutes}min ${seconds}s` : `${minutes}min`;
+  }
+
+  return `${seconds}s`;
+}


### PR DESCRIPTION
## Summary

- Add `completedAt` timestamp to `Game` entity, set automatically on first completion (not updated on edit)
- Compute duration statistics in `StatisticsService` using `TIMESTAMPDIFF` (via `beberlei/doctrineextensions`): average game duration and total play time, both globally and per player
- Display live elapsed timer in `InProgressBanner` during in-progress games (`useElapsedTime` hook)
- Show game duration below score in `GameList` for completed games
- Add duration metric cards to `Stats` and `PlayerStats` pages
- New `formatDuration` utility (seconds → "Xh Xmin" / "Xmin Xs" format)
- 98 backend tests (343 assertions) + 348 frontend tests all passing

fixes #23

## Test plan

- [ ] Create a game, wait, complete it → verify `completedAt` in API response
- [ ] Verify live timer ticks in InProgressBanner
- [ ] Verify game duration shows below score in GameList history
- [ ] Verify duration stats on global Stats page
- [ ] Verify duration stats on PlayerStats page
- [ ] Verify `completedAt` does NOT change when editing a completed game
- [ ] `make test-back` passes
- [ ] `make test-front` passes
- [ ] `make lint` passes