### PR TITLE
fix(backend): valider oudlers (0-3) et points (0-91) sur Game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Fixed
 
+- **Validation des oudlers et points** : les champs `oudlers` (0–3) et `points` (0–91) sont désormais validés par des contraintes `Range`. Un garde-fou dans `ScoreCalculator` empêche aussi les valeurs hors bornes de provoquer une `UndefinedArrayKeyException`.
 - **Validation du preneur à la création de donne** : le preneur est désormais vérifié comme appartenant à la session, à la fois dans le processeur de création (POST) et dans le validateur de complétion (PATCH). Auparavant, seul le partenaire était validé.
 - **APP_SECRET retiré du contrôle de version** : le secret applicatif n'est plus stocké en dur dans `.env.dev` (fichier tracké par Git). Le fichier `.env.dev` a été supprimé et `.env` contient désormais une valeur placeholder. Les environnements de développement doivent utiliser `.env.dev.local` (gitignored) pour surcharger le secret.
 

--- a/backend/src/Entity/Game.php
+++ b/backend/src/Entity/Game.php
@@ -27,6 +27,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
@@ -91,6 +92,7 @@ class Game
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $createdAt;
 
+    #[Assert\Range(max: 3, min: 0)]
     #[Groups(['game:read', 'game:complete', 'session:detail'])]
     #[ORM\Column(nullable: true)]
     private ?int $oudlers = null;
@@ -112,6 +114,7 @@ class Game
     #[ORM\Column(enumType: Side::class)]
     private Side $poigneeOwner = Side::None;
 
+    #[Assert\Range(max: 91, min: 0)]
     #[Groups(['game:read', 'game:complete', 'session:detail'])]
     #[ORM\Column(nullable: true)]
     private ?float $points = null;

--- a/backend/src/Service/Scoring/ScoreCalculator.php
+++ b/backend/src/Service/Scoring/ScoreCalculator.php
@@ -159,6 +159,6 @@ class ScoreCalculator
 
     private function getRequiredPoints(int $oudlers): int
     {
-        return self::REQUIRED_POINTS[$oudlers];
+        return self::REQUIRED_POINTS[$oudlers] ?? throw new \InvalidArgumentException(\sprintf('Nombre d\'oudlers invalide : %d', $oudlers));
     }
 }

--- a/backend/tests/Api/GameApiTest.php
+++ b/backend/tests/Api/GameApiTest.php
@@ -550,6 +550,110 @@ class GameApiTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(422);
     }
 
+    public function testRejectsOudlersOutOfRange(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+
+        $game = new Game();
+        $game->setContract(Contract::Petite);
+        $game->setPosition(1);
+        $game->setSession($session);
+        $game->setTaker($players[0]);
+        $this->em->persist($game);
+        $this->em->flush();
+
+        // oudlers = -1 → 422
+        $this->client->request('PATCH', '/api/games/'.$game->getId(), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => [
+                'oudlers' => -1,
+                'points' => 45,
+                'status' => 'completed',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRejectsOudlersAboveMax(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+
+        $game = new Game();
+        $game->setContract(Contract::Petite);
+        $game->setPosition(1);
+        $game->setSession($session);
+        $game->setTaker($players[0]);
+        $this->em->persist($game);
+        $this->em->flush();
+
+        // oudlers = 4 → 422
+        $this->client->request('PATCH', '/api/games/'.$game->getId(), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => [
+                'oudlers' => 4,
+                'points' => 45,
+                'status' => 'completed',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRejectsPointsBelowMin(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+
+        $game = new Game();
+        $game->setContract(Contract::Petite);
+        $game->setPosition(1);
+        $game->setSession($session);
+        $game->setTaker($players[0]);
+        $this->em->persist($game);
+        $this->em->flush();
+
+        // points = -1 → 422
+        $this->client->request('PATCH', '/api/games/'.$game->getId(), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => [
+                'oudlers' => 2,
+                'points' => -1,
+                'status' => 'completed',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRejectsPointsAboveMax(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+
+        $game = new Game();
+        $game->setContract(Contract::Petite);
+        $game->setPosition(1);
+        $game->setSession($session);
+        $game->setTaker($players[0]);
+        $this->em->persist($game);
+        $this->em->flush();
+
+        // points = 92 → 422
+        $this->client->request('PATCH', '/api/games/'.$game->getId(), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => [
+                'oudlers' => 2,
+                'points' => 92,
+                'status' => 'completed',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
     public function testPartnerMustBelongToSession(): void
     {
         $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');

--- a/backend/tests/Service/ScoreCalculatorTest.php
+++ b/backend/tests/Service/ScoreCalculatorTest.php
@@ -510,6 +510,22 @@ class ScoreCalculatorTest extends TestCase
     }
 
     // ---------------------------------------------------------------
+    // Garde-fou : oudlers invalide
+    // ---------------------------------------------------------------
+
+    public function testThrowsOnInvalidOudlersCount(): void
+    {
+        $game = $this->createGame(
+            contract: Contract::Petite,
+            oudlers: 5,
+            points: 45,
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->calculator->compute($game);
+    }
+
+    // ---------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Ajoute `#[Assert\Range(min: 0, max: 3)]` sur `Game::$oudlers` et `#[Assert\Range(min: 0, max: 91)]` sur `Game::$points`
- Ajoute un garde-fou dans `ScoreCalculator::getRequiredPoints()` pour lever une `InvalidArgumentException` au lieu d'un `UndefinedArrayKeyException`
- 5 nouveaux tests (4 API + 1 unit)

## Test plan

- [x] `testRejectsOudlersOutOfRange` — PATCH avec oudlers=-1 → 422
- [x] `testRejectsOudlersAboveMax` — PATCH avec oudlers=4 → 422
- [x] `testRejectsPointsBelowMin` — PATCH avec points=-1 → 422
- [x] `testRejectsPointsAboveMax` — PATCH avec points=92 → 422
- [x] `testThrowsOnInvalidOudlersCount` — ScoreCalculator avec oudlers=5 → InvalidArgumentException
- [x] Suite complète : 160 tests, 594 assertions OK
- [x] PHPStan : aucune erreur
- [x] PHP CS Fixer : aucun correctif nécessaire

fixes #137