### PR TITLE
fix(backend): désactiver la doc API Platform en prod et plafonner la pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Fixed
 
+- **Documentation API désactivée en production** : la doc Swagger/OpenAPI et l'entrypoint API Platform sont désormais désactivés en environnement de production pour ne pas exposer la structure de l'API.
+- **Pagination max par page** : ajout d'un plafond de 50 éléments par page (`pagination_maximum_items_per_page`) et activation du contrôle client (`?itemsPerPage=N`) pour empêcher les requêtes abusives demandant des milliers d'éléments.
 - **Session PHP désactivée en production** : la session PHP (`PHPSESSID`) est désormais désactivée en environnement de production, conformément à l'architecture stateless de l'API.
 - **Validation de longueur des noms** : ajout de contraintes `Assert\Length` sur `Player::$name` (max 50) et `PlayerGroup::$name` (max 100) pour retourner une erreur 422 au lieu d'une exception Doctrine 500 lorsque le nom dépasse la taille de la colonne en base.
 - **Validation des oudlers et points** : les champs `oudlers` (0–3) et `points` (0–91) sont désormais validés par des contraintes `Range`. Un garde-fou dans `ScoreCalculator` empêche aussi les valeurs hors bornes de provoquer une `UndefinedArrayKeyException`.

--- a/backend/config/packages/api_platform.yaml
+++ b/backend/config/packages/api_platform.yaml
@@ -5,18 +5,22 @@ api_platform:
     defaults:
         cache_headers:
             # En-têtes qui influencent la représentation renvoyée.
-            # Objectif : éviter qu’un cache partage une réponse entre formats/utilisateurs différents.
+            # Objectif : éviter qu'un cache partage une réponse entre formats/utilisateurs différents.
             vary: ['Content-Type', 'Authorization', 'Accept']
         extra_properties:
             # Active des erreurs conformes à RFC 7807 (application/problem+json) côté API Platform.
             rfc_7807_compliant_errors: true
-            # "PUT standard" : un PUT remplace la ressource (plutôt qu’un merge partiel).
+            # "PUT standard" : un PUT remplace la ressource (plutôt qu'un merge partiel).
             # Utile pour un comportement REST plus prévisible.
             standard_put: true
+        # Autorise le client à choisir le nombre d'éléments par page (via ?itemsPerPage=N).
+        pagination_client_items_per_page: true
+        # Plafonne le nombre d'éléments par page côté client.
+        pagination_maximum_items_per_page: 50
         # API "stateless" : pas de session Symfony (auth typiquement par token).
         stateless: true
 
-    # Formats d’entrée/sortie exposés par l’API.
+    # Formats d'entrée/sortie exposés par l'API.
     formats:
         # JSON-LD (Hydra) : format principal pour la doc/clients JSON-LD.
         jsonld: ['application/ld+json']
@@ -24,3 +28,8 @@ api_platform:
     # Métadonnées affichées dans la documentation (OpenAPI / Swagger UI).
     title: 'Tarot API'
     version: '1.0.0'
+
+when@prod:
+    api_platform:
+        enable_docs: false
+        enable_entrypoint: false


### PR DESCRIPTION
## Résumé

- Désactive la documentation Swagger/OpenAPI et l'entrypoint API Platform en production (`enable_docs: false`, `enable_entrypoint: false` sous `when@prod`)
- Active le contrôle client du nombre d'éléments par page (`pagination_client_items_per_page: true`) et plafonne à 50 (`pagination_maximum_items_per_page: 50`)
- Ajoute un test backend vérifiant que `?itemsPerPage=100` est plafonné à 50 résultats

fixes #141