### PR TITLE
feat(frontend): rendre toute la ligne cliquable dans la liste des joueurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 - **Badges dans l'aide** : la page d'aide (`/aide`) affiche désormais la liste complète des 15 badges disponibles, regroupés par catégorie (Progression, Performance, Fun, Social), avec leur icône, nom et condition d'obtention.
 - **Rate limiting API** : les endpoints sous `/api/` sont désormais limités à 60 requêtes par minute par IP (sliding window). En cas de dépassement, l'API retourne une réponse 429 avec un corps JSON conforme RFC 7807. Les en-têtes `X-RateLimit-Limit`, `X-RateLimit-Remaining` et `Retry-After` sont inclus dans les réponses.
+- **Liste des joueurs cliquable** : toute la ligne d'un joueur est désormais cliquable pour accéder directement à sa page de statistiques.
 
 ### Changed
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -61,6 +61,8 @@ Accessible via l'onglet **Joueurs** dans la barre de navigation basse.
 
 Chaque joueur affiche sous son nom sa **dernière activité** en format relatif (« Aujourd'hui », « Hier », « Il y a 3 jours »…). Si le joueur n'a encore participé à aucune donne, la date de création est affichée à la place.
 
+**Appuyer sur la ligne d'un joueur** (avatar, nom ou date) pour accéder directement à sa page de statistiques détaillées.
+
 ### Ajouter un joueur
 
 1. Appuyer sur le bouton **+** (en bas à droite)

--- a/frontend/src/__tests__/pages/Players.test.tsx
+++ b/frontend/src/__tests__/pages/Players.test.tsx
@@ -342,6 +342,26 @@ describe("Players page", () => {
     expect(screen.getByText("17/01/2025")).toBeInTheDocument();
   });
 
+  it("navigates to player stats when clicking on a player row", () => {
+    setupMocks();
+    renderWithProviders(<Players />);
+
+    const aliceLink = screen.getByRole("link", { name: /Alice/ });
+    expect(aliceLink).toHaveAttribute("href", "/stats/player/1");
+
+    const bobLink = screen.getByRole("link", { name: /Bob/ });
+    expect(bobLink).toHaveAttribute("href", "/stats/player/2");
+  });
+
+  it("does not navigate when clicking the edit button", async () => {
+    setupMocks();
+    renderWithProviders(<Players />);
+
+    // Edit button should not be inside a link
+    const editButtons = screen.getAllByRole("button", { name: /Modifier/i });
+    expect(editButtons[0].closest("a")).toBeNull();
+  });
+
   it("renders inactive player with visual treatment", () => {
     const playersWithInactive = [
       { active: true, createdAt: "2025-01-15T10:00:00+00:00", id: 1, lastActivityAt: null, name: "Alice", playerGroups: [] },

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -1,5 +1,6 @@
 import { Pencil, Plus, UserX } from "lucide-react";
 import { type FormEvent, useCallback, useState } from "react";
+import { Link } from "react-router-dom";
 import { EmptyState, FAB, Modal, PlayerAvatar, SearchInput, Spinner } from "../components/ui";
 import { useCreatePlayer } from "../hooks/useCreatePlayer";
 import { usePlayerGroups } from "../hooks/usePlayerGroups";
@@ -147,41 +148,46 @@ export default function Players() {
         <ul className="flex flex-col gap-2">
           {players.map((player) => (
             <li
-              className="flex items-center gap-3 rounded-lg bg-surface-secondary p-3"
+              className="flex items-center gap-1 rounded-lg bg-surface-secondary"
               key={player.id}
             >
-              <PlayerAvatar
-                className={player.active ? "" : "opacity-50"}
-                color={player.color}
-                name={player.name}
-                playerId={player.id}
-              />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <p
-                    className={`truncate font-medium ${
-                      player.active
-                        ? "text-text-primary"
-                        : "text-text-muted line-through"
-                    }`}
-                  >
-                    {player.name}
+              <Link
+                className="flex min-w-0 flex-1 items-center gap-3 rounded-l-lg p-3 transition-colors hover:bg-surface-tertiary/50"
+                to={`/stats/player/${player.id}`}
+              >
+                <PlayerAvatar
+                  className={player.active ? "" : "opacity-50"}
+                  color={player.color}
+                  name={player.name}
+                  playerId={player.id}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <p
+                      className={`truncate font-medium ${
+                        player.active
+                          ? "text-text-primary"
+                          : "text-text-muted line-through"
+                      }`}
+                    >
+                      {player.name}
+                    </p>
+                    {!player.active && (
+                      <span className="shrink-0 rounded bg-surface-tertiary px-1.5 py-0.5 text-xs text-text-muted">
+                        Inactif
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-text-muted">
+                    {player.lastActivityAt
+                      ? formatRelativeDate(player.lastActivityAt)
+                      : new Date(player.createdAt).toLocaleDateString("fr-FR")}
                   </p>
-                  {!player.active && (
-                    <span className="shrink-0 rounded bg-surface-tertiary px-1.5 py-0.5 text-xs text-text-muted">
-                      Inactif
-                    </span>
-                  )}
                 </div>
-                <p className="text-xs text-text-muted">
-                  {player.lastActivityAt
-                    ? formatRelativeDate(player.lastActivityAt)
-                    : new Date(player.createdAt).toLocaleDateString("fr-FR")}
-                </p>
-              </div>
+              </Link>
               <button
                 aria-label={`Modifier ${player.name}`}
-                className="flex min-h-10 min-w-10 items-center justify-center rounded-full text-text-secondary transition-colors hover:bg-surface-tertiary"
+                className="mr-1 flex min-h-10 min-w-10 items-center justify-center rounded-full text-text-secondary transition-colors hover:bg-surface-tertiary"
                 onClick={() => openEditModal(player)}
                 type="button"
               >


### PR DESCRIPTION
## Résumé

- Entoure l'avatar et les informations du joueur dans un `<Link>` vers `/stats/player/:id`, rendant toute la zone principale de la ligne cliquable
- Le bouton d'édition (crayon) reste indépendant et ne déclenche pas la navigation

## Tests

- 2 nouveaux tests : navigation via lien + bouton édition hors du lien
- 25/25 tests Players passent

fixes #168