### PR TITLE
feat(ui): add dark mode toggle button in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Toggle thème sombre** : bouton lune/soleil dans le header (à gauche de l'aide) pour basculer entre les modes clair et sombre. Détection automatique de la préférence système au premier lancement, persistance du choix en localStorage.
+
 - **Couleur d'avatar personnalisée** : choix d'une couleur pour l'avatar d'un joueur (palette de 10 couleurs prédéfinies + sélecteur libre), avec option « Auto » pour revenir à la couleur déterministe par défaut. La couleur choisie est utilisée partout où l'avatar apparaît (sessions, classements, statistiques, historique des donnes). Champ `color` ajouté à l'entité `Player` et propagé dans les endpoints statistiques (`playerColor`).
 
 - **Undo rapide** : bouton flottant « Annuler » avec décompte circulaire de 5 secondes après chaque saisie de donne, permettant de supprimer instantanément la dernière donne sans passer par la modale de suppression

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -34,14 +34,7 @@ Définis dans `frontend/src/index.css` via `@theme`. Utilisables directement com
 
 Le mode sombre est géré via la classe `.dark` sur `<html>`. Les tokens de surface, texte et score sont automatiquement redéfinis.
 
-```tsx
-import { useTheme } from "./hooks/useTheme";
-
-function ThemeToggle() {
-  const { isDark, toggle } = useTheme();
-  return <button onClick={toggle}>{isDark ? "☀️" : "🌙"}</button>;
-}
-```
+Le toggle est intégré dans le `Layout.tsx` (header, icône Sun/Moon de `lucide-react`). Il appelle `useTheme().toggle()`.
 
 L'application doit être wrappée dans `<ThemeProvider>` (déjà fait dans `App.tsx`).
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -429,9 +429,15 @@ Quand une donne est perdue par l'attaque, un **mème de défaite** peut apparaî
 
 ## Thème sombre
 
-L'application supporte un **mode sombre**. Pour basculer entre les thèmes clair et sombre, utiliser le bouton de bascule dans l'interface.
+L'application supporte un **mode sombre**. Pour basculer entre les thèmes clair et sombre, appuyer sur l'icône **lune** (☽) en haut à droite de l'écran, à gauche de l'icône d'aide. En mode sombre, l'icône devient un **soleil** (☀).
 
-Le choix est **mémorisé** automatiquement et persiste entre les visites.
+### Détection automatique
+
+Au premier lancement, l'application suit la **préférence système** du navigateur (`prefers-color-scheme`). Si le système est en mode sombre, l'application l'adopte automatiquement.
+
+### Persistance
+
+Le choix est **mémorisé** automatiquement dans le navigateur (`localStorage`) et persiste entre les visites.
 
 ---
 

--- a/frontend/src/__tests__/components/Layout.test.tsx
+++ b/frontend/src/__tests__/components/Layout.test.tsx
@@ -1,8 +1,14 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import Layout from "../../components/Layout";
 import { renderWithProviders } from "../test-utils";
 
 describe("Layout", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+  });
+
   it("renders the bottom navigation", () => {
     renderWithProviders(<Layout />);
 
@@ -21,5 +27,33 @@ describe("Layout", () => {
 
     const helpLink = screen.getByRole("link", { name: /aide/i });
     expect(helpLink).toHaveAttribute("href", "/aide");
+  });
+
+  it("renders a theme toggle button", () => {
+    renderWithProviders(<Layout />);
+
+    const toggle = screen.getByRole("button", { name: /thème/i });
+    expect(toggle).toBeInTheDocument();
+  });
+
+  it("toggles dark mode when clicking the theme button", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Layout />);
+
+    const toggle = screen.getByRole("button", { name: /thème/i });
+    await user.click(toggle);
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("toggles back to light mode on second click", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Layout />);
+
+    const toggle = screen.getByRole("button", { name: /thème/i });
+    await user.click(toggle);
+    await user.click(toggle);
+
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 });

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,11 +1,26 @@
-import { CircleHelp } from "lucide-react";
+import { CircleHelp, Moon, Sun } from "lucide-react";
 import { Link, Outlet } from "react-router-dom";
+import { useTheme } from "../hooks/useTheme";
 import BottomNav from "./BottomNav";
 
 export default function Layout() {
+  const { isDark, toggle } = useTheme();
+
   return (
     <div className="min-h-screen bg-surface-secondary pb-16 text-text-primary lg:pb-20">
-      <header className="flex justify-end p-2 lg:mx-auto lg:max-w-4xl">
+      <header className="flex justify-end gap-1 p-2 lg:mx-auto lg:max-w-4xl">
+        <button
+          aria-label="Changer de thème"
+          className="rounded-lg p-1.5 text-text-secondary hover:bg-surface-tertiary"
+          onClick={toggle}
+          type="button"
+        >
+          {isDark ? (
+            <Sun className="size-5 lg:size-6" />
+          ) : (
+            <Moon className="size-5 lg:size-6" />
+          )}
+        </button>
         <Link
           aria-label="Aide"
           className="rounded-lg p-1.5 text-text-secondary hover:bg-surface-tertiary"

--- a/frontend/src/pages/Help.tsx
+++ b/frontend/src/pages/Help.tsx
@@ -360,11 +360,15 @@ export default function Help() {
 
       <AccordionSection title="Thème sombre">
         <p>
-          L'application supporte un mode sombre. Utiliser le bouton de bascule
-          dans l'interface pour changer de thème.
+          L'application supporte un mode sombre. Appuyer sur l'icône{" "}
+          <strong>lune</strong> (☽) en haut à droite de l'écran, à gauche de
+          l'icône d'aide, pour basculer. En mode sombre, l'icône devient un{" "}
+          <strong>soleil</strong> (☀).
         </p>
         <p className="mt-2">
-          Le choix est mémorisé automatiquement et persiste entre les visites.
+          Au premier lancement, l'application suit la préférence système du
+          navigateur. Le choix est ensuite mémorisé automatiquement et persiste
+          entre les visites.
         </p>
       </AccordionSection>
 


### PR DESCRIPTION
## Résumé

- Ajout d'un bouton lune/soleil (lucide-react `Moon`/`Sun`) dans le header du Layout, à gauche de l'icône d'aide
- Le bouton appelle `useTheme().toggle()` pour basculer entre les modes clair et sombre
- 3 nouveaux tests dans `Layout.test.tsx` (présence du bouton, toggle dark on, toggle dark off)
- Mise à jour des docs (user-guide, frontend-usage, page aide in-app) et du CHANGELOG

> Toute l'infrastructure dark mode (CSS variables, ThemeProvider, useTheme, localStorage, prefers-color-scheme) existait déjà — il ne manquait que le bouton dans l'UI.

fixes #84

## Test plan

- [ ] Vérifier que l'icône lune apparaît en mode clair
- [ ] Cliquer → vérifier que le thème passe en sombre et l'icône devient soleil
- [ ] Cliquer à nouveau → retour au mode clair
- [ ] Recharger la page → le choix est mémorisé
- [ ] Tests frontend : `make test-front` (400/400 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)