### PR TITLE
fix(ui): move dark mode toggle to home page next to help button

### DIFF
--- a/frontend/src/__tests__/components/Layout.test.tsx
+++ b/frontend/src/__tests__/components/Layout.test.tsx
@@ -1,14 +1,8 @@
 import { screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import Layout from "../../components/Layout";
 import { renderWithProviders } from "../test-utils";
 
 describe("Layout", () => {
-  beforeEach(() => {
-    localStorage.clear();
-    document.documentElement.classList.remove("dark");
-  });
-
   it("renders the bottom navigation", () => {
     renderWithProviders(<Layout />);
 
@@ -26,33 +20,5 @@ describe("Layout", () => {
     renderWithProviders(<Layout />);
 
     expect(screen.queryByRole("link", { name: /aide/i })).not.toBeInTheDocument();
-  });
-
-  it("renders a theme toggle button", () => {
-    renderWithProviders(<Layout />);
-
-    const toggle = screen.getByRole("button", { name: /thème/i });
-    expect(toggle).toBeInTheDocument();
-  });
-
-  it("toggles dark mode when clicking the theme button", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<Layout />);
-
-    const toggle = screen.getByRole("button", { name: /thème/i });
-    await user.click(toggle);
-
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
-  });
-
-  it("toggles back to light mode on second click", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<Layout />);
-
-    const toggle = screen.getByRole("button", { name: /thème/i });
-    await user.click(toggle);
-    await user.click(toggle);
-
-    expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 });

--- a/frontend/src/__tests__/pages/Home.test.tsx
+++ b/frontend/src/__tests__/pages/Home.test.tsx
@@ -336,4 +336,36 @@ describe("Home page", () => {
     const sessionsHeading = screen.getByText("Sessions récentes");
     expect(sessionsHeading.closest("div")).toContainElement(helpLink);
   });
+
+  it("renders a theme toggle button", () => {
+    setupMocks();
+    renderWithProviders(<Home />);
+
+    expect(screen.getByRole("button", { name: /thème/i })).toBeInTheDocument();
+  });
+
+  it("toggles dark mode when clicking the theme button", async () => {
+    setupMocks();
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    renderWithProviders(<Home />);
+
+    const toggle = screen.getByRole("button", { name: /thème/i });
+    await userEvent.click(toggle);
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("toggles back to light mode on second click", async () => {
+    setupMocks();
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    renderWithProviders(<Home />);
+
+    const toggle = screen.getByRole("button", { name: /thème/i });
+    await userEvent.click(toggle);
+    await userEvent.click(toggle);
+
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
 });

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,27 +1,9 @@
-import { Moon, Sun } from "lucide-react";
 import { Outlet } from "react-router-dom";
-import { useTheme } from "../hooks/useTheme";
 import BottomNav from "./BottomNav";
 
 export default function Layout() {
-  const { isDark, toggle } = useTheme();
-
   return (
     <div className="min-h-screen bg-surface-secondary pb-16 text-text-primary lg:pb-20">
-      <header className="flex justify-end gap-1 p-2 lg:mx-auto lg:max-w-4xl">
-        <button
-          aria-label="Changer de thème"
-          className="rounded-lg p-1.5 text-text-secondary hover:bg-surface-tertiary"
-          onClick={toggle}
-          type="button"
-        >
-          {isDark ? (
-            <Sun className="size-5 lg:size-6" />
-          ) : (
-            <Moon className="size-5 lg:size-6" />
-          )}
-        </button>
-      </header>
       <main className="animate-fade-in lg:mx-auto lg:max-w-4xl">
         <Outlet />
       </main>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,9 +1,10 @@
-import { CircleHelp } from "lucide-react";
+import { CircleHelp, Moon, Sun } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import PlayerSelector from "../components/PlayerSelector";
 import SessionList from "../components/SessionList";
 import { useCreateSession } from "../hooks/useCreateSession";
+import { useTheme } from "../hooks/useTheme";
 import type { Session } from "../types/api";
 
 const REQUIRED_PLAYERS = 5;
@@ -21,6 +22,7 @@ export default function Home() {
   const [selectedPlayerIds, setSelectedPlayerIds] = useState<number[]>([]);
   const createSession = useCreateSession();
   const navigate = useNavigate();
+  const { isDark, toggle } = useTheme();
 
   const motivationalMessage = useMemo(
     () => MOTIVATIONAL_MESSAGES[Math.floor(Math.random() * MOTIVATIONAL_MESSAGES.length)],
@@ -46,13 +48,27 @@ export default function Home() {
           <h2 className="text-2xl font-bold text-text-primary">
             Sessions récentes
           </h2>
-          <Link
-            aria-label="Aide"
-            className="rounded-lg p-1.5 text-text-secondary hover:bg-surface-tertiary"
-            to="/aide"
-          >
-            <CircleHelp className="size-5 lg:size-6" />
-          </Link>
+          <div className="flex gap-1">
+            <button
+              aria-label="Changer de thème"
+              className="rounded-lg p-1.5 text-text-secondary hover:bg-surface-tertiary"
+              onClick={toggle}
+              type="button"
+            >
+              {isDark ? (
+                <Sun className="size-5 lg:size-6" />
+              ) : (
+                <Moon className="size-5 lg:size-6" />
+              )}
+            </button>
+            <Link
+              aria-label="Aide"
+              className="rounded-lg p-1.5 text-text-secondary hover:bg-surface-tertiary"
+              to="/aide"
+            >
+              <CircleHelp className="size-5 lg:size-6" />
+            </Link>
+          </div>
         </div>
         <SessionList />
       </section>


### PR DESCRIPTION
## Résumé

- Déplace le bouton dark mode du header global (Layout) vers la page d'accueil, à côté du bouton d'aide
- Supprime le header vide du Layout qui prenait de l'espace vertical inutilement

fixes #84

## Test plan

- [ ] Vérifier que le toggle dark mode apparaît sur la page d'accueil à côté de l'icône d'aide
- [ ] Vérifier que le toggle n'apparaît plus sur les autres pages (session, stats)
- [ ] Vérifier que le changement de thème fonctionne toujours correctement
- [ ] Vérifier que le contenu n'est plus poussé vers le bas

🤖 Generated with [Claude Code](https://claude.com/claude-code)