### PR TITLE
fix(backend): supprimer le side-effect badge du GET statistiques

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 - **Rate limiting API** : les endpoints sous `/api/` sont désormais limités à 60 requêtes par minute par IP (sliding window). En cas de dépassement, l'API retourne une réponse 429 avec un corps JSON conforme RFC 7807. Les en-têtes `X-RateLimit-Limit`, `X-RateLimit-Remaining` et `Retry-After` sont inclus dans les réponses.
 
+### Changed
+
+- **Badges : suppression du side-effect sur GET statistiques** : le check de badges a été retiré de l'endpoint `GET /api/statistics/players/{id}` (side-effect d'écriture sur une route de lecture). Les badges sont désormais vérifiés uniquement lors de la complétion d'une donne (`GameCompleteProcessor`) et de l'ajout d'étoiles.
+
 ### Fixed
 
 - **Documentation API désactivée en production** : la doc Swagger/OpenAPI et l'entrypoint API Platform sont désormais désactivés en environnement de production pour ne pas exposer la structure de l'API.

--- a/backend/src/Controller/StatisticsController.php
+++ b/backend/src/Controller/StatisticsController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Repository\PlayerRepository;
-use App\Service\BadgeChecker;
 use App\Service\GlobalStatisticsService;
 use App\Service\PlayerStatisticsService;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -42,14 +41,12 @@ readonly class StatisticsController
     }
 
     #[Route('/api/statistics/players/{id}', methods: ['GET'])]
-    public function player(int $id, Request $request, BadgeChecker $badgeChecker, PlayerStatisticsService $playerStatisticsService): JsonResponse
+    public function player(int $id, Request $request, PlayerStatisticsService $playerStatisticsService): JsonResponse
     {
         $player = $this->playerRepository->find($id);
         if (null === $player) {
             throw new NotFoundHttpException('Joueur introuvable.');
         }
-
-        $badgeChecker->checkAndAwardForPlayer($player);
 
         $playerGroupId = $request->query->has('playerGroup')
             ? (int) $request->query->get('playerGroup')

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -541,7 +541,6 @@ L'application propose un système de **15 badges** (succès) que les joueurs dé
 Les badges sont vérifiés automatiquement :
 - À chaque **donne complétée** (pour tous les joueurs de la session)
 - À chaque **étoile ajoutée** (pour tous les joueurs de la session)
-- À la **consultation des statistiques** d'un joueur (attribution rétroactive)
 
 ### Notification
 


### PR DESCRIPTION
## Résumé

- Supprime l'appel `badgeChecker->checkAndAwardForPlayer()` dans `StatisticsController::player()` (endpoint `GET /api/statistics/players/{id}`), qui créait un side-effect d'écriture (attribution de badges) sur un endpoint de lecture
- Les badges étaient déjà vérifiés dans `GameCompleteProcessor::process()` à chaque donne complétée — cette vérification redondante violait la sémantique HTTP et empêchait le cache
- Ajout de 2 tests : un vérifiant l'absence de side-effect sur le GET, un vérifiant que les badges sont bien attribués à la complétion de donne
- Mise à jour du guide utilisateur (retrait de la mention d'attribution rétroactive à la consultation des statistiques)

fixes #142