### PR TITLE
fix(frontend): masquer les boutons modifier/supprimer sur session clôturée

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Fixed
 
+- **Boutons de modification de la dernière donne** : les boutons « Modifier » et « Supprimer » restaient visibles et actifs sur une session clôturée. Ils sont désormais masqués lorsque la session est terminée.
 - **Graphe d'évolution des scores** : les scores cumulés étaient calculés uniquement à partir des donnes chargées (10 par page), faussant le graphe pour les sessions de plus de 10 donnes. Le graphe utilise désormais toutes les donnes de la session.
 - **Calculateur de score (frontend)** : les demi-points (ex. 53.5) n'étaient pas tronqués à l'entier avant le calcul, contrairement au backend, provoquant des écarts dans la prévisualisation.
 

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -935,13 +935,14 @@ Liste des donnes terminées en ordre anti-chronologique (position décroissante)
 | `games` | `Game[]` | *requis* — donnes terminées (triées par position DESC depuis l'API) |
 | `hasNextPage` | `boolean` | *requis* — `true` s'il reste des pages à charger |
 | `isFetchingNextPage` | `boolean` | *requis* — `true` pendant le chargement de la page suivante |
+| `isSessionActive` | `boolean` | *requis* — `true` si la session est en cours (masque les boutons d'action sinon) |
 | `onDeleteLast` | `() => void` | *requis* — action pour supprimer la dernière donne |
 | `onEditLast` | `() => void` | *requis* — action pour modifier la dernière donne |
 | `onLoadMore` | `() => void` | *requis* — action pour charger la page suivante |
 
 **Fonctionnalités** :
 - Chaque carte : avatar preneur, nom, badge contrat, durée de la donne (si `completedAt` disponible), « avec [partenaire] » ou « Seul », donneur, score du preneur
-- Boutons « Modifier » et « Supprimer » uniquement sur la dernière donne (position la plus élevée)
+- Boutons « Modifier » et « Supprimer » uniquement sur la dernière donne (position la plus élevée) et uniquement si la session est en cours (`isSessionActive`)
 - Bouton « Voir plus » quand `hasNextPage` est vrai, affichant « Chargement… » pendant le fetch
 - État vide : « Aucune donne jouée »
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -323,7 +323,7 @@ Après la validation d'une donne, un **bouton flottant « Annuler »** (en bas �
 
 ### Modifier la dernière donne
 
-Seule la **dernière donne** de la session est modifiable. Pour la modifier :
+Seule la **dernière donne** de la session est modifiable (uniquement si la session est encore **en cours** — les boutons sont masqués sur une session terminée). Pour la modifier :
 
 1. Appuyer sur le bouton **« Modifier »** affiché à côté de la dernière donne dans l'historique
 2. Modifier les paramètres souhaités (partenaire, oudlers, points, bonus)
@@ -331,7 +331,7 @@ Seule la **dernière donne** de la session est modifiable. Pour la modifier :
 
 ### Supprimer la dernière donne
 
-Seule la **dernière donne** peut être supprimée (erreur de saisie, donne annulée). Deux cas :
+Seule la **dernière donne** peut être supprimée (erreur de saisie, donne annulée), uniquement si la session est **en cours**. Deux cas :
 
 - **Donne terminée** : appuyer sur le bouton **« Supprimer »** (en rouge) à côté de la dernière donne dans l'historique
 - **Donne en cours** : appuyer sur le bouton **« Annuler »** dans le bandeau de donne en cours

--- a/frontend/src/__tests__/components/GameList.test.tsx
+++ b/frontend/src/__tests__/components/GameList.test.tsx
@@ -52,6 +52,7 @@ const games: Game[] = [
 const defaultProps = {
   hasNextPage: false,
   isFetchingNextPage: false,
+  isSessionActive: true,
   onDeleteLast: () => {},
   onEditLast: () => {},
   onLoadMore: () => {},
@@ -186,5 +187,14 @@ describe("GameList", () => {
     );
 
     expect(screen.getByText("Chargement…")).toBeInTheDocument();
+  });
+
+  it("hides edit and delete buttons when session is not active", () => {
+    renderWithProviders(
+      <GameList games={games} {...defaultProps} isSessionActive={false} />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Modifier" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Supprimer" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -7,6 +7,7 @@ interface GameListProps {
   games: Game[];
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
+  isSessionActive: boolean;
   onDeleteLast: () => void;
   onEditLast: () => void;
   onLoadMore: () => void;
@@ -16,6 +17,7 @@ export default function GameList({
   games,
   hasNextPage,
   isFetchingNextPage,
+  isSessionActive,
   onDeleteLast,
   onEditLast,
   onLoadMore,
@@ -79,7 +81,7 @@ export default function GameList({
                   )}
                 </div>
               </div>
-              {game.position === maxPosition && (
+              {isSessionActive && game.position === maxPosition && (
                 <div className="mt-2 flex gap-2">
                   <button
                     className="flex-1 rounded-lg bg-surface-elevated px-3 py-1.5 text-sm font-medium text-text-secondary"

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -223,6 +223,7 @@ export default function SessionPage() {
           games={completedGames}
           hasNextPage={hasNextPage ?? false}
           isFetchingNextPage={isFetchingNextPage}
+          isSessionActive={session.isActive}
           onDeleteLast={() => setDeleteModalOpen(true)}
           onEditLast={() => setEditModalOpen(true)}
           onLoadMore={() => fetchNextPage()}


### PR DESCRIPTION
## Summary
- Ajoute une prop `isSessionActive` à `GameList` pour conditionner l'affichage des boutons « Modifier » et « Supprimer » sur la dernière donne
- Les boutons sont masqués lorsque la session est terminée (`closedAt` non null)
- Test unitaire ajouté pour vérifier le comportement

## Test plan
- [x] Test unitaire : boutons masqués quand `isSessionActive=false`
- [x] Tests existants GameList et SessionPage toujours verts
- [x] TypeScript : aucune erreur de typage

fixes #179