### PR TITLE
feat(stats): add contract success rate by player table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Taux de réussite par contrat et par joueur** : tableau croisé joueurs × contrats sur la page Statistiques, montrant le pourcentage de victoire et le nombre de donnes pour chaque joueur en tant que preneur. Cellules colorées pour une lecture rapide. Nouveau endpoint `contractSuccessRateByPlayer` dans l'API statistiques globales, composant `ContractSuccessRateTable`.
+
 - **Graphique d'évolution ELO globale** : sur la page Statistiques, un graphique multi-lignes montre l'évolution du rating ELO de tous les joueurs au fil des donnes. Chips cliquables pour filtrer par joueur, couleur personnalisée, ligne de référence à 1500. Nouveau endpoint `eloEvolution` dans l'API statistiques globales, composant `GlobalEloEvolutionChart`.
 
 - **Toggle thème sombre** : bouton lune/soleil dans le header (à gauche de l'aide) pour basculer entre les modes clair et sombre. Détection automatique de la préférence système au premier lancement, persistance du choix en localStorage.

--- a/backend/src/Controller/StatisticsController.php
+++ b/backend/src/Controller/StatisticsController.php
@@ -30,6 +30,7 @@ class StatisticsController
         return new JsonResponse([
             'averageGameDuration' => $this->statisticsService->getAverageGameDurationSeconds($playerGroupId),
             'contractDistribution' => $this->statisticsService->getContractDistribution($playerGroupId),
+            'contractSuccessRateByPlayer' => $this->statisticsService->getContractSuccessRateByPlayer($playerGroupId),
             'eloEvolution' => $this->statisticsService->getAllPlayersEloHistory($playerGroupId),
             'eloRanking' => $this->statisticsService->getEloRanking($playerGroupId),
             'leaderboard' => $this->statisticsService->getLeaderboard($playerGroupId),

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -68,10 +68,11 @@ import type { HydraCollection, Player } from "./types/api";
 | `StarEvent` | `id: number`, `createdAt: string`, `player: GamePlayer` |
 | `SessionPlayer` | `color: string \| null`, `id: number`, `name: string` |
 | `ContractDistributionEntry` | `contract: Contract`, `count: number`, `percentage: number` |
+| `ContractSuccessRatePlayer` | `color: string \| null`, `contracts: PlayerContractEntry[]`, `id: number`, `name: string` |
 | `EloHistoryEntry` | `date: string`, `gameId: number`, `ratingAfter: number`, `ratingChange: number` |
 | `EloRankingEntry` | `eloRating: number`, `gamesPlayed: number`, `playerColor: string \| null`, `playerId: number`, `playerName: string` |
 | `EloEvolutionPlayer` | `history: { date: string; gameId: number; ratingAfter: number }[]`, `playerColor: string \| null`, `playerId: number`, `playerName: string` |
-| `GlobalStatistics` | `averageGameDuration: number \| null`, `contractDistribution: ContractDistributionEntry[]`, `eloEvolution: EloEvolutionPlayer[]`, `eloRanking: EloRankingEntry[]`, `leaderboard: LeaderboardEntry[]`, `totalGames`, `totalPlayTime: number`, `totalSessions`, `totalStars` |
+| `GlobalStatistics` | `averageGameDuration: number \| null`, `contractDistribution: ContractDistributionEntry[]`, `contractSuccessRateByPlayer: ContractSuccessRatePlayer[]`, `eloEvolution: EloEvolutionPlayer[]`, `eloRanking: EloRankingEntry[]`, `leaderboard: LeaderboardEntry[]`, `totalGames`, `totalPlayTime: number`, `totalSessions`, `totalStars` |
 | `LeaderboardEntry` | `gamesAsTaker`, `gamesPlayed`, `playerColor: string \| null`, `playerId`, `playerName`, `totalScore`, `winRate`, `wins` |
 | `PlayerContractEntry` | `contract: Contract`, `count`, `winRate`, `wins` |
 | `PlayerStatistics` | `averageGameDurationSeconds: number \| null`, `averageScore`, `bestGameScore`, `contractDistribution`, `eloHistory: EloHistoryEntry[]`, `eloRating: number`, `gamesAsDefender`, `gamesAsPartner`, `gamesAsTaker`, `gamesPlayed`, `player`, `playerGroups: { id: number; name: string }[]`, `recentScores`, `sessionsPlayed`, `starPenalties`, `totalPlayTimeSeconds: number`, `totalStars`, `winRateAsTaker`, `worstGameScore` |
@@ -629,6 +630,7 @@ Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.m
 - Classement ELO (`EloRanking`) trié par rating décroissant (masqué si aucune donnée)
 - Évolution ELO (`GlobalEloEvolutionChart`) — graphique multi-lignes avec filtrage par joueur via chips (masqué si aucune donnée)
 - Répartition des contrats (`ContractDistributionChart`) en barres horizontales
+- Taux de réussite par contrat (`ContractSuccessRateTable`) — tableau croisé joueurs × contrats (masqué si aucune donnée)
 - Navigation vers le détail d'un joueur au clic (propage le filtre groupe via `?group=`)
 - États : chargement, erreur
 
@@ -982,6 +984,16 @@ Graphique à barres horizontales (Recharts) affichant la répartition des contra
 | Prop | Type | Description |
 |------|------|-------------|
 | `data` | `ContractDistributionEntry[]` | *requis* — données de répartition |
+
+### `ContractSuccessRateTable`
+
+**Fichier** : `components/ContractSuccessRateTable.tsx`
+
+Tableau croisé joueurs × contrats. Affiche le taux de réussite (%) et le nombre de donnes pour chaque joueur en tant que preneur, par type de contrat. Cellules colorées selon le taux (vert ≥ 70%, orange 30-49%, rouge < 30%).
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `data` | `ContractSuccessRatePlayer[]` | *requis* — données par joueur |
 
 ### `ScoreTrendChart`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -276,6 +276,7 @@ L'écran principal des statistiques affiche :
 - **Métriques** : nombre total de donnes, de sessions jouées, **durée moyenne par donne** et **temps de jeu total** (si des donnes avec suivi de durée existent)
 - **Classement** : tous les joueurs triés par score total décroissant, avec nombre de donnes jouées et taux de victoire en tant que preneur
 - **Répartition des contrats** : graphique à barres horizontales montrant combien de donnes ont été jouées par type de contrat (Petite, Garde, etc.)
+- **Taux de réussite par contrat** : tableau croisé joueurs × contrats montrant le pourcentage de victoire et le nombre de donnes pour chaque joueur en tant que preneur, par type de contrat. Les cellules sont colorées (vert = bon taux, rouge = faible taux) pour une lecture rapide.
 
 Appuyer sur un joueur dans le classement pour voir ses statistiques détaillées.
 

--- a/frontend/src/__tests__/components/ContractSuccessRateTable.test.tsx
+++ b/frontend/src/__tests__/components/ContractSuccessRateTable.test.tsx
@@ -1,0 +1,70 @@
+import { screen } from "@testing-library/react";
+import ContractSuccessRateTable from "../../components/ContractSuccessRateTable";
+import type { ContractSuccessRatePlayer } from "../../types/api";
+import { Contract } from "../../types/enums";
+import { renderWithProviders } from "../test-utils";
+
+const mockData: ContractSuccessRatePlayer[] = [
+  {
+    color: "#ef4444",
+    contracts: [
+      { contract: Contract.Petite, count: 8, winRate: 75, wins: 6 },
+      { contract: Contract.Garde, count: 4, winRate: 50, wins: 2 },
+    ],
+    id: 1,
+    name: "Alice",
+  },
+  {
+    color: null,
+    contracts: [
+      { contract: Contract.Garde, count: 3, winRate: 100, wins: 3 },
+      { contract: Contract.GardeSans, count: 1, winRate: 0, wins: 0 },
+    ],
+    id: 2,
+    name: "Bob",
+  },
+];
+
+describe("ContractSuccessRateTable", () => {
+  it("renders player names", () => {
+    renderWithProviders(<ContractSuccessRateTable data={mockData} />);
+
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("renders contract column headers", () => {
+    renderWithProviders(<ContractSuccessRateTable data={mockData} />);
+
+    expect(screen.getByText("Petite")).toBeInTheDocument();
+    expect(screen.getByText("Garde")).toBeInTheDocument();
+    expect(screen.getByText("G. Sans")).toBeInTheDocument();
+    expect(screen.getByText("G. Contre")).toBeInTheDocument();
+  });
+
+  it("renders win rate and count for existing contracts", () => {
+    renderWithProviders(<ContractSuccessRateTable data={mockData} />);
+
+    // Alice: Petite 75% (8)
+    expect(screen.getByText("75%")).toBeInTheDocument();
+    expect(screen.getByText("(8)")).toBeInTheDocument();
+
+    // Bob: Garde 100% (3)
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    expect(screen.getByText("(3)")).toBeInTheDocument();
+  });
+
+  it("renders dash for contracts not played", () => {
+    renderWithProviders(<ContractSuccessRateTable data={mockData} />);
+
+    // Alice has no GardeSans/GardeContre, Bob has no Petite/GardeContre
+    const dashes = screen.getAllByText("–");
+    expect(dashes.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("renders empty message when no data", () => {
+    renderWithProviders(<ContractSuccessRateTable data={[]} />);
+
+    expect(screen.getByText("Aucune donnée disponible")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/Stats.test.tsx
+++ b/frontend/src/__tests__/pages/Stats.test.tsx
@@ -18,6 +18,7 @@ const mockStats = {
     { contract: "petite" as const, count: 5, percentage: 50.0 },
     { contract: "garde" as const, count: 5, percentage: 50.0 },
   ],
+  contractSuccessRateByPlayer: [],
   eloEvolution: [] as { history: { date: string; gameId: number; ratingAfter: number }[]; playerColor: string | null; playerId: number; playerName: string }[],
   eloRanking: [
     { eloRating: 1520, gamesPlayed: 5, playerId: 1, playerName: "Alice" },

--- a/frontend/src/components/ContractSuccessRateTable.tsx
+++ b/frontend/src/components/ContractSuccessRateTable.tsx
@@ -1,0 +1,97 @@
+import type { ContractSuccessRatePlayer, PlayerContractEntry } from "../types/api";
+import { Contract } from "../types/enums";
+import PlayerAvatar from "./ui/PlayerAvatar";
+
+interface ContractSuccessRateTableProps {
+  data: ContractSuccessRatePlayer[];
+}
+
+const CONTRACT_COLUMNS: { key: Contract; label: string }[] = [
+  { key: Contract.Petite, label: "Petite" },
+  { key: Contract.Garde, label: "Garde" },
+  { key: Contract.GardeSans, label: "G. Sans" },
+  { key: Contract.GardeContre, label: "G. Contre" },
+];
+
+function getCellColor(winRate: number): string {
+  if (winRate >= 70) return "text-green-500";
+  if (winRate >= 50) return "text-text-primary";
+  if (winRate >= 30) return "text-orange-400";
+  return "text-red-400";
+}
+
+function ContractCell({ entry }: { entry: PlayerContractEntry | undefined }) {
+  if (!entry) {
+    return <span className="text-text-muted">–</span>;
+  }
+
+  return (
+    <div className="flex flex-col items-center">
+      <span className={`text-sm font-semibold ${getCellColor(entry.winRate)}`}>
+        {Math.round(entry.winRate)}%
+      </span>
+      <span className="text-xs text-text-muted">({entry.count})</span>
+    </div>
+  );
+}
+
+export default function ContractSuccessRateTable({ data }: ContractSuccessRateTableProps) {
+  if (data.length === 0) {
+    return (
+      <p className="py-4 text-center text-sm text-text-muted">
+        Aucune donnée disponible
+      </p>
+    );
+  }
+
+  const sorted = [...data].sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <div className="overflow-x-auto rounded-xl bg-surface-elevated">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-surface-border">
+            <th className="px-3 py-2 text-left text-xs font-medium text-text-muted">
+              Joueur
+            </th>
+            {CONTRACT_COLUMNS.map((col) => (
+              <th
+                className="px-2 py-2 text-center text-xs font-medium text-text-muted"
+                key={col.key}
+              >
+                {col.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((player) => {
+            const contractMap = new Map(
+              player.contracts.map((c) => [c.contract, c]),
+            );
+            return (
+              <tr
+                className="border-b border-surface-border last:border-b-0"
+                key={player.id}
+              >
+                <td className="px-3 py-2">
+                  <div className="flex items-center gap-2">
+                    <PlayerAvatar color={player.color} name={player.name} size="sm" />
+                    <span className="font-medium text-text-primary">
+                      {player.name}
+                    </span>
+                  </div>
+                </td>
+                {CONTRACT_COLUMNS.map((col) => (
+                  <td className="px-2 py-2 text-center" key={col.key}>
+                    <ContractCell entry={contractMap.get(col.key)} />
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import ContractDistributionChart from "../components/ContractDistributionChart";
+import ContractSuccessRateTable from "../components/ContractSuccessRateTable";
 import EloRanking from "../components/EloRanking";
 import GlobalEloEvolutionChart from "../components/GlobalEloEvolutionChart";
 import GroupFilter from "../components/GroupFilter";
@@ -111,6 +112,15 @@ export default function Stats() {
         </h2>
         <ContractDistributionChart data={stats.contractDistribution} />
       </section>
+
+      {stats.contractSuccessRateByPlayer.length > 0 && (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold text-text-secondary">
+            Taux de réussite par contrat
+          </h2>
+          <ContractSuccessRateTable data={stats.contractSuccessRateByPlayer} />
+        </section>
+      )}
     </div>
   );
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -22,6 +22,13 @@ export interface EloRankingEntry {
   playerName: string;
 }
 
+export interface ContractSuccessRatePlayer {
+  color: string | null;
+  contracts: PlayerContractEntry[];
+  id: number;
+  name: string;
+}
+
 export interface ContractDistributionEntry {
   contract: Contract;
   count: number;
@@ -62,6 +69,7 @@ export interface GamePlayer {
 export interface GlobalStatistics {
   averageGameDuration: number | null;
   contractDistribution: ContractDistributionEntry[];
+  contractSuccessRateByPlayer: ContractSuccessRatePlayer[];
   eloEvolution: EloEvolutionPlayer[];
   eloRanking: EloRankingEntry[];
   leaderboard: LeaderboardEntry[];


### PR DESCRIPTION
## Summary

- Nouveau tableau croisé joueurs × contrats sur la page Statistiques globales
- Affiche le taux de réussite (%) et le nombre de donnes pour chaque joueur en tant que preneur, par type de contrat (Petite, Garde, G. Sans, G. Contre)
- Cellules colorées selon le taux de réussite (vert ≥ 70%, orange 30-49%, rouge < 30%)
- Backend: nouvelle méthode `getContractSuccessRateByPlayer()` dans `StatisticsService`, exposée via `contractSuccessRateByPlayer` dans `/api/statistics`
- Supporte le filtrage par groupe de joueurs

fixes #87

## Test plan

- [x] Backend: 132 tests (130 existants + 2 nouveaux), 0 erreurs
- [x] Frontend: 52 fichiers, 417 tests (412 existants + 5 nouveaux), 0 erreurs
- [x] PHPStan: aucune erreur
- [x] TypeScript: aucune erreur
- [ ] Manuel: visiter `/stats`, vérifier le tableau avec des donnes existantes