### PR TITLE
refactor(backend): identifier les joueurs par ID dans EloCalculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Changed
 
+- **EloCalculator : identification par ID** : `EloCalculator::compute()` utilise désormais les IDs des joueurs comme clés du tableau `$ratings` (au lieu des noms), rendant le mapping plus robuste et simplifiant `GameCompleteProcessor`.
 - **Services `final readonly`** : `ScoreCalculator`, `EloCalculator`, `GlobalStatisticsService`, `PlayerStatisticsService` et `SessionSummaryService` sont désormais `final readonly`, alignés sur la convention des autres services du projet.
 - **Badges : suppression du side-effect sur GET statistiques** : le check de badges a été retiré de l'endpoint `GET /api/statistics/players/{id}` (side-effect d'écriture sur une route de lecture). Les badges sont désormais vérifiés uniquement lors de la complétion d'une donne (`GameCompleteProcessor`) et de l'ajout d'étoiles.
 

--- a/backend/src/State/GameCompleteProcessor.php
+++ b/backend/src/State/GameCompleteProcessor.php
@@ -78,20 +78,20 @@ final readonly class GameCompleteProcessor implements ProcessorInterface
     {
         $players = $game->getSession()->getPlayers()->toArray();
 
+        /** @var array<int, int> $ratings */
         $ratings = [];
+        $playersById = [];
         foreach ($players as $player) {
-            $ratings[$player->getName()] = $player->getEloRating();
+            $id = $player->getId();
+            \assert(null !== $id);
+            $playersById[$id] = $player;
+            $ratings[$id] = $player->getEloRating();
         }
 
         $results = $this->eloCalculator->compute($game, $ratings);
 
-        $playersByName = [];
-        foreach ($players as $player) {
-            $playersByName[$player->getName()] = $player;
-        }
-
         foreach ($results as $result) {
-            $player = $playersByName[$result['playerName']];
+            $player = $playersById[$result['playerId']];
             $player->setEloRating($result['ratingAfter']);
 
             $history = new EloHistory();

--- a/backend/tests/Service/EloCalculatorTest.php
+++ b/backend/tests/Service/EloCalculatorTest.php
@@ -27,9 +27,14 @@ class EloCalculatorTest extends TestCase
         $this->calculator = new EloCalculator();
 
         $this->players = [];
+        $id = 1;
         foreach (['Alice', 'Bob', 'Charlie', 'Diana', 'Eve'] as $name) {
             $player = new Player();
             $player->setName($name);
+
+            $ref = new \ReflectionProperty(Player::class, 'id');
+            $ref->setValue($player, $id++);
+
             $this->players[$name] = $player;
         }
 
@@ -103,7 +108,7 @@ class EloCalculatorTest extends TestCase
         );
 
         $ratings = $this->buildRatings(1500);
-        $ratings[$this->players['Alice']->getName()] = 1800;
+        $ratings[$this->players['Alice']->getId()] = 1800;
 
         $result = $this->calculator->compute($game, $ratings);
         $indexed = $this->indexByPlayerName($result);
@@ -125,7 +130,7 @@ class EloCalculatorTest extends TestCase
         );
 
         $ratings = $this->buildRatings(1500);
-        $ratings[$this->players['Alice']->getName()] = 1200;
+        $ratings[$this->players['Alice']->getId()] = 1200;
 
         $result = $this->calculator->compute($game, $ratings);
         $indexed = $this->indexByPlayerName($result);
@@ -175,11 +180,11 @@ class EloCalculatorTest extends TestCase
         );
 
         $ratings = [
-            'Alice' => 1600,
-            'Bob' => 1450,
-            'Charlie' => 1550,
-            'Diana' => 1400,
-            'Eve' => 1500,
+            $this->players['Alice']->getId() => 1600,
+            $this->players['Bob']->getId() => 1450,
+            $this->players['Charlie']->getId() => 1550,
+            $this->players['Diana']->getId() => 1400,
+            $this->players['Eve']->getId() => 1500,
         ];
 
         $result = $this->calculator->compute($game, $ratings);
@@ -215,13 +220,13 @@ class EloCalculatorTest extends TestCase
     }
 
     /**
-     * @return array<string, int>
+     * @return array<int, int>
      */
     private function buildRatings(int $rating): array
     {
         $ratings = [];
-        foreach ($this->players as $name => $player) {
-            $ratings[$name] = $rating;
+        foreach ($this->players as $player) {
+            $ratings[$player->getId()] = $rating;
         }
 
         return $ratings;
@@ -258,9 +263,9 @@ class EloCalculatorTest extends TestCase
     }
 
     /**
-     * @param list<array{playerId: int|null, playerName: string, ratingAfter: int, ratingBefore: int, ratingChange: int}> $result
+     * @param list<array{playerId: int, playerName: string, ratingAfter: int, ratingBefore: int, ratingChange: int}> $result
      *
-     * @return array<string, array{playerId: int|null, playerName: string, ratingAfter: int, ratingBefore: int, ratingChange: int}>
+     * @return array<string, array{playerId: int, playerName: string, ratingAfter: int, ratingBefore: int, ratingChange: int}>
      */
     private function indexByPlayerName(array $result): array
     {


### PR DESCRIPTION
## Résumé

- `EloCalculator::compute()` utilise désormais les IDs des joueurs (au lieu des noms) comme clés du tableau `$ratings`, rendant le mapping plus robuste
- `GameCompleteProcessor::computeEloRatings()` simplifié : un seul tableau `$playersById` remplace le double mapping par nom
- Le type de retour `playerId` passe de `int|null` à `int` (les joueurs sont toujours persistés)
- Tests unitaires mis à jour pour utiliser des IDs via Reflection

fixes #144