### PR TITLE
feat(session): légende filtrable pour le graphique d'évolution des scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **Légende du graphique d'évolution des scores** : le graphique de la page session affiche désormais des chips filtrables permettant d'identifier et de masquer/afficher chaque joueur. Les couleurs des courbes correspondent aux couleurs d'avatar personnalisées des joueurs (ou à la couleur par défaut).
+
 ### Changed
+
+- **Graphique ELO global** : les chips de filtrage des joueurs sont remplacées par un menu déroulant « Joueurs » avec indicateurs de couleur, plus adapté quand le nombre de joueurs est élevé. Les couleurs utilisent désormais les 10 couleurs d'avatar (au lieu de 5) et sont basées sur `playerId % 10`.
 
 - **Session — menu overflow** : toutes les actions du header de session (récap, QR code, modifier les joueurs, changer le groupe, terminer/réouvrir) sont regroupées dans un menu « ⋮ » (overflow) à droite du titre. Le header passe à une seule ligne (titre + menu). Nouveau composant UI réutilisable `OverflowMenu` et nouvelle modale `ChangeGroupModal`.
 

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -685,7 +685,7 @@ Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.m
 - Métriques clés : total de donnes, de sessions, durée moyenne par donne et temps de jeu total (si disponible)
 - Classement (`Leaderboard`) trié par score total décroissant
 - Classement ELO (`EloRanking`) trié par rating décroissant (masqué si aucune donnée)
-- Évolution ELO (`GlobalEloEvolutionChart`) — graphique multi-lignes avec filtrage par joueur via chips (masqué si aucune donnée)
+- Évolution ELO (`GlobalEloEvolutionChart`) — graphique multi-lignes avec filtrage par joueur via menu déroulant (masqué si aucune donnée)
 - Répartition des contrats (`ContractDistributionChart`) en barres horizontales
 - Taux de réussite par contrat (`ContractSuccessRateTable`) — tableau croisé joueurs × contrats (masqué si aucune donnée)
 - Navigation vers le détail d'un joueur au clic (propage le filtre groupe via `?group=`)
@@ -1187,14 +1187,14 @@ Graphique linéaire (Recharts) affichant l'évolution du rating ELO d'un joueur 
 
 **Fichier** : `components/GlobalEloEvolutionChart.tsx`
 
-Graphique linéaire multi-joueurs (Recharts) affichant l'évolution du rating ELO de tous les joueurs avec ligne de référence y=1500, filtrage par joueur via chips cliquables et `connectNulls` pour les joueurs absents de certaines donnes.
+Graphique linéaire multi-joueurs (Recharts) affichant l'évolution du rating ELO de tous les joueurs avec ligne de référence y=1500, filtrage par joueur via un **menu déroulant** avec indicateurs de couleur et `connectNulls` pour les joueurs absents de certaines donnes.
 
 | Prop | Type | Description |
 |------|------|-------------|
 | `data` | `EloEvolutionPlayer[]` | *requis* — données d'évolution par joueur (depuis l'API globale) |
 
 **Fonctionnalités** :
-- Chips colorées pour chaque joueur — clic pour masquer/afficher la ligne
+- Menu déroulant « Joueurs » avec indicateurs de couleur — clic pour masquer/afficher la ligne
 - Couleur personnalisée du joueur (si définie), sinon fallback sur la palette avatar
 - Tooltip montrant les ratings de tous les joueurs visibles
 - Ligne de référence à y=1500
@@ -1205,7 +1205,7 @@ Graphique linéaire multi-joueurs (Recharts) affichant l'évolution du rating EL
 
 **Fichier** : `components/ScoreEvolutionChart.tsx`
 
-Graphique linéaire (Recharts) affichant l'évolution des scores cumulés de tous les joueurs au fil des donnes. Une ligne par joueur, colorée par couleur d'avatar.
+Graphique linéaire (Recharts) affichant l'évolution des scores cumulés de tous les joueurs au fil des donnes. Une ligne par joueur, colorée par couleur d'avatar personnalisée (ou couleur par défaut basée sur `playerId % 10`). Des **chips colorées** au-dessus du graphique permettent de masquer/afficher chaque joueur individuellement.
 
 | Prop | Type | Description |
 |------|------|-------------|

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -362,7 +362,7 @@ L'écran de détail d'un joueur affiche :
 
 ### Évolution des scores en session
 
-Depuis l'**écran de session**, un graphique d'évolution apparaît automatiquement dès qu'au moins **2 donnes sont terminées**. Il montre les scores cumulés de chaque joueur au fil des donnes, avec une ligne de couleur par joueur.
+Depuis l'**écran de session**, un graphique d'évolution apparaît automatiquement dès qu'au moins **2 donnes sont terminées**. Il montre les scores cumulés de chaque joueur au fil des donnes, avec une ligne de couleur par joueur. Des **chips colorées** au-dessus du graphique permettent d'identifier chaque joueur et de masquer/afficher ses scores en cliquant dessus. Les couleurs correspondent aux couleurs d'avatar des joueurs.
 
 ---
 
@@ -409,7 +409,7 @@ Le système ELO fournit un **classement dynamique** qui tient compte du niveau d
 
 ### Où le trouver
 
-- **Page Statistiques** : une section **« Classement ELO »** affiche tous les joueurs triés par rating décroissant, avec un code couleur (vert > 1500, rouge < 1500). En dessous, un graphique **« Évolution ELO »** montre les courbes de tous les joueurs sur un même graphique, avec des chips cliquables pour masquer/afficher chaque joueur. La ligne de référence à 1500 sert de repère.
+- **Page Statistiques** : une section **« Classement ELO »** affiche tous les joueurs triés par rating décroissant, avec un code couleur (vert > 1500, rouge < 1500). En dessous, un graphique **« Évolution ELO »** montre les courbes de tous les joueurs sur un même graphique, avec un menu déroulant « Joueurs » pour masquer/afficher chaque joueur. La ligne de référence à 1500 sert de repère.
 - **Statistiques d'un joueur** : la carte « ELO » affiche le rating actuel, et un graphique **« Évolution ELO »** montre la courbe au fil des donnes
 
 ### Recalcul et suppression

--- a/frontend/src/__tests__/components/GlobalEloEvolutionChart.test.tsx
+++ b/frontend/src/__tests__/components/GlobalEloEvolutionChart.test.tsx
@@ -104,16 +104,28 @@ describe("GlobalEloEvolutionChart", () => {
     expect(container.innerHTML).toBe("");
   });
 
-  it("renders player filter chips", () => {
+  it("renders a dropdown button for player filter", () => {
     render(<GlobalEloEvolutionChart data={sampleData} />);
+
+    expect(screen.getByRole("button", { name: /joueurs/i })).toBeInTheDocument();
+  });
+
+  it("shows player list when dropdown is opened", async () => {
+    const user = userEvent.setup();
+    render(<GlobalEloEvolutionChart data={sampleData} />);
+
+    await user.click(screen.getByRole("button", { name: /joueurs/i }));
 
     expect(screen.getByText("Alice")).toBeInTheDocument();
     expect(screen.getByText("Bob")).toBeInTheDocument();
   });
 
-  it("toggles player visibility when chip is clicked", async () => {
+  it("toggles player visibility when clicking in dropdown", async () => {
     const user = userEvent.setup();
     render(<GlobalEloEvolutionChart data={sampleData} />);
+
+    // Open dropdown
+    await user.click(screen.getByRole("button", { name: /joueurs/i }));
 
     // Click Alice to hide her
     await user.click(screen.getByText("Alice"));
@@ -125,5 +137,16 @@ describe("GlobalEloEvolutionChart", () => {
     // Click again to show
     await user.click(screen.getByText("Alice"));
     expect(screen.getByTestId("line-Alice")).toBeInTheDocument();
+  });
+
+  it("displays color indicator for each player in dropdown", async () => {
+    const user = userEvent.setup();
+    render(<GlobalEloEvolutionChart data={sampleData} />);
+
+    await user.click(screen.getByRole("button", { name: /joueurs/i }));
+
+    // Alice has custom color #ef4444
+    const aliceIndicator = screen.getByTestId("color-indicator-Alice");
+    expect(aliceIndicator).toHaveStyle({ backgroundColor: "#ef4444" });
   });
 });

--- a/frontend/src/components/ScoreEvolutionChart.tsx
+++ b/frontend/src/components/ScoreEvolutionChart.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from "react";
 import {
   Line,
   LineChart,
@@ -14,12 +15,17 @@ interface ScoreEvolutionChartProps {
   players: GamePlayer[];
 }
 
-const playerColors = [
+const avatarColors = [
   "var(--color-avatar-0)",
   "var(--color-avatar-1)",
   "var(--color-avatar-2)",
   "var(--color-avatar-3)",
   "var(--color-avatar-4)",
+  "var(--color-avatar-5)",
+  "var(--color-avatar-6)",
+  "var(--color-avatar-7)",
+  "var(--color-avatar-8)",
+  "var(--color-avatar-9)",
 ];
 
 export function computeScoreEvolution(
@@ -42,46 +48,101 @@ export function computeScoreEvolution(
 }
 
 export default function ScoreEvolutionChart({ games, players }: ScoreEvolutionChartProps) {
+  const [hiddenPlayers, setHiddenPlayers] = useState<Set<number>>(new Set());
+
+  const playerColorMap = useMemo(
+    () =>
+      new Map(
+        players.map((p) => [
+          p.id,
+          p.color ?? avatarColors[p.id % avatarColors.length],
+        ]),
+      ),
+    [players],
+  );
+
   const data = computeScoreEvolution(games, players);
 
   if (data.length < 2) {
     return null;
   }
 
+  const visiblePlayers = players.filter((p) => !hiddenPlayers.has(p.id));
+
+  const togglePlayer = (playerId: number) => {
+    setHiddenPlayers((prev) => {
+      const next = new Set(prev);
+      if (next.has(playerId)) {
+        next.delete(playerId);
+      } else {
+        next.add(playerId);
+      }
+      return next;
+    });
+  };
+
   return (
-    <div className="h-64 lg:h-96">
-      <ResponsiveContainer height="100%" width="100%">
-        <LineChart data={data} margin={{ bottom: 0, left: 0, right: 16, top: 8 }}>
-          <XAxis
-            dataKey="position"
-            tick={{ fill: "var(--color-text-muted)", fontSize: 11 }}
-          />
-          <YAxis
-            tick={{ fill: "var(--color-text-muted)", fontSize: 11 }}
-            width={45}
-          />
-          <Tooltip
-            contentStyle={{
-              background: "var(--color-surface-elevated)",
-              border: "1px solid var(--color-surface-border)",
-              borderRadius: "0.5rem",
-              color: "var(--color-text-primary)",
-            }}
-            labelFormatter={(label) => `Donne ${label}`}
-          />
-          <ReferenceLine stroke="var(--color-text-muted)" strokeDasharray="3 3" y={0} />
-          {players.map((player, index) => (
-            <Line
-              dataKey={player.name}
-              dot={{ fill: playerColors[index % playerColors.length], r: 3 }}
+    <div>
+      <div className="mb-3 flex flex-wrap gap-2">
+        {players.map((player) => {
+          const color = playerColorMap.get(player.id)!;
+          const isHidden = hiddenPlayers.has(player.id);
+          return (
+            <button
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-opacity ${
+                isHidden ? "opacity-40" : ""
+              }`}
               key={player.id}
-              stroke={playerColors[index % playerColors.length]}
-              strokeWidth={2}
-              type="monotone"
+              onClick={() => togglePlayer(player.id)}
+              style={{
+                backgroundColor: isHidden ? undefined : color,
+                border: `2px solid ${color}`,
+                color: isHidden ? color : "#fff",
+              }}
+              type="button"
+            >
+              {player.name}
+            </button>
+          );
+        })}
+      </div>
+      <div className="h-64 lg:h-96">
+        <ResponsiveContainer height="100%" width="100%">
+          <LineChart data={data} margin={{ bottom: 0, left: 0, right: 16, top: 8 }}>
+            <XAxis
+              dataKey="position"
+              tick={{ fill: "var(--color-text-muted)", fontSize: 11 }}
             />
-          ))}
-        </LineChart>
-      </ResponsiveContainer>
+            <YAxis
+              tick={{ fill: "var(--color-text-muted)", fontSize: 11 }}
+              width={45}
+            />
+            <Tooltip
+              contentStyle={{
+                background: "var(--color-surface-elevated)",
+                border: "1px solid var(--color-surface-border)",
+                borderRadius: "0.5rem",
+                color: "var(--color-text-primary)",
+              }}
+              labelFormatter={(label) => `Donne ${label}`}
+            />
+            <ReferenceLine stroke="var(--color-text-muted)" strokeDasharray="3 3" y={0} />
+            {visiblePlayers.map((player) => {
+              const color = playerColorMap.get(player.id)!;
+              return (
+                <Line
+                  dataKey={player.name}
+                  dot={{ fill: color, r: 3 }}
+                  key={player.id}
+                  stroke={color}
+                  strokeWidth={2}
+                  type="monotone"
+                />
+              );
+            })}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Résumé

- **ScoreEvolutionChart** (page session) : ajout de chips filtrables au-dessus du graphique pour masquer/afficher chaque joueur. Les couleurs correspondent aux avatars personnalisés (ou couleur par défaut basée sur `playerId % 10`).
- **GlobalEloEvolutionChart** (page stats) : remplacement des chips par un menu déroulant « Joueurs » avec indicateurs de couleur, plus adapté à un grand nombre de joueurs.
- Les deux graphiques utilisent désormais les 10 couleurs d'avatar (au lieu de 5).

fixes #112