### PR TITLE
feat(frontend): remplacer window.confirm par une modale (clôture sessions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Changed
 
+- **Clôture de sessions (groupe)** : le bouton « Clôturer les sessions » sur la page d'un groupe ouvre désormais une modale de confirmation au lieu d'un `window.confirm()` natif du navigateur, pour une expérience cohérente avec le reste de l'application.
 - **Nettoyage backend** : suppression des annotations `@throws` trompeuses sur `SessionController`, extraction du `applyGroupFilter` dupliqué dans un trait partagé `GroupFilterTrait`, et correction du risque N+1 sur `Session::getLastPlayedAt()` (la valeur est désormais hydratée depuis SQL par les providers).
 - **Index composites** : ajout d'index composites sur `game(session_id, status)`, `score_entry(game_id, player_id)` et `star_event(session_id, player_id)` pour optimiser les requêtes fréquentes.
 - **BadgeChecker : requêtes en batch** : `BadgeChecker::checkAndAward()` pré-charge désormais toutes les statistiques en batch (~12 requêtes) au lieu de requêtes individuelles par joueur × badge (~75+ requêtes). Introduit `BadgeCheckContext` comme value object portant les données pré-chargées.

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -682,6 +682,7 @@ Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.m
 - Modification du nom inline (bouton crayon)
 - Liste des membres avec avatar et bouton de retrait
 - Ajout de membres via modale `PlayerSelector`
+- Clôture des sessions ouvertes du groupe avec modale de confirmation
 - Suppression du groupe avec confirmation
 - Bouton retour vers `/groups`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -275,7 +275,7 @@ Sur l'écran récapitulatif, le bouton **« Partager »** génère une image du 
 
 ### Clôturer toutes les sessions d'un groupe
 
-Depuis la page d'un **groupe de joueurs** (menu Groupes → sélectionner un groupe), le bouton **« Clôturer les sessions »** ferme en un clic toutes les sessions ouvertes du groupe.
+Depuis la page d'un **groupe de joueurs** (menu Groupes → sélectionner un groupe), le bouton **« Clôturer les sessions »** ouvre une modale de confirmation. Après validation, toutes les sessions ouvertes du groupe sont clôturées.
 
 ---
 

--- a/frontend/src/__tests__/pages/GroupDetail.test.tsx
+++ b/frontend/src/__tests__/pages/GroupDetail.test.tsx
@@ -1,0 +1,132 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GroupDetail from "../../pages/GroupDetail";
+import * as useCloseGroupSessionsModule from "../../hooks/useCloseGroupSessions";
+import * as useDeletePlayerGroupModule from "../../hooks/useDeletePlayerGroup";
+import * as usePlayerGroupModule from "../../hooks/usePlayerGroup";
+import * as useUpdatePlayerGroupModule from "../../hooks/useUpdatePlayerGroup";
+import { renderWithProviders } from "../test-utils";
+
+vi.mock("../../hooks/useCloseGroupSessions");
+vi.mock("../../hooks/useDeletePlayerGroup");
+vi.mock("../../hooks/usePlayerGroup");
+vi.mock("../../hooks/useUpdatePlayerGroup");
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    useParams: () => ({ id: "1" }),
+  };
+});
+
+const mockGroup = {
+  id: 1,
+  name: "Groupe A",
+  players: [
+    { color: null, id: 1, name: "Alice" },
+    { color: null, id: 2, name: "Bob" },
+  ],
+};
+
+function makeMutationResult(overrides?: Record<string, unknown>) {
+  return {
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    failureReason: null,
+    isError: false,
+    isIdle: true,
+    isPaused: false,
+    isPending: false,
+    isSuccess: false,
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    status: "idle" as const,
+    submittedAt: 0,
+    variables: undefined,
+    ...overrides,
+  };
+}
+
+function setupMocks(overrides?: {
+  closeGroupSessions?: Record<string, unknown>;
+  group?: typeof mockGroup | undefined;
+  isPending?: boolean;
+}) {
+  const closeMutate = vi.fn();
+  const closeResult = makeMutationResult({ mutate: closeMutate, ...overrides?.closeGroupSessions });
+
+  vi.mocked(usePlayerGroupModule.usePlayerGroup).mockReturnValue({
+    group: overrides?.group !== undefined ? overrides.group : mockGroup,
+    isPending: overrides?.isPending ?? false,
+  } as ReturnType<typeof usePlayerGroupModule.usePlayerGroup>);
+
+  vi.mocked(useCloseGroupSessionsModule.useCloseGroupSessions).mockReturnValue(
+    closeResult as unknown as ReturnType<typeof useCloseGroupSessionsModule.useCloseGroupSessions>,
+  );
+
+  vi.mocked(useUpdatePlayerGroupModule.useUpdatePlayerGroup).mockReturnValue(
+    makeMutationResult() as unknown as ReturnType<typeof useUpdatePlayerGroupModule.useUpdatePlayerGroup>,
+  );
+
+  vi.mocked(useDeletePlayerGroupModule.useDeletePlayerGroup).mockReturnValue(
+    makeMutationResult() as unknown as ReturnType<typeof useDeletePlayerGroupModule.useDeletePlayerGroup>,
+  );
+
+  return { closeMutate };
+}
+
+describe("GroupDetail — close sessions modal", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens a confirmation modal when clicking 'Clôturer les sessions'", async () => {
+    setupMocks();
+    renderWithProviders(<GroupDetail />);
+
+    await userEvent.click(screen.getByRole("button", { name: /clôturer les sessions/i }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveTextContent("Clôturer les sessions");
+    expect(dialog).toHaveTextContent(/clôturer toutes les sessions ouvertes/i);
+  });
+
+  it("closes the modal when clicking 'Annuler'", async () => {
+    setupMocks();
+    renderWithProviders(<GroupDetail />);
+
+    await userEvent.click(screen.getByRole("button", { name: /clôturer les sessions/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Annuler" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("calls closeGroupSessions.mutate when confirming", async () => {
+    const { closeMutate } = setupMocks();
+    renderWithProviders(<GroupDetail />);
+
+    await userEvent.click(screen.getByRole("button", { name: /clôturer les sessions/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Confirmer" }));
+
+    expect(closeMutate).toHaveBeenCalledWith(1, expect.anything());
+  });
+
+  it("does not call mutate if modal is cancelled", async () => {
+    const { closeMutate } = setupMocks();
+    renderWithProviders(<GroupDetail />);
+
+    await userEvent.click(screen.getByRole("button", { name: /clôturer les sessions/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Annuler" }));
+
+    expect(closeMutate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/GroupDetail.tsx
+++ b/frontend/src/pages/GroupDetail.tsx
@@ -24,6 +24,7 @@ export default function GroupDetail() {
   const [editName, setEditName] = useState("");
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [selectedPlayerIds, setSelectedPlayerIds] = useState<number[]>([]);
+  const [closeModalOpen, setCloseModalOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
   const startEditName = useCallback(() => {
@@ -167,13 +168,7 @@ export default function GroupDetail() {
       <button
         className="rounded-lg bg-amber-100 px-3 py-2 text-sm font-medium text-amber-800 transition-colors hover:bg-amber-200 disabled:opacity-50 dark:bg-amber-900/30 dark:text-amber-200 dark:hover:bg-amber-700"
         disabled={closeGroupSessions.isPending}
-        onClick={() => {
-          if (window.confirm("Voulez-vous clôturer toutes les sessions ouvertes de ce groupe ?")) {
-            closeGroupSessions.mutate(groupId, {
-              onSuccess: () => toast("Sessions terminées"),
-            });
-          }
-        }}
+        onClick={() => setCloseModalOpen(true)}
         type="button"
       >
         {closeGroupSessions.isPending ? "Clôture en cours…" : "Clôturer les sessions"}
@@ -261,6 +256,43 @@ export default function GroupDetail() {
           >
             Enregistrer
           </button>
+        </div>
+      </Modal>
+
+      {/* Modal confirmation clôture */}
+      <Modal
+        onClose={() => setCloseModalOpen(false)}
+        open={closeModalOpen}
+        title="Clôturer les sessions"
+      >
+        <div className="flex flex-col gap-4">
+          <p className="text-text-secondary">
+            Voulez-vous clôturer toutes les sessions ouvertes de ce groupe ?
+          </p>
+          <div className="flex gap-3">
+            <button
+              className="flex-1 rounded-lg border border-surface-border px-4 py-2 font-medium text-text-primary transition-colors hover:bg-surface-secondary"
+              onClick={() => setCloseModalOpen(false)}
+              type="button"
+            >
+              Annuler
+            </button>
+            <button
+              className="flex-1 rounded-lg bg-amber-500 px-4 py-2 font-medium text-white transition-colors hover:bg-amber-600 disabled:opacity-50"
+              disabled={closeGroupSessions.isPending}
+              onClick={() => {
+                closeGroupSessions.mutate(groupId, {
+                  onSuccess: () => {
+                    toast("Sessions terminées");
+                    setCloseModalOpen(false);
+                  },
+                });
+              }}
+              type="button"
+            >
+              Confirmer
+            </button>
+          </div>
         </div>
       </Modal>
 


### PR DESCRIPTION
## Summary
- Remplace le `window.confirm()` natif par une modale applicative sur la page de détail d'un groupe pour le bouton « Clôturer les sessions »
- La modale suit le même pattern que la modale de suppression de groupe existante (boutons Annuler / Confirmer, couleur amber)
- Ajout de tests unitaires pour GroupDetail (ouverture/fermeture modale, appel mutation, annulation)

fixes #167

## Test plan
- [x] Tests unitaires GroupDetail : 4/4 pass
- [x] TypeScript : clean
- [ ] Tester manuellement : cliquer « Clôturer les sessions » → modale s'ouvre → Annuler ferme → Confirmer appelle l'API

🤖 Generated with [Claude Code](https://claude.com/claude-code)