### PR TITLE
feat(frontend): lister les badges et conditions dans la page d'aide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Badges dans l'aide** : la page d'aide (`/aide`) affiche désormais la liste complète des 15 badges disponibles, regroupés par catégorie (Progression, Performance, Fun, Social), avec leur icône, nom et condition d'obtention.
 - **Rate limiting API** : les endpoints sous `/api/` sont désormais limités à 60 requêtes par minute par IP (sliding window). En cas de dépassement, l'API retourne une réponse 429 avec un corps JSON conforme RFC 7807. Les en-têtes `X-RateLimit-Limit`, `X-RateLimit-Remaining` et `Retry-After` sont inclus dans les réponses.
 
 ### Changed

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -629,7 +629,7 @@ Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.m
 
 **Fonctionnalités** :
 - Section « Installation » toujours visible
-- 12 sections en accordéon dépliable (`AccordionSection`, composant local)
+- 13 sections en accordéon dépliable (`AccordionSection`, composant local) dont une section « Badges » listant les 15 badges par catégorie (données statiques dans `BADGE_CATEGORIES`)
 - Lien vers le dépôt GitHub en bas de page
 - Bouton retour vers l'accueil
 - Accessible via l'icône `CircleHelp` sur la page d'accueil (`Home.tsx`), à droite du titre « Sessions récentes »

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -553,6 +553,10 @@ Sur la page **Statistiques d'un joueur** (accessible via Stats → clic sur un j
 - Un bouton **« Voir les X restants »** pour révéler les badges verrouillés (grisés, avec leur condition de déblocage)
 - Un clic sur **« Masquer les badges verrouillés »** les cache à nouveau
 
+### Liste complète dans l'aide
+
+La page **Aide** (`/aide`) contient une section **Badges** listant l'ensemble des 15 badges, regroupés par catégorie (Progression, Performance, Fun, Social), avec pour chacun l'icône, le nom et la condition d'obtention. Cette section est accessible sans nécessiter de données joueur.
+
 ---
 
 ## Thème sombre

--- a/frontend/src/__tests__/pages/Help.test.tsx
+++ b/frontend/src/__tests__/pages/Help.test.tsx
@@ -30,6 +30,7 @@ describe("Help", () => {
       "Consulter les statistiques",
       "Système d'étoiles",
       "Classement ELO",
+      "Badges",
       "Utilisation sur Smart TV",
       "Thème sombre",
       "Règles de calcul des scores",
@@ -79,6 +80,51 @@ describe("Help", () => {
 
     await user.click(conceptsButton);
     expect(conceptsButton).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("displays all badges with emoji, name and condition when expanded", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Help />);
+
+    const badgesButton = screen.getByRole("button", { name: /Badges/ });
+    await user.click(badgesButton);
+
+    const expectedBadges = [
+      { emoji: "🎮", label: "Première donne", description: "Jouer sa première donne" },
+      { emoji: "💯", label: "Centurion", description: "Jouer 100 donnes" },
+      { emoji: "🔟", label: "Habitué", description: "Jouer 10 sessions" },
+      { emoji: "🔥", label: "Inarrêtable", description: "5 victoires consécutives comme preneur" },
+      { emoji: "👑", label: "Premier Chelem", description: "Réussir un Chelem annoncé" },
+      { emoji: "⚔️", label: "Kamikaze", description: "Tenter une Garde Contre" },
+      { emoji: "🎯", label: "Sans filet", description: "Réussir une Garde Sans" },
+      { emoji: "🃏", label: "Petit malin", description: "Réussir 5 Petits au bout" },
+      { emoji: "🛡️", label: "Muraille", description: "10 victoires en défense d'affilée" },
+      { emoji: "📈", label: "Comeback", description: "Remonter de dernier à premier en une session" },
+      { emoji: "💀", label: "Lanterne rouge", description: "Finir dernier 5 fois" },
+      { emoji: "⭐", label: "Collectionneur d'étoiles", description: "Recevoir 10 étoiles" },
+      { emoji: "⏰", label: "Marathon", description: "Jouer une session de plus de 3 heures" },
+      { emoji: "🌙", label: "Noctambule", description: "Jouer une donne après minuit" },
+      { emoji: "👥", label: "Sociable", description: "Jouer avec 10 joueurs différents" },
+    ];
+
+    for (const badge of expectedBadges) {
+      expect(screen.getByText(badge.emoji)).toBeInTheDocument();
+      expect(screen.getByText(badge.label)).toBeInTheDocument();
+      expect(screen.getByText(badge.description)).toBeInTheDocument();
+    }
+  });
+
+  it("groups badges by category", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Help />);
+
+    const badgesButton = screen.getByRole("button", { name: /Badges/ });
+    await user.click(badgesButton);
+
+    expect(screen.getByText("Progression")).toBeInTheDocument();
+    expect(screen.getByText("Performance")).toBeInTheDocument();
+    expect(screen.getByText("Fun")).toBeInTheDocument();
+    expect(screen.getByText("Social")).toBeInTheDocument();
   });
 
   it("renders a link to the GitHub repository", () => {

--- a/frontend/src/pages/Help.tsx
+++ b/frontend/src/pages/Help.tsx
@@ -2,6 +2,45 @@ import { ArrowLeft, ChevronDown, ExternalLink } from "lucide-react";
 import { type ReactNode, useId, useState } from "react";
 import { Link } from "react-router-dom";
 
+// Source : backend/src/Enum/BadgeType.php — mettre à jour si les badges changent.
+const BADGE_CATEGORIES: { category: string; badges: { description: string; emoji: string; label: string }[] }[] = [
+  {
+    category: "Progression",
+    badges: [
+      { description: "Jouer sa première donne", emoji: "🎮", label: "Première donne" },
+      { description: "Jouer 100 donnes", emoji: "💯", label: "Centurion" },
+      { description: "Jouer 10 sessions", emoji: "🔟", label: "Habitué" },
+    ],
+  },
+  {
+    category: "Performance",
+    badges: [
+      { description: "5 victoires consécutives comme preneur", emoji: "🔥", label: "Inarrêtable" },
+      { description: "Réussir un Chelem annoncé", emoji: "👑", label: "Premier Chelem" },
+      { description: "Tenter une Garde Contre", emoji: "⚔️", label: "Kamikaze" },
+      { description: "Réussir une Garde Sans", emoji: "🎯", label: "Sans filet" },
+      { description: "Réussir 5 Petits au bout", emoji: "🃏", label: "Petit malin" },
+      { description: "10 victoires en défense d'affilée", emoji: "🛡️", label: "Muraille" },
+    ],
+  },
+  {
+    category: "Fun",
+    badges: [
+      { description: "Remonter de dernier à premier en une session", emoji: "📈", label: "Comeback" },
+      { description: "Finir dernier 5 fois", emoji: "💀", label: "Lanterne rouge" },
+      { description: "Recevoir 10 étoiles", emoji: "⭐", label: "Collectionneur d'étoiles" },
+    ],
+  },
+  {
+    category: "Social",
+    badges: [
+      { description: "Jouer une session de plus de 3 heures", emoji: "⏰", label: "Marathon" },
+      { description: "Jouer une donne après minuit", emoji: "🌙", label: "Noctambule" },
+      { description: "Jouer avec 10 joueurs différents", emoji: "👥", label: "Sociable" },
+    ],
+  },
+];
+
 function AccordionSection({
   children,
   title,
@@ -341,6 +380,27 @@ export default function Help() {
           Visible dans les statistiques globales et sur la fiche de chaque
           joueur.
         </p>
+      </AccordionSection>
+
+      <AccordionSection title="Badges">
+        <div className="space-y-4">
+          {BADGE_CATEGORIES.map(({ badges, category }) => (
+            <div key={category}>
+              <h3 className="font-medium text-text-primary">{category}</h3>
+              <div className="mt-2 space-y-2">
+                {badges.map((badge) => (
+                  <div key={badge.label} className="flex items-start gap-3">
+                    <span className="text-xl">{badge.emoji}</span>
+                    <div>
+                      <span className="text-sm font-medium text-text-primary">{badge.label}</span>
+                      <p className="text-xs text-text-muted">{badge.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
       </AccordionSection>
 
       <AccordionSection title="Utilisation sur Smart TV">


### PR DESCRIPTION
## Résumé

Ajout d'une section « Badges » dans la page d'aide (`/aide`) listant les 15 badges disponibles, regroupés par catégorie (Progression, Performance, Fun, Social), avec pour chacun l'icône, le nom et la condition d'obtention.

- Données statiques dans une constante `BADGE_CATEGORIES` (pas d'appel API nécessaire)
- Section en accordéon, cohérente avec les autres sections de la page
- Tests unitaires couvrant le contenu des badges et les catégories

fixes #166