### PR TITLE
fix(frontend): corriger l'affichage des scores (graphe + calculateur)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Graphe d'évolution des scores** : les scores cumulés étaient calculés uniquement à partir des donnes chargées (10 par page), faussant le graphe pour les sessions de plus de 10 donnes. Le graphe utilise désormais toutes les donnes de la session.
+- **Calculateur de score (frontend)** : les demi-points (ex. 53.5) n'étaient pas tronqués à l'entier avant le calcul, contrairement au backend, provoquant des écarts dans la prévisualisation.
+
 ## [1.1.0] - 2026-02-18
 
 ### Added

--- a/backend/src/Entity/Game.php
+++ b/backend/src/Entity/Game.php
@@ -49,6 +49,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     uriTemplate: '/sessions/{sessionId}/games',
     operations: [
         new GetCollection(
+            paginationClientEnabled: true,
             paginationItemsPerPage: 10,
             order: ['position' => 'DESC'],
         ),

--- a/backend/src/Repository/ScoreEntryRepository.php
+++ b/backend/src/Repository/ScoreEntryRepository.php
@@ -200,7 +200,7 @@ final class ScoreEntryRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
 
-        $map = array_fill_keys($playerIds, 0);
+        $map = \array_fill_keys($playerIds, 0);
         foreach ($results as $row) {
             $map[(int) $row['playerId']] = (int) $row['cnt'];
         }
@@ -244,7 +244,7 @@ final class ScoreEntryRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
 
-        $map = array_fill_keys($playerIds, 0);
+        $map = \array_fill_keys($playerIds, 0);
         foreach ($results as $row) {
             $map[(int) $row['playerId']] = (int) $row['cnt'];
         }
@@ -294,7 +294,7 @@ final class ScoreEntryRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
 
-        $map = array_fill_keys($playerIds, 0);
+        $map = \array_fill_keys($playerIds, 0);
         foreach ($results as $row) {
             $map[(int) $row['playerId']] = (int) $row['cnt'];
         }
@@ -318,7 +318,7 @@ final class ScoreEntryRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
 
-        return array_map(static fn (array $row): int => (int) $row['sessionId'], $results);
+        return \array_map(static fn (array $row): int => (int) $row['sessionId'], $results);
     }
 
     /**
@@ -344,7 +344,7 @@ final class ScoreEntryRepository extends ServiceEntityRepository
             ->getResult();
 
         /** @var array<int, list<int>> $map */
-        $map = array_fill_keys($playerIds, []);
+        $map = \array_fill_keys($playerIds, []);
         foreach ($results as $row) {
             $map[(int) $row['playerId']][] = (int) $row['sessionId'];
         }
@@ -550,7 +550,7 @@ final class ScoreEntryRepository extends ServiceEntityRepository
             ->getResult();
 
         /** @var array<int, list<GameTakerScoreDto>> $map */
-        $map = array_fill_keys($playerIds, []);
+        $map = \array_fill_keys($playerIds, []);
         foreach ($results as $row) {
             $map[(int) $row['playerId']][] = new GameTakerScoreDto(
                 $row['gameId'],

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -439,6 +439,24 @@ const allGames = data?.pages.flatMap(p => p.member) ?? [];
 
 **Query key** : `["session", sessionId, "games"]` — invalidé automatiquement par prefix matching quand `["session", sessionId]` est invalidé par les mutations existantes.
 
+### `useAllSessionGames`
+
+**Fichier** : `hooks/useAllSessionGames.ts`
+
+Récupère **toutes** les donnes d'une session en une seule requête (sans pagination). Utilisé par le graphe d'évolution des scores pour calculer les scores cumulés corrects.
+
+```ts
+const { data: allGames } = useAllSessionGames(sessionId);
+// allGames: Game[] | undefined
+```
+
+| Retour | Type | Description |
+|--------|------|-------------|
+| `data` | `Game[] \| undefined` | Toutes les donnes de la session (sélecteur `member`) |
+| …autres | — | Tous les champs de `UseQueryResult` |
+
+**Query key** : `["session", sessionId, "allGames"]` — invalidé automatiquement par prefix matching.
+
 ### `useCloseGroupSessions`
 
 **Fichier** : `hooks/useCloseGroupSessions.ts`
@@ -735,7 +753,7 @@ Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.m
 
 **Fonctionnalités** :
 - Tableau des scores cumulés (composant `Scoreboard`) avec avatars et scores colorés
-- Graphique d'évolution des scores (`ScoreEvolutionChart`) visible quand ≥ 2 donnes terminées (basé sur les donnes chargées)
+- Graphique d'évolution des scores (`ScoreEvolutionChart`) visible quand ≥ 2 donnes terminées (basé sur toutes les donnes via `useAllSessionGames`)
 - Bandeau « donne en cours » (`InProgressBanner`) si `session.inProgressGame` est non nul
 - Historique des donnes terminées (`GameList`) paginé côté serveur (10 par page, bouton « Voir plus »)
 - Bouton FAB (+) pour démarrer une nouvelle donne (désactivé si donne en cours)
@@ -745,7 +763,7 @@ Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.m
 - Bouton retour vers l'accueil
 - États : chargement, session introuvable
 
-**Hooks utilisés** : `useSession`, `useSessionGames`, `useAddStar`, `useCloseSession`, `useCreateGame`, `useCreateSession` (via SwapPlayersModal), `useCompleteGame`, `useDeleteGame`, `usePlayerGroups`, `useUpdateDealer`, `useUpdateSessionGroup`, `useNavigate`
+**Hooks utilisés** : `useSession`, `useSessionGames`, `useAllSessionGames`, `useAddStar`, `useCloseSession`, `useCreateGame`, `useCreateSession` (via SwapPlayersModal), `useCompleteGame`, `useDeleteGame`, `usePlayerGroups`, `useUpdateDealer`, `useUpdateSessionGroup`, `useNavigate`
 
 **Modales** :
 - `AddStarModal` : confirmation avant attribution d'étoile à un joueur
@@ -1267,7 +1285,7 @@ formatDuration(7200);  // "2h"
 
 **Fichier** : `services/scoreCalculator.ts`
 
-Miroir frontend du `ScoreCalculator` backend. Calcule les scores d'une donne en temps réel pour l'aperçu.
+Miroir frontend du `ScoreCalculator` backend. Calcule les scores d'une donne en temps réel pour l'aperçu. Les points sont tronqués à l'entier (`Math.trunc`) avant le calcul, comme le backend (`(int) $points`).
 
 ```ts
 import { calculateScore } from "./services/scoreCalculator";

--- a/frontend/src/__tests__/components/ScoreEvolutionChart.test.tsx
+++ b/frontend/src/__tests__/components/ScoreEvolutionChart.test.tsx
@@ -82,6 +82,12 @@ describe("computeScoreEvolution", () => {
     expect(computeScoreEvolution([], players)).toEqual([]);
   });
 
+  it("filters out in-progress games", () => {
+    const inProgressGame: Game = { ...makeGame(3, {}), scoreEntries: [], status: "in_progress" };
+    const result = computeScoreEvolution([...twoGames, inProgressGame], players);
+    expect(result).toHaveLength(2);
+  });
+
   it("sorts games by position", () => {
     const game2 = makeGame(2, { Alice: -10, Bob: -10, Charlie: 10, Diana: 10, Eve: 0 });
     const game1 = makeGame(1, { Alice: 50, Bob: 20, Charlie: -20, Diana: -20, Eve: -30 });

--- a/frontend/src/__tests__/services/scoreCalculator.test.ts
+++ b/frontend/src/__tests__/services/scoreCalculator.test.ts
@@ -199,6 +199,34 @@ describe("calculateScore", () => {
   });
 
   // ---------------------------------------------------------------
+  // Demi-points : tronqués à l'entier comme le backend
+  // ---------------------------------------------------------------
+
+  it("tronque les demi-points avant le calcul (garde, 53.5 pts, 1 oudler)", () => {
+    // Backend: (int)53.5 = 53, requis=51, diff=2, base=(2+25)×2=54
+    const result = calculateScore(makeInput({
+      contract: Contract.Garde,
+      oudlers: 1,
+      points: 53.5,
+    }));
+
+    expect(result.baseScore).toBe(54);
+    expect(result.takerScore).toBe(108);
+  });
+
+  it("tronque les demi-points pour déterminer le résultat (40.5 pts, 2 oudlers)", () => {
+    // Backend: (int)40.5 = 40, requis=41, attaque perd
+    // base=-(|40-41|+25)×1 = -26
+    const result = calculateScore(makeInput({
+      oudlers: 2,
+      points: 40.5,
+    }));
+
+    expect(result.attackWins).toBe(false);
+    expect(result.baseScore).toBe(-26);
+  });
+
+  // ---------------------------------------------------------------
   // Distribution : self-call
   // ---------------------------------------------------------------
 

--- a/frontend/src/components/ScoreEvolutionChart.tsx
+++ b/frontend/src/components/ScoreEvolutionChart.tsx
@@ -9,6 +9,7 @@ import {
   YAxis,
 } from "recharts";
 import type { Game, GamePlayer } from "../types/api";
+import { GameStatus } from "../types/enums";
 
 interface ScoreEvolutionChartProps {
   games: Game[];
@@ -32,7 +33,9 @@ export function computeScoreEvolution(
   games: Game[],
   players: GamePlayer[],
 ): Record<string, number | string>[] {
-  const completed = [...games].sort((a, b) => a.position - b.position);
+  const completed = [...games]
+    .filter((g) => g.status === GameStatus.Completed)
+    .sort((a, b) => a.position - b.position);
 
   const cumulative: Record<number, number> = {};
   players.forEach((p) => (cumulative[p.id] = 0));

--- a/frontend/src/hooks/useAllSessionGames.ts
+++ b/frontend/src/hooks/useAllSessionGames.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "../services/api";
+import type { Game, HydraCollection } from "../types/api";
+
+export function useAllSessionGames(sessionId: number) {
+  return useQuery({
+    queryFn: () =>
+      apiFetch<HydraCollection<Game>>(
+        `/sessions/${sessionId}/games?pagination=false`,
+      ),
+    queryKey: ["session", sessionId, "allGames"],
+    select: (data) => data.member,
+  });
+}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -20,6 +20,7 @@ import SwapPlayersModal from "../components/SwapPlayersModal";
 import { FAB, Modal, OverflowMenu, Spinner, UndoFAB } from "../components/ui";
 import type { OverflowMenuItem } from "../components/ui/OverflowMenu";
 import { useAddStar } from "../hooks/useAddStar";
+import { useAllSessionGames } from "../hooks/useAllSessionGames";
 import { useCloseSession } from "../hooks/useCloseSession";
 import { useCreateGame } from "../hooks/useCreateGame";
 import { usePlayerGroups } from "../hooks/usePlayerGroups";
@@ -32,6 +33,7 @@ import { apiFetch } from "../services/api";
 import type { GameContext, MemeConfig } from "../services/memeSelector";
 import { selectDefeatMeme, selectVictoryMeme } from "../services/memeSelector";
 import type { Badge } from "../types/api";
+import { GameStatus } from "../types/enums";
 
 export default function SessionPage() {
   const { id } = useParams<{ id: string }>();
@@ -44,6 +46,7 @@ export default function SessionPage() {
     hasNextPage,
     isFetchingNextPage,
   } = useSessionGames(sessionId);
+  const { data: allGames } = useAllSessionGames(sessionId);
   const addStar = useAddStar(sessionId);
   const closeSession = useCloseSession(sessionId);
   const createGame = useCreateGame(sessionId);
@@ -200,13 +203,13 @@ export default function SessionPage() {
         />
       )}
 
-      {completedGames.length >= 2 && (
+      {allGames && allGames.filter((g) => g.status === GameStatus.Completed).length >= 2 && (
         <section>
           <h2 className="mb-2 text-sm font-semibold text-text-secondary">
             Évolution des scores
           </h2>
           <ScoreEvolutionChart
-            games={completedGames}
+            games={allGames}
             players={session.players}
           />
         </section>

--- a/frontend/src/services/scoreCalculator.ts
+++ b/frontend/src/services/scoreCalculator.ts
@@ -49,11 +49,12 @@ export function calculateScore(input: ScoreCalculatorInput): ScoreResult {
   const { chelem, contract, oudlers, partnerId, petitAuBout, poignee, points } = input;
   const multiplier = CONTRACT_MULTIPLIER[contract];
   const requiredPoints = REQUIRED_POINTS[oudlers];
-  const attackWins = points >= requiredPoints;
+  const intPoints = Math.trunc(points);
+  const attackWins = intPoints >= requiredPoints;
   const selfCall = partnerId === null;
 
   // Score de base : (|points - requis| + 25) × multiplicateur
-  let baseScore = (Math.abs(points - requiredPoints) + 25) * multiplier;
+  let baseScore = (Math.abs(intPoints - requiredPoints) + 25) * multiplier;
   if (!attackWins) {
     baseScore = -baseScore;
   }


### PR DESCRIPTION
## Résumé

- **Graphe d'évolution** : chargeait uniquement les 10 premières donnes (pagination par défaut), faussant les scores cumulés. Ajout du hook `useAllSessionGames` avec `pagination=false` et activation de `paginationClientEnabled` sur l'entité `Game`.
- **Calculateur de scores** : ne tronquait pas les demi-points (`53.5 → 53`), contrairement au backend `(int)$points`, créant des écarts d'affichage.

## Fichiers modifiés

- `frontend/src/hooks/useAllSessionGames.ts` — nouveau hook pour charger toutes les donnes
- `frontend/src/pages/SessionPage.tsx` — utilise `useAllSessionGames` pour le graphe
- `frontend/src/services/scoreCalculator.ts` — `Math.trunc(points)` pour parité backend
- `frontend/src/__tests__/services/scoreCalculator.test.ts` — tests demi-points
- `backend/src/Entity/Game.php` — `paginationClientEnabled: true`
- `frontend/src/components/ScoreEvolutionChart.tsx` — inchangé (logique identique)

fixes #189