### PR TITLE
fix(backend): ajouter game:read au groupe de sérialisation de Player.id

### DIFF
--- a/backend/src/Entity/Player.php
+++ b/backend/src/Entity/Player.php
@@ -31,7 +31,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[UniqueEntity('name')]
 class Player
 {
-    #[Groups(['player-group:detail', 'player:read', 'session:detail', 'session:read'])]
+    #[Groups(['game:read', 'player-group:detail', 'player:read', 'score-entry:read', 'session:detail', 'session:read'])]
     #[ORM\Id]
     #[ORM\Column]
     #[ORM\GeneratedValue]


### PR DESCRIPTION
## Summary
- Le champ `id` manquait dans le groupe `game:read` de `Player`, rendant `player.id` undefined dans la réponse `/sessions/{id}/games`
- Le `find()` frontend matchait le premier score entry (défenseur) au lieu du preneur, affichant des scores négatifs erronés dans l'historique des donnes

## Test plan
- Vérifier que `/api/sessions/{id}/games` retourne bien `id` numérique dans les objets `player` des `scoreEntries` et `taker`
- Vérifier que l'historique des donnes affiche le score du preneur (positif quand l'attaque gagne)