### PR TITLE
fix(backend): valider que le preneur appartient à la session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Fixed
 
+- **Validation du preneur à la création de donne** : le preneur est désormais vérifié comme appartenant à la session, à la fois dans le processeur de création (POST) et dans le validateur de complétion (PATCH). Auparavant, seul le partenaire était validé.
 - **APP_SECRET retiré du contrôle de version** : le secret applicatif n'est plus stocké en dur dans `.env.dev` (fichier tracké par Git). Le fichier `.env.dev` a été supprimé et `.env` contient désormais une valeur placeholder. Les environnements de développement doivent utiliser `.env.dev.local` (gitignored) pour surcharger le secret.
 
 ### Changed

--- a/backend/src/State/GameCreateProcessor.php
+++ b/backend/src/State/GameCreateProcessor.php
@@ -49,6 +49,12 @@ final readonly class GameCreateProcessor implements ProcessorInterface
             throw new UnprocessableEntityHttpException('Une donne est déjà en cours pour cette session.');
         }
 
+        // Vérifier que le preneur appartient à la session
+        $taker = $data->getTaker();
+        if (!$session->getPlayers()->contains($taker)) {
+            throw new UnprocessableEntityHttpException(\sprintf('Le joueur "%s" n\'appartient pas à la session.', $taker->getName()));
+        }
+
         // Position auto-incrémentée
         $maxPosition = $this->gameRepository->getMaxPositionForSession($session);
 

--- a/backend/src/Validator/PlayersBelongToSessionValidator.php
+++ b/backend/src/Validator/PlayersBelongToSessionValidator.php
@@ -24,6 +24,15 @@ class PlayersBelongToSessionValidator extends ConstraintValidator
         $session = $value->getSession();
         $sessionPlayers = $session->getPlayers();
 
+        // Vérifier le preneur
+        $taker = $value->getTaker();
+        if (!$sessionPlayers->contains($taker)) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ player }}', $taker->getName())
+                ->atPath('taker')
+                ->addViolation();
+        }
+
         // Vérifier le partenaire
         $partner = $value->getPartner();
         if (null !== $partner && !$sessionPlayers->contains($partner)) {

--- a/backend/tests/Api/GameApiTest.php
+++ b/backend/tests/Api/GameApiTest.php
@@ -534,6 +534,22 @@ class GameApiTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(422);
     }
 
+    public function testTakerMustBelongToSession(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $outsidePlayer = $this->createPlayer('Frank');
+
+        $this->client->request('POST', $this->getIri($session).'/games', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => [
+                'contract' => 'petite',
+                'taker' => $this->getIri($outsidePlayer),
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
     public function testPartnerMustBelongToSession(): void
     {
         $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');


### PR DESCRIPTION
## Résumé

- Ajout de la validation du preneur dans `GameCreateProcessor` (POST) : rejet 422 si le preneur n'appartient pas à la session
- Ajout de la validation du preneur dans `PlayersBelongToSessionValidator` (PATCH) : défense en profondeur
- Ajout du test `testTakerMustBelongToSession` dans `GameApiTest`

fixes #136