### PR TITLE
fix(backend): ajouter Assert\Length sur Player:: et PlayerGroup::

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Fixed
 
+- **Validation de longueur des noms** : ajout de contraintes `Assert\Length` sur `Player::$name` (max 50) et `PlayerGroup::$name` (max 100) pour retourner une erreur 422 au lieu d'une exception Doctrine 500 lorsque le nom dépasse la taille de la colonne en base.
 - **Validation des oudlers et points** : les champs `oudlers` (0–3) et `points` (0–91) sont désormais validés par des contraintes `Range`. Un garde-fou dans `ScoreCalculator` empêche aussi les valeurs hors bornes de provoquer une `UndefinedArrayKeyException`.
 - **Validation du preneur à la création de donne** : le preneur est désormais vérifié comme appartenant à la session, à la fois dans le processeur de création (POST) et dans le validateur de complétion (PATCH). Auparavant, seul le partenaire était validé.
 - **APP_SECRET retiré du contrôle de version** : le secret applicatif n'est plus stocké en dur dans `.env.dev` (fichier tracké par Git). Le fichier `.env.dev` a été supprimé et `.env` contient désormais une valeur placeholder. Les environnements de développement doivent utiliser `.env.dev.local` (gitignored) pour surcharger le secret.

--- a/backend/src/Entity/Player.php
+++ b/backend/src/Entity/Player.php
@@ -58,6 +58,7 @@ class Player
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private ?\DateTimeImmutable $lastActivityAt = null;
 
+    #[Assert\Length(max: 50)]
     #[Assert\NotBlank]
     #[Groups(['game:read', 'player-group:detail', 'player:read', 'player:write', 'score-entry:read', 'session:detail', 'session:read'])]
     #[ORM\Column(length: 50, unique: true)]

--- a/backend/src/Entity/PlayerGroup.php
+++ b/backend/src/Entity/PlayerGroup.php
@@ -46,6 +46,7 @@ class PlayerGroup
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $createdAt;
 
+    #[Assert\Length(max: 100)]
     #[Assert\NotBlank]
     #[Groups(['player-group:read', 'player-group:write', 'player:read', 'session:read'])]
     #[ORM\Column(length: 100, unique: true)]

--- a/backend/tests/Api/PlayerApiTest.php
+++ b/backend/tests/Api/PlayerApiTest.php
@@ -53,6 +53,16 @@ class PlayerApiTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(422);
     }
 
+    public function testCreatePlayerWithNameTooLong(): void
+    {
+        $this->client->request('POST', '/api/players', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => ['name' => str_repeat('A', 51)],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
     public function testUpdatePlayerName(): void
     {
         $player = $this->createPlayer('Alice');

--- a/backend/tests/Api/PlayerGroupApiTest.php
+++ b/backend/tests/Api/PlayerGroupApiTest.php
@@ -57,6 +57,16 @@ class PlayerGroupApiTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(422);
     }
 
+    public function testCreateGroupWithNameTooLong(): void
+    {
+        $this->client->request('POST', '/api/player-groups', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => ['name' => str_repeat('A', 101)],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
     public function testGetGroupDetail(): void
     {
         $alice = $this->createPlayer('Alice');


### PR DESCRIPTION
## Summary

- Ajout de `Assert\Length(max: 50)` sur `Player::$name` et `Assert\Length(max: 100)` sur `PlayerGroup::$name`
- Les noms dépassant la taille de la colonne DB retournent désormais une 422 au lieu d'une exception Doctrine 500
- Tests ajoutés pour valider les deux cas

fixes #138