### PR TITLE
perf(frontend): lazy-load des pages et code-splitting recharts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Changed
 
+- **Lazy-load et code-splitting** : toutes les pages (sauf Home) sont désormais chargées en lazy-loading via `React.lazy()`, et `recharts` est isolé dans un chunk dédié via `manualChunks`. Cela réduit la taille du bundle initial et supprime le warning Vite sur les chunks > 500 kB.
 - **Clôture de sessions (groupe)** : le bouton « Clôturer les sessions » sur la page d'un groupe ouvre désormais une modale de confirmation au lieu d'un `window.confirm()` natif du navigateur, pour une expérience cohérente avec le reste de l'application.
 - **Nettoyage backend** : suppression des annotations `@throws` trompeuses sur `SessionController`, extraction du `applyGroupFilter` dupliqué dans un trait partagé `GroupFilterTrait`, et correction du risque N+1 sur `Session::getLastPlayedAt()` (la valeur est désormais hydratée depuis SQL par les providers).
 - **Index composites** : ajout d'index composites sur `game(session_id, status)`, `score_entry(game_id, player_id)` et `star_event(session_id, player_id)` pour optimiser les requêtes fréquentes.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,16 +4,17 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Layout from "./components/Layout";
 import { ThemeProvider } from "./hooks/useTheme";
 import { ToastProvider } from "./hooks/useToast";
-import GroupDetail from "./pages/GroupDetail";
-import Groups from "./pages/Groups";
-import Help from "./pages/Help";
 import Home from "./pages/Home";
-import Players from "./pages/Players";
-import PlayerStats from "./pages/PlayerStats";
-import SessionPage from "./pages/SessionPage";
-import SessionSummary from "./pages/SessionSummary";
-import Stats from "./pages/Stats";
 import ToastContainer from "./components/ui/ToastContainer";
+
+const GroupDetail = lazy(() => import("./pages/GroupDetail"));
+const Groups = lazy(() => import("./pages/Groups"));
+const Help = lazy(() => import("./pages/Help"));
+const Players = lazy(() => import("./pages/Players"));
+const PlayerStats = lazy(() => import("./pages/PlayerStats"));
+const SessionPage = lazy(() => import("./pages/SessionPage"));
+const SessionSummary = lazy(() => import("./pages/SessionSummary"));
+const Stats = lazy(() => import("./pages/Stats"));
 
 const ReactQueryDevtools = import.meta.env.DEV
   ? lazy(() =>
@@ -31,19 +32,27 @@ export default function App() {
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
           <BrowserRouter>
-            <Routes>
-              <Route element={<Layout />}>
-                <Route path="/" element={<Home />} />
-                <Route path="/aide" element={<Help />} />
-                <Route path="/groups" element={<Groups />} />
-                <Route path="/groups/:id" element={<GroupDetail />} />
-                <Route path="/players" element={<Players />} />
-                <Route path="/sessions/:id/summary" element={<SessionSummary />} />
-                <Route path="/sessions/:id" element={<SessionPage />} />
-                <Route path="/stats" element={<Stats />} />
-                <Route path="/stats/player/:id" element={<PlayerStats />} />
-              </Route>
-            </Routes>
+            <Suspense>
+              <Routes>
+                <Route element={<Layout />}>
+                  <Route path="/" element={<Home />} />
+                  <Route path="/aide" element={<Help />} />
+                  <Route path="/groups" element={<Groups />} />
+                  <Route path="/groups/:id" element={<GroupDetail />} />
+                  <Route path="/players" element={<Players />} />
+                  <Route
+                    path="/sessions/:id/summary"
+                    element={<SessionSummary />}
+                  />
+                  <Route path="/sessions/:id" element={<SessionPage />} />
+                  <Route path="/stats" element={<Stats />} />
+                  <Route
+                    path="/stats/player/:id"
+                    element={<PlayerStats />}
+                  />
+                </Route>
+              </Routes>
+            </Suspense>
           </BrowserRouter>
           <ToastContainer />
         </ToastProvider>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -33,6 +33,13 @@ export default defineConfig({
   ],
   build: {
     target: "chrome64",
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          recharts: ["recharts"],
+        },
+      },
+    },
   },
   server: {
     host: "0.0.0.0",


### PR DESCRIPTION
## Résumé

- Lazy-load de toutes les pages (sauf Home) via `React.lazy()` + `<Suspense>` dans `App.tsx`
- Isolation de `recharts` dans un chunk dédié via `manualChunks` dans `vite.config.ts`
- Supprime le warning Vite « chunks are larger than 500 kB after minification »

## Fichiers modifiés

- `frontend/src/App.tsx` — imports statiques → `lazy()`, ajout `<Suspense>` autour des routes
- `frontend/vite.config.ts` — ajout `rollupOptions.output.manualChunks` pour `recharts`
- `CHANGELOG.md`

fixes #152