### PR TITLE
feat(badges): masquer les badges verrouillés par défaut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 ### Changed
 
 - **Statistiques — sections en menu déroulant** : les pages de statistiques globales et par joueur affichent désormais les métriques clés et le classement en haut, suivis d'un menu déroulant permettant de choisir la section détaillée à afficher. Réduit le scroll sur mobile.
+- **Badges — masquer les verrouillés par défaut** : seuls les badges débloqués sont affichés. Un bouton « Voir les X restants » permet de révéler les badges verrouillés à la demande.
 
 ### Fixed
 

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -784,7 +784,7 @@ Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.m
 
 **Fichier** : `components/BadgeGrid.tsx`
 
-Grille affichant les 15 badges d'un joueur (débloqués en premier avec date, verrouillés grisés ensuite). Titre avec compteur (X/Y).
+Grille affichant les badges d'un joueur. Seuls les badges débloqués sont visibles par défaut ; un bouton toggle permet de révéler/masquer les badges verrouillés. Titre avec compteur (X/Y).
 
 | Prop | Type | Description |
 |------|------|-------------|
@@ -794,7 +794,8 @@ Grille affichant les 15 badges d'un joueur (débloqués en premier avec date, ve
 - Header « Badges (X/Y) » avec compteur débloqués/total
 - Grille 3 colonnes mobile, 5 colonnes TV (`grid-cols-3 lg:grid-cols-5`)
 - Badges débloqués : fond élevé, emoji + nom + date au format `fr-FR`
-- Badges verrouillés : fond secondaire, `opacity-40`
+- Badges verrouillés masqués par défaut ; bouton « Voir les X restants » / « Masquer les badges verrouillés » pour toggle
+- Badges verrouillés (quand révélés) : fond secondaire, `opacity-40`
 
 ### `BadgeUnlockedModal`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -362,7 +362,7 @@ L'écran de détail d'un joueur affiche :
 - **Groupes** (toujours visibles) : badges cliquables vers la page du groupe
 - **Menu déroulant de section** : un sélecteur permet de choisir la section affichée parmi :
   - **Records personnels** (par défaut) : meilleur score, pire score, série de victoires consécutives (en tant que preneur), meilleure session (total de points dans une session) et plus grand écart (différence entre points réalisés et points requis). Chaque record indique la date, le contrat (si applicable) et un lien vers la session concernée.
-  - **Badges** : grille des badges débloqués et verrouillés
+  - **Badges** : grille des badges débloqués (verrouillés masqués par défaut, révélables via un bouton)
   - **Répartition des rôles** : barre visuelle montrant combien de fois le joueur a été preneur, partenaire ou défenseur
   - **Contrats** : graphique à barres des contrats joués en tant que preneur
   - **Évolution des scores** : graphique linéaire des 50 derniers scores
@@ -534,7 +534,8 @@ Quand un ou plusieurs badges sont débloqués, une **modale** s'affiche automati
 
 Sur la page **Statistiques d'un joueur** (accessible via Stats → clic sur un joueur), une section **Badges (X/15)** affiche :
 - Les badges **débloqués** en premier, avec leur date d'obtention
-- Les badges **verrouillés** grisés ensuite, avec leur condition de déblocage
+- Un bouton **« Voir les X restants »** pour révéler les badges verrouillés (grisés, avec leur condition de déblocage)
+- Un clic sur **« Masquer les badges verrouillés »** les cache à nouveau
 
 ---
 

--- a/frontend/src/components/BadgeGrid.tsx
+++ b/frontend/src/components/BadgeGrid.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { Badge } from "../types/api";
 
 interface BadgeGridProps {
@@ -5,9 +6,11 @@ interface BadgeGridProps {
 }
 
 export default function BadgeGrid({ badges }: BadgeGridProps) {
+  const [showLocked, setShowLocked] = useState(false);
+
   const unlocked = badges.filter((b) => b.unlockedAt !== null);
   const locked = badges.filter((b) => b.unlockedAt === null);
-  const sorted = [...unlocked, ...locked];
+  const displayed = showLocked ? [...unlocked, ...locked] : unlocked;
 
   return (
     <section>
@@ -15,7 +18,7 @@ export default function BadgeGrid({ badges }: BadgeGridProps) {
         Badges ({unlocked.length}/{badges.length})
       </h2>
       <div className="grid grid-cols-3 gap-2 lg:grid-cols-5">
-        {sorted.map((badge) => (
+        {displayed.map((badge) => (
           <div
             key={badge.type}
             className={`flex flex-col items-center gap-1 rounded-xl p-3 text-center ${
@@ -36,6 +39,17 @@ export default function BadgeGrid({ badges }: BadgeGridProps) {
           </div>
         ))}
       </div>
+      {locked.length > 0 && (
+        <button
+          className="mt-3 w-full rounded-lg bg-surface-secondary py-2 text-xs font-medium text-text-secondary"
+          onClick={() => setShowLocked((prev) => !prev)}
+          type="button"
+        >
+          {showLocked
+            ? "Masquer les badges verrouillés"
+            : `Voir les ${locked.length} restant${locked.length > 1 ? "s" : ""}`}
+        </button>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- Seuls les badges débloqués sont affichés par défaut dans `BadgeGrid`
- Bouton toggle « Voir les X restants » / « Masquer les badges verrouillés » pour révéler/cacher les badges verrouillés
- Tests mis à jour (10 tests couvrant le nouveau comportement)

fixes #117