### PR TITLE
feat(session): permettre de changer l'ordre des joueurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Ordre personnalisé des joueurs** : possibilité de réorganiser l'ordre des joueurs dans une session via le menu ⋮ > « Changer l'ordre ». L'ordre personnalisé s'applique au tableau des scores, au graphe d'évolution, à la sélection preneur/appelé et à la rotation automatique du donneur.
 - **Détail des scores par donne** : au clic sur une donne dans l'historique, un panneau dépliable affiche les scores individuels de chaque joueur (preneur → appelé → défense) avec le nombre de bouts et l'écart par rapport au contrat.
 
 ### Fixed

--- a/backend/migrations/Version20260220205348.php
+++ b/backend/migrations/Version20260220205348.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260220205348 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE session ADD player_order JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE session DROP player_order');
+    }
+}

--- a/backend/src/Entity/Session.php
+++ b/backend/src/Entity/Session.php
@@ -15,6 +15,7 @@ use App\State\SessionCreateProcessor;
 use App\State\SessionDetailProvider;
 use App\State\SessionPatchProcessor;
 use App\Validator\DealerBelongsToSession;
+use App\Validator\PlayerOrderMatchesSession;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -40,6 +41,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     denormalizationContext: ['groups' => ['session:write']],
 )]
 #[DealerBelongsToSession]
+#[PlayerOrderMatchesSession]
 #[ORM\Entity(repositoryClass: SessionRepository::class)]
 class Session
 {
@@ -70,6 +72,11 @@ class Session
     #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
     #[ORM\ManyToOne(targetEntity: PlayerGroup::class)]
     private ?PlayerGroup $playerGroup = null;
+
+    /** @var int[]|null */
+    #[Groups(['session:detail', 'session:patch'])]
+    #[ORM\Column(type: 'json', nullable: true)]
+    private ?array $playerOrder = null;
 
     /** @var Collection<int, Player> */
     #[Assert\Count(exactly: 5, exactMessage: 'Une session doit avoir exactement 5 joueurs.')]
@@ -120,7 +127,7 @@ class Session
 
     public function advanceDealer(): void
     {
-        $players = $this->players->getValues();
+        $players = $this->getOrderedPlayers();
         $count = \count($players);
 
         if (0 === $count || null === $this->currentDealer) {
@@ -180,6 +187,32 @@ class Session
         return $this->games;
     }
 
+    /**
+     * @return Player[]
+     */
+    public function getOrderedPlayers(): array
+    {
+        $players = $this->players->getValues();
+
+        if (null === $this->playerOrder) {
+            return $players;
+        }
+
+        $indexed = [];
+        foreach ($players as $player) {
+            $indexed[$player->getId()] = $player;
+        }
+
+        $ordered = [];
+        foreach ($this->playerOrder as $id) {
+            if (isset($indexed[$id])) {
+                $ordered[] = $indexed[$id];
+            }
+        }
+
+        return $ordered;
+    }
+
     public function getInProgressGame(): ?Game
     {
         return $this->inProgressGame;
@@ -226,11 +259,12 @@ class Session
         return $this->playerGroup;
     }
 
-    public function setPlayerGroup(?PlayerGroup $playerGroup): static
+    /**
+     * @return int[]|null
+     */
+    public function getPlayerOrder(): ?array
     {
-        $this->playerGroup = $playerGroup;
-
-        return $this;
+        return $this->playerOrder;
     }
 
     /**
@@ -239,6 +273,23 @@ class Session
     public function getPlayers(): Collection
     {
         return $this->players;
+    }
+
+    public function setPlayerGroup(?PlayerGroup $playerGroup): static
+    {
+        $this->playerGroup = $playerGroup;
+
+        return $this;
+    }
+
+    /**
+     * @param int[]|null $playerOrder
+     */
+    public function setPlayerOrder(?array $playerOrder): static
+    {
+        $this->playerOrder = $playerOrder;
+
+        return $this;
     }
 
     public function addPlayer(Player $player): static

--- a/backend/src/State/SessionCreateProcessor.php
+++ b/backend/src/State/SessionCreateProcessor.php
@@ -57,6 +57,13 @@ final readonly class SessionCreateProcessor implements ProcessorInterface
             $session->setCurrentDealer($firstPlayer);
         }
 
+        /** @var int[] $playerOrder */
+        $playerOrder = \array_map(
+            static fn (Player $p) => $p->getId(),
+            $session->getPlayers()->getValues()
+        );
+        $session->setPlayerOrder($playerOrder);
+
         $this->autoAssociatePlayerGroup($session, $playerIds, $count);
         $this->em->flush();
 

--- a/backend/src/Validator/PlayerOrderMatchesSession.php
+++ b/backend/src/Validator/PlayerOrderMatchesSession.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Vérifie que playerOrder contient exactement les mêmes IDs que les joueurs de la session.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class PlayerOrderMatchesSession extends Constraint
+{
+    public string $message = 'L\'ordre des joueurs ne correspond pas aux joueurs de la session.';
+
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/backend/src/Validator/PlayerOrderMatchesSessionValidator.php
+++ b/backend/src/Validator/PlayerOrderMatchesSessionValidator.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator;
+
+use App\Entity\Session;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+class PlayerOrderMatchesSessionValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$value instanceof Session) {
+            throw new UnexpectedValueException($value, Session::class);
+        }
+
+        if (!$constraint instanceof PlayerOrderMatchesSession) {
+            throw new UnexpectedValueException($constraint, PlayerOrderMatchesSession::class);
+        }
+
+        $playerOrder = $value->getPlayerOrder();
+
+        if (null === $playerOrder) {
+            return;
+        }
+
+        $playerIds = $value->getPlayers()->map(
+            static fn ($player) => $player->getId()
+        )->getValues();
+
+        \sort($playerIds);
+
+        $sortedOrder = $playerOrder;
+        \sort($sortedOrder);
+
+        if ($playerIds !== $sortedOrder || \count($playerOrder) !== \count(\array_unique($playerOrder))) {
+            $this->context->buildViolation($constraint->message)
+                ->atPath('playerOrder')
+                ->addViolation();
+        }
+    }
+}

--- a/backend/tests/Api/SessionApiTest.php
+++ b/backend/tests/Api/SessionApiTest.php
@@ -402,6 +402,144 @@ class SessionApiTest extends ApiTestCase
         $this->assertSame(0, $data['closedCount']);
     }
 
+    public function testPatchPlayerOrderValid(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $playerIds = $session->getPlayers()->map(static fn ($p) => $p->getId())->getValues();
+
+        // Reverse the order
+        $reversed = \array_reverse($playerIds);
+
+        $response = $this->client->request('PATCH', $this->getIri($session), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => ['playerOrder' => $reversed],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray();
+        $this->assertSame($reversed, $data['playerOrder']);
+    }
+
+    public function testPatchPlayerOrderInvalidIds(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+
+        $this->client->request('PATCH', $this->getIri($session), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => ['playerOrder' => [999, 998, 997, 996, 995]],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPatchPlayerOrderDuplicates(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $firstId = $session->getPlayers()->first()->getId();
+
+        $this->client->request('PATCH', $this->getIri($session), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => ['playerOrder' => [$firstId, $firstId, $firstId, $firstId, $firstId]],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPatchPlayerOrderWrongCount(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $playerIds = $session->getPlayers()->map(static fn ($p) => $p->getId())->getValues();
+
+        $this->client->request('PATCH', $this->getIri($session), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => ['playerOrder' => \array_slice($playerIds, 0, 3)],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPatchPlayerOrderNullResetsOrder(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $playerIds = $session->getPlayers()->map(static fn ($p) => $p->getId())->getValues();
+
+        // Set order first
+        $this->client->request('PATCH', $this->getIri($session), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => ['playerOrder' => \array_reverse($playerIds)],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        // Reset to null
+        $response = $this->client->request('PATCH', $this->getIri($session), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => ['playerOrder' => null],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray();
+        $this->assertNull($data['playerOrder']);
+    }
+
+    public function testDealerAdvancesFollowingCustomPlayerOrder(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+        $playerIds = \array_map(static fn ($p) => $p->getId(), $players);
+
+        // Custom order: reverse (Eve, Diana, Charlie, Bob, Alice)
+        $reversed = \array_reverse($playerIds);
+        $session->setPlayerOrder($reversed);
+        // Eve = first in custom order, set as current dealer
+        $session->setCurrentDealer($players[4]); // Eve
+        $this->em->flush();
+
+        // Create an in-progress game via entity
+        $game = new Game();
+        $game->setContract(Contract::Petite);
+        $game->setPosition(1);
+        $game->setSession($session);
+        $game->setStatus(GameStatus::InProgress);
+        $game->setTaker($players[0]); // Alice
+        $this->em->persist($game);
+        $this->em->flush();
+
+        // Complete the game via API PATCH → triggers advanceDealer
+        $this->client->request('PATCH', $this->getIri($game), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => [
+                'oudlers' => 2,
+                'partner' => $this->getIri($players[1]),
+                'points' => 45,
+                'status' => 'completed',
+            ],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        // Dealer should advance: Eve → Diana (second in reversed order)
+        $response = $this->client->request('GET', $this->getIri($session));
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray();
+        $this->assertSame($players[3]->getId(), $data['currentDealer']['id']); // Diana
+    }
+
+    public function testCreateSessionSetsInitialPlayerOrder(): void
+    {
+        $playerIris = $this->createPlayerIris('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+
+        $response = $this->client->request('POST', '/api/sessions', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => ['players' => $playerIris],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $data = $response->toArray();
+
+        // Fetch detail to get playerOrder (session:detail group)
+        $detail = $this->client->request('GET', '/api/sessions/'.$data['id'])->toArray();
+        $this->assertNotNull($detail['playerOrder']);
+        $this->assertCount(5, $detail['playerOrder']);
+    }
+
     /**
      * @return string[]
      */

--- a/backend/tests/Unit/Entity/SessionTest.php
+++ b/backend/tests/Unit/Entity/SessionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Player;
+use App\Entity\Session;
+use PHPUnit\Framework\TestCase;
+
+class SessionTest extends TestCase
+{
+    public function testGetOrderedPlayersReturnsDefaultOrderWhenNull(): void
+    {
+        $session = new Session();
+        $players = $this->createPlayers(['Alice', 'Bob', 'Charlie', 'Diana', 'Eve']);
+        foreach ($players as $player) {
+            $session->addPlayer($player);
+        }
+
+        // playerOrder is null by default → returns players as-is
+        $ordered = $session->getOrderedPlayers();
+        $this->assertCount(5, $ordered);
+        $this->assertSame($players, $ordered);
+    }
+
+    public function testGetOrderedPlayersReturnsCustomOrder(): void
+    {
+        $session = new Session();
+        $players = $this->createPlayers(['Alice', 'Bob', 'Charlie', 'Diana', 'Eve']);
+        foreach ($players as $player) {
+            $session->addPlayer($player);
+        }
+
+        // Custom order: Eve, Charlie, Alice, Diana, Bob
+        $customOrder = [5, 3, 1, 4, 2];
+        $session->setPlayerOrder($customOrder);
+
+        $ordered = $session->getOrderedPlayers();
+        $this->assertSame('Eve', $ordered[0]->getName());
+        $this->assertSame('Charlie', $ordered[1]->getName());
+        $this->assertSame('Alice', $ordered[2]->getName());
+        $this->assertSame('Diana', $ordered[3]->getName());
+        $this->assertSame('Bob', $ordered[4]->getName());
+    }
+
+    public function testAdvanceDealerFollowsCustomOrder(): void
+    {
+        $session = new Session();
+        $players = $this->createPlayers(['Alice', 'Bob', 'Charlie', 'Diana', 'Eve']);
+        foreach ($players as $player) {
+            $session->addPlayer($player);
+        }
+
+        // Custom order: Eve(5), Charlie(3), Alice(1), Diana(4), Bob(2)
+        $session->setPlayerOrder([5, 3, 1, 4, 2]);
+        $session->setCurrentDealer($players[4]); // Eve
+
+        $session->advanceDealer();
+        $this->assertSame('Charlie', $session->getCurrentDealer()->getName());
+
+        $session->advanceDealer();
+        $this->assertSame('Alice', $session->getCurrentDealer()->getName());
+    }
+
+    public function testAdvanceDealerWrapsAroundWithCustomOrder(): void
+    {
+        $session = new Session();
+        $players = $this->createPlayers(['Alice', 'Bob', 'Charlie', 'Diana', 'Eve']);
+        foreach ($players as $player) {
+            $session->addPlayer($player);
+        }
+
+        // Custom order: Eve(5), Charlie(3), Alice(1), Diana(4), Bob(2)
+        $session->setPlayerOrder([5, 3, 1, 4, 2]);
+        $session->setCurrentDealer($players[1]); // Bob — last in custom order
+
+        $session->advanceDealer();
+        $this->assertSame('Eve', $session->getCurrentDealer()->getName()); // wraps to first
+    }
+
+    /**
+     * @return Player[]
+     */
+    private function createPlayers(array $names): array
+    {
+        $players = [];
+        $id = 1;
+        foreach ($names as $name) {
+            $player = new Player();
+            $player->setName($name);
+            // Use reflection to set the ID
+            $ref = new \ReflectionProperty(Player::class, 'id');
+            $ref->setValue($player, $id++);
+            $players[] = $player;
+        }
+
+        return $players;
+    }
+}

--- a/backend/tests/Unit/Validator/PlayerOrderMatchesSessionValidatorTest.php
+++ b/backend/tests/Unit/Validator/PlayerOrderMatchesSessionValidatorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Validator;
+
+use App\Entity\Player;
+use App\Entity\Session;
+use App\Validator\PlayerOrderMatchesSession;
+use App\Validator\PlayerOrderMatchesSessionValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @extends ConstraintValidatorTestCase<PlayerOrderMatchesSessionValidator>
+ */
+class PlayerOrderMatchesSessionValidatorTest extends ConstraintValidatorTestCase
+{
+    public function testNullPlayerOrderIsValid(): void
+    {
+        $session = $this->createSession([1, 2, 3, 4, 5]);
+        $session->setPlayerOrder(null);
+
+        $this->validator->validate($session, new PlayerOrderMatchesSession());
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidPlayerOrderIsAccepted(): void
+    {
+        $session = $this->createSession([1, 2, 3, 4, 5]);
+        $session->setPlayerOrder([3, 1, 5, 2, 4]);
+
+        $this->validator->validate($session, new PlayerOrderMatchesSession());
+
+        $this->assertNoViolation();
+    }
+
+    public function testPlayerOrderWithWrongCountIsInvalid(): void
+    {
+        $session = $this->createSession([1, 2, 3, 4, 5]);
+        $session->setPlayerOrder([1, 2, 3]);
+
+        $this->validator->validate($session, new PlayerOrderMatchesSession());
+
+        $this->buildViolation('L\'ordre des joueurs ne correspond pas aux joueurs de la session.')
+            ->atPath('property.path.playerOrder')
+            ->assertRaised();
+    }
+
+    public function testPlayerOrderWithDuplicatesIsInvalid(): void
+    {
+        $session = $this->createSession([1, 2, 3, 4, 5]);
+        $session->setPlayerOrder([1, 1, 3, 4, 5]);
+
+        $this->validator->validate($session, new PlayerOrderMatchesSession());
+
+        $this->buildViolation('L\'ordre des joueurs ne correspond pas aux joueurs de la session.')
+            ->atPath('property.path.playerOrder')
+            ->assertRaised();
+    }
+
+    public function testPlayerOrderWithWrongIdsIsInvalid(): void
+    {
+        $session = $this->createSession([1, 2, 3, 4, 5]);
+        $session->setPlayerOrder([1, 2, 3, 4, 99]);
+
+        $this->validator->validate($session, new PlayerOrderMatchesSession());
+
+        $this->buildViolation('L\'ordre des joueurs ne correspond pas aux joueurs de la session.')
+            ->atPath('property.path.playerOrder')
+            ->assertRaised();
+    }
+
+    protected function createValidator(): PlayerOrderMatchesSessionValidator
+    {
+        return new PlayerOrderMatchesSessionValidator();
+    }
+
+    private function createSession(array $playerIds): Session
+    {
+        $session = new Session();
+        foreach ($playerIds as $id) {
+            $player = new Player();
+            $player->setName("Player{$id}");
+            $ref = new \ReflectionProperty(Player::class, 'id');
+            $ref->setValue($player, $id);
+            $session->addPlayer($player);
+        }
+
+        return $session;
+    }
+}

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -374,6 +374,28 @@ updateDealer.mutate(playerId, {
 | `isError` | `boolean` | `true` si erreur (ex. joueur pas dans la session 422) |
 | `error` | `ApiError \| null` | Détails de l'erreur |
 
+### `useReorderPlayers`
+
+**Fichier** : `hooks/useReorderPlayers.ts`
+
+Mutation pour changer l'ordre des joueurs d'une session. Envoie un PATCH à `/sessions/{id}` avec `Content-Type: application/merge-patch+json` et `{ playerOrder: number[] }`.
+Invalide le cache `["session", sessionId]` en cas de succès.
+
+```ts
+const reorderPlayers = useReorderPlayers(sessionId);
+
+reorderPlayers.mutate([3, 1, 5, 2, 4], {
+  onSuccess: () => closeModal(),
+});
+```
+
+| Retour | Type | Description |
+|--------|------|-------------|
+| `mutate` | `(playerOrder: number[]) => void` | Lance la mise à jour de l'ordre |
+| `isPending` | `boolean` | `true` pendant la requête |
+| `isError` | `boolean` | `true` si erreur (ex. IDs invalides 422) |
+| `error` | `ApiError \| null` | Détails de l'erreur |
+
 ### `useGlobalStats`
 
 **Fichier** : `hooks/useGlobalStats.ts`
@@ -763,7 +785,7 @@ Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.m
 - Bouton retour vers l'accueil
 - États : chargement, session introuvable
 
-**Hooks utilisés** : `useSession`, `useSessionGames`, `useAllSessionGames`, `useAddStar`, `useCloseSession`, `useCreateGame`, `useCreateSession` (via SwapPlayersModal), `useCompleteGame`, `useDeleteGame`, `usePlayerGroups`, `useUpdateDealer`, `useUpdateSessionGroup`, `useNavigate`
+**Hooks utilisés** : `useSession`, `useSessionGames`, `useAllSessionGames`, `useAddStar`, `useCloseSession`, `useCreateGame`, `useCreateSession` (via SwapPlayersModal), `useCompleteGame`, `useDeleteGame`, `usePlayerGroups`, `useReorderPlayers`, `useUpdateDealer`, `useUpdateSessionGroup`, `useNavigate`
 
 **Modales** :
 - `AddStarModal` : confirmation avant attribution d'étoile à un joueur
@@ -774,6 +796,7 @@ Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.m
 - `DeleteGameModal` : confirmation de suppression de la dernière donne
 - Modale de confirmation de clôture de session (inline `<Modal>`)
 - `NewGameModal` : sélection preneur + contrat (étape 1)
+- `ReorderPlayersModal` : réorganisation de l'ordre des joueurs avec flèches haut/bas
 - `ShareQrCodeModal` : affichage d'un QR code encodant l'URL de la session avec mode plein écran
 - `SwapPlayersModal` : changement de joueurs avec navigation vers la session résultante
 
@@ -966,6 +989,25 @@ Modal de sélection manuelle du donneur parmi les joueurs de la session.
 - Donneur actuel pré-sélectionné
 - Bouton Valider désactivé si le même donneur est sélectionné ou si `isPending`
 - Affichage du nom du joueur sélectionné
+
+### `ReorderPlayersModal`
+
+**Fichier** : `components/ReorderPlayersModal.tsx`
+
+Modal de réorganisation de l'ordre des joueurs dans une session. Liste verticale avec flèches haut/bas.
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `isPending` | `boolean?` | Désactiver le bouton Valider pendant la mutation |
+| `onClose` | `() => void` | *requis* — fermeture |
+| `onConfirm` | `(playerIds: number[]) => void` | *requis* — callback avec le nouvel ordre d'IDs |
+| `open` | `boolean` | *requis* — afficher ou masquer |
+| `players` | `GamePlayer[]` | *requis* — joueurs dans l'ordre actuel |
+
+**Fonctionnalités** :
+- Liste verticale avec avatar + nom + flèches ChevronUp/ChevronDown
+- Flèche haut désactivée pour le premier joueur, flèche bas pour le dernier
+- Bouton Valider désactivé si l'ordre n'a pas changé ou si `isPending`
 
 ### `AddStarModal`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -116,7 +116,7 @@ En bas de l'écran, la zone de sélection des joueurs est accessible au pouce :
 
 ### Donneur
 
-À la création d'une session, le **premier joueur** (ordre alphabétique) est désigné comme donneur. Après chaque donne terminée, le donneur **tourne automatiquement** au joueur suivant dans l'ordre alphabétique. Après le dernier joueur, la rotation reprend au premier (cycle).
+À la création d'une session, le **premier joueur** (ordre alphabétique) est désigné comme donneur. Après chaque donne terminée, le donneur **tourne automatiquement** au joueur suivant. Après le dernier joueur, la rotation reprend au premier (cycle). L'ordre de rotation suit l'**ordre personnalisé** des joueurs s'il a été défini (voir ci-dessous), sinon l'ordre alphabétique par défaut.
 
 Le donneur actuel est identifiable par un **icône de cartes** bleu sur son avatar dans le tableau des scores.
 
@@ -130,6 +130,19 @@ Si le donneur automatique ne correspond pas (reprise de partie, erreur de rotati
 4. Appuyer sur **Valider**
 
 > Le donneur sélectionné doit être un joueur de la session. La rotation automatique reprend normalement à partir du nouveau donneur.
+
+#### Changer l'ordre des joueurs
+
+Par défaut, les joueurs sont affichés et la rotation du donneur suit l'**ordre alphabétique**. Pour adapter l'ordre à la disposition physique autour de la table :
+
+1. Ouvrir le **menu ⋮** en haut à droite
+2. Appuyer sur **« Changer l'ordre »** (disponible uniquement quand la session est active et aucune donne n'est en cours)
+3. Utiliser les **flèches haut/bas** pour déplacer chaque joueur
+4. Appuyer sur **Valider**
+
+L'ordre personnalisé s'applique au **tableau des scores**, au **graphe d'évolution**, à la **sélection du preneur/appelé** et à la **rotation du donneur**.
+
+> Pour réinitialiser l'ordre alphabétique, il suffit de ré-ordonner manuellement les joueurs dans l'ordre alphabétique.
 
 ---
 

--- a/frontend/src/__tests__/components/ReorderPlayersModal.test.tsx
+++ b/frontend/src/__tests__/components/ReorderPlayersModal.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, screen, within } from "@testing-library/react";
+import ReorderPlayersModal from "../../components/ReorderPlayersModal";
+import { renderWithProviders } from "../test-utils";
+
+const players = [
+  { color: null, id: 1, name: "Alice" },
+  { color: null, id: 2, name: "Bob" },
+  { color: null, id: 3, name: "Charlie" },
+  { color: null, id: 4, name: "Diana" },
+  { color: null, id: 5, name: "Eve" },
+];
+
+describe("ReorderPlayersModal", () => {
+  it("affiche tous les joueurs dans l'ordre initial", () => {
+    renderWithProviders(
+      <ReorderPlayersModal
+        onClose={() => {}}
+        onConfirm={() => {}}
+        open={true}
+        players={players}
+      />,
+    );
+
+    expect(screen.getByText("Changer l'ordre")).toBeInTheDocument();
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(5);
+    expect(within(items[0]).getByText("Alice")).toBeInTheDocument();
+    expect(within(items[4]).getByText("Eve")).toBeInTheDocument();
+  });
+
+  it("déplace un joueur vers le haut", () => {
+    renderWithProviders(
+      <ReorderPlayersModal
+        onClose={() => {}}
+        onConfirm={() => {}}
+        open={true}
+        players={players}
+      />,
+    );
+
+    // Move Bob (index 1) up
+    fireEvent.click(screen.getByLabelText("Monter Bob"));
+
+    const items = screen.getAllByRole("listitem");
+    expect(within(items[0]).getByText("Bob")).toBeInTheDocument();
+    expect(within(items[1]).getByText("Alice")).toBeInTheDocument();
+  });
+
+  it("déplace un joueur vers le bas", () => {
+    renderWithProviders(
+      <ReorderPlayersModal
+        onClose={() => {}}
+        onConfirm={() => {}}
+        open={true}
+        players={players}
+      />,
+    );
+
+    // Move Alice (index 0) down
+    fireEvent.click(screen.getByLabelText("Descendre Alice"));
+
+    const items = screen.getAllByRole("listitem");
+    expect(within(items[0]).getByText("Bob")).toBeInTheDocument();
+    expect(within(items[1]).getByText("Alice")).toBeInTheDocument();
+  });
+
+  it("désactive le bouton monter pour le premier joueur", () => {
+    renderWithProviders(
+      <ReorderPlayersModal
+        onClose={() => {}}
+        onConfirm={() => {}}
+        open={true}
+        players={players}
+      />,
+    );
+
+    expect(screen.getByLabelText("Monter Alice")).toBeDisabled();
+  });
+
+  it("désactive le bouton descendre pour le dernier joueur", () => {
+    renderWithProviders(
+      <ReorderPlayersModal
+        onClose={() => {}}
+        onConfirm={() => {}}
+        open={true}
+        players={players}
+      />,
+    );
+
+    expect(screen.getByLabelText("Descendre Eve")).toBeDisabled();
+  });
+
+  it("désactive le bouton valider quand l'ordre n'a pas changé", () => {
+    renderWithProviders(
+      <ReorderPlayersModal
+        onClose={() => {}}
+        onConfirm={() => {}}
+        open={true}
+        players={players}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Valider" })).toBeDisabled();
+  });
+
+  it("appelle onConfirm avec le nouvel ordre d'IDs", () => {
+    const onConfirm = vi.fn();
+    renderWithProviders(
+      <ReorderPlayersModal
+        onClose={() => {}}
+        onConfirm={onConfirm}
+        open={true}
+        players={players}
+      />,
+    );
+
+    // Move Bob up: [Bob, Alice, Charlie, Diana, Eve]
+    fireEvent.click(screen.getByLabelText("Monter Bob"));
+    fireEvent.click(screen.getByRole("button", { name: "Valider" }));
+
+    expect(onConfirm).toHaveBeenCalledWith([2, 1, 3, 4, 5]);
+  });
+
+  it("désactive le bouton valider quand isPending est true", () => {
+    renderWithProviders(
+      <ReorderPlayersModal
+        isPending={true}
+        onClose={() => {}}
+        onConfirm={() => {}}
+        open={true}
+        players={players}
+      />,
+    );
+
+    // Move a player to enable the button normally
+    fireEvent.click(screen.getByLabelText("Monter Bob"));
+
+    expect(screen.getByRole("button", { name: "Valider" })).toBeDisabled();
+  });
+});

--- a/frontend/src/__tests__/hooks/useReorderPlayers.test.ts
+++ b/frontend/src/__tests__/hooks/useReorderPlayers.test.ts
@@ -1,0 +1,74 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import { useReorderPlayers } from "../../hooks/useReorderPlayers";
+import * as api from "../../services/api";
+import { createTestQueryClient } from "../test-utils";
+
+vi.mock("../../services/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  const w = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper: w };
+}
+
+describe("useReorderPlayers", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends PATCH with playerOrder", async () => {
+    vi.mocked(api.apiFetch).mockResolvedValue({ id: 1 });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useReorderPlayers(1), { wrapper });
+
+    await act(() => result.current.mutateAsync([3, 1, 5, 2, 4]));
+
+    expect(api.apiFetch).toHaveBeenCalledWith("/sessions/1", {
+      body: JSON.stringify({ playerOrder: [3, 1, 5, 2, 4] }),
+      headers: { "Content-Type": "application/merge-patch+json" },
+      method: "PATCH",
+    });
+  });
+
+  it("invalidates session query on success", async () => {
+    vi.mocked(api.apiFetch).mockResolvedValue({ id: 1 });
+    const { queryClient, wrapper } = createWrapper();
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useReorderPlayers(1), { wrapper });
+
+    await act(() => result.current.mutateAsync([3, 1, 5, 2, 4]));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["session", 1],
+    });
+  });
+
+  it("propagates API errors", async () => {
+    const apiError = new api.ApiError(
+      { detail: "Validation error" },
+      "API error: 422",
+      422,
+    );
+    vi.mocked(api.apiFetch).mockRejectedValue(apiError);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useReorderPlayers(1), { wrapper });
+
+    act(() => result.current.mutate([99, 98, 97, 96, 95]));
+
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(api.ApiError);
+    });
+  });
+});

--- a/frontend/src/__tests__/utils/sortPlayersByOrder.test.ts
+++ b/frontend/src/__tests__/utils/sortPlayersByOrder.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { sortPlayersByOrder } from "../../utils/playerOrder";
+
+const players = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" },
+  { id: 4, name: "Diana" },
+  { id: 5, name: "Eve" },
+];
+
+describe("sortPlayersByOrder", () => {
+  it("renvoie les joueurs inchangés quand playerOrder est null", () => {
+    const result = sortPlayersByOrder(players, null);
+    expect(result).toEqual(players);
+  });
+
+  it("trie les joueurs selon l'ordre personnalisé", () => {
+    const result = sortPlayersByOrder(players, [5, 3, 1, 4, 2]);
+    expect(result.map((p) => p.name)).toEqual([
+      "Eve",
+      "Charlie",
+      "Alice",
+      "Diana",
+      "Bob",
+    ]);
+  });
+
+  it("ignore les IDs absents de la liste des joueurs", () => {
+    const result = sortPlayersByOrder(players, [5, 3, 99, 4, 2]);
+    expect(result).toHaveLength(4);
+    expect(result.map((p) => p.id)).toEqual([5, 3, 4, 2]);
+  });
+});

--- a/frontend/src/components/ReorderPlayersModal.tsx
+++ b/frontend/src/components/ReorderPlayersModal.tsx
@@ -1,0 +1,81 @@
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useCallback, useState } from "react";
+import type { GamePlayer } from "../types/api";
+import { Modal, PlayerAvatar } from "./ui";
+
+interface ReorderPlayersModalProps {
+  isPending?: boolean;
+  onClose: () => void;
+  onConfirm: (playerIds: number[]) => void;
+  open: boolean;
+  players: GamePlayer[];
+}
+
+export default function ReorderPlayersModal({
+  isPending = false,
+  onClose,
+  onConfirm,
+  open,
+  players,
+}: ReorderPlayersModalProps) {
+  const [order, setOrder] = useState<GamePlayer[]>(players);
+
+  const initialIds = players.map((p) => p.id).join(",");
+  const currentIds = order.map((p) => p.id).join(",");
+  const hasChanged = initialIds !== currentIds;
+  const canSubmit = hasChanged && !isPending;
+
+  const move = useCallback((index: number, direction: -1 | 1) => {
+    setOrder((prev) => {
+      const next = [...prev];
+      const target = index + direction;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  }, []);
+
+  return (
+    <Modal onClose={onClose} open={open} title="Changer l'ordre">
+      <div className="flex flex-col gap-4">
+        <ul className="flex flex-col gap-2">
+          {order.map((player, index) => (
+            <li
+              className="flex items-center gap-3 rounded-xl bg-surface-secondary px-3 py-2"
+              key={player.id}
+            >
+              <PlayerAvatar color={player.color} name={player.name} playerId={player.id} size="sm" />
+              <span className="flex-1 text-sm font-medium text-text-primary">{player.name}</span>
+              <button
+                aria-label={`Monter ${player.name}`}
+                className="rounded-lg p-1 text-text-secondary transition-colors hover:bg-surface-primary disabled:opacity-30"
+                disabled={index === 0}
+                onClick={() => move(index, -1)}
+                type="button"
+              >
+                <ChevronUp size={18} />
+              </button>
+              <button
+                aria-label={`Descendre ${player.name}`}
+                className="rounded-lg p-1 text-text-secondary transition-colors hover:bg-surface-primary disabled:opacity-30"
+                disabled={index === order.length - 1}
+                onClick={() => move(index, 1)}
+                type="button"
+              >
+                <ChevronDown size={18} />
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <button
+          className="w-full rounded-xl bg-accent-500 py-3 text-sm font-semibold text-white transition-colors disabled:opacity-40"
+          disabled={!canSubmit}
+          onClick={() => onConfirm(order.map((p) => p.id))}
+          type="button"
+        >
+          Valider
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/hooks/useReorderPlayers.ts
+++ b/frontend/src/hooks/useReorderPlayers.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "../services/api";
+import type { SessionDetail } from "../types/api";
+
+export function useReorderPlayers(sessionId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (playerOrder: number[]) =>
+      apiFetch<SessionDetail>(`/sessions/${sessionId}`, {
+        body: JSON.stringify({ playerOrder }),
+        headers: { "Content-Type": "application/merge-patch+json" },
+        method: "PATCH",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
+    },
+  });
+}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { ArrowLeftRight, BarChart3, Lock, LockOpen, QrCode, Users } from "lucide-react";
+import { ArrowLeftRight, ArrowUpDown, BarChart3, Lock, LockOpen, QrCode, Users } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import NotFound from "./NotFound";
@@ -13,6 +13,7 @@ import GameList from "../components/GameList";
 import InProgressBanner from "../components/InProgressBanner";
 import MemeOverlay from "../components/MemeOverlay";
 import NewGameModal from "../components/NewGameModal";
+import ReorderPlayersModal from "../components/ReorderPlayersModal";
 import Scoreboard from "../components/Scoreboard";
 import ScoreEvolutionChart from "../components/ScoreEvolutionChart";
 import ShareQrCodeModal from "../components/ShareQrCodeModal";
@@ -24,6 +25,7 @@ import { useAllSessionGames } from "../hooks/useAllSessionGames";
 import { useCloseSession } from "../hooks/useCloseSession";
 import { useCreateGame } from "../hooks/useCreateGame";
 import { usePlayerGroups } from "../hooks/usePlayerGroups";
+import { useReorderPlayers } from "../hooks/useReorderPlayers";
 import { useSession } from "../hooks/useSession";
 import { useSessionGames } from "../hooks/useSessionGames";
 import { useUpdateDealer } from "../hooks/useUpdateDealer";
@@ -34,6 +36,7 @@ import type { GameContext, MemeConfig } from "../services/memeSelector";
 import { selectDefeatMeme, selectVictoryMeme } from "../services/memeSelector";
 import type { Badge } from "../types/api";
 import { GameStatus } from "../types/enums";
+import { sortPlayersByOrder } from "../utils/playerOrder";
 
 export default function SessionPage() {
   const { id } = useParams<{ id: string }>();
@@ -51,6 +54,7 @@ export default function SessionPage() {
   const closeSession = useCloseSession(sessionId);
   const createGame = useCreateGame(sessionId);
   const { groups } = usePlayerGroups();
+  const reorderPlayers = useReorderPlayers(sessionId);
   const updateDealer = useUpdateDealer(sessionId);
   const updateGroup = useUpdateSessionGroup(sessionId);
   const { toast } = useToast();
@@ -66,6 +70,11 @@ export default function SessionPage() {
 
   const lastGame = inProgressGame ?? lastCompletedGame;
 
+  const orderedPlayers = useMemo(
+    () => (session ? sortPlayersByOrder(session.players, session.playerOrder) : []),
+    [session],
+  );
+
   const queryClient = useQueryClient();
   const [activeMeme, setActiveMeme] = useState<MemeConfig | null>(null);
   const [badgeModalBadges, setBadgeModalBadges] = useState<Record<string, Badge[]> | null>(null);
@@ -77,6 +86,7 @@ export default function SessionPage() {
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [memeLabel, setMemeLabel] = useState<string | undefined>(undefined);
   const [newGameModalOpen, setNewGameModalOpen] = useState(false);
+  const [reorderModalOpen, setReorderModalOpen] = useState(false);
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [starModalOpen, setStarModalOpen] = useState(false);
   const [starPlayerId, setStarPlayerId] = useState<number | null>(null);
@@ -89,6 +99,9 @@ export default function SessionPage() {
       { icon: <QrCode size={18} />, label: "Partager (QR)", onClick: () => setShareModalOpen(true) },
       { disabled: !!inProgressGame, icon: <ArrowLeftRight size={18} />, label: "Modifier les joueurs", onClick: () => setSwapModalOpen(true) },
     ];
+    if (session?.isActive) {
+      items.push({ disabled: !!inProgressGame, icon: <ArrowUpDown size={18} />, label: "Changer l'ordre", onClick: () => setReorderModalOpen(true) });
+    }
     if (groups.length > 0) {
       items.push({ icon: <Users size={18} />, label: "Changer le groupe", onClick: () => setChangeGroupModalOpen(true) });
     }
@@ -191,7 +204,7 @@ export default function SessionPage() {
           setStarModalOpen(true);
         }}
         onDealerChange={() => setChangeDealerModalOpen(true)}
-        players={session.players}
+        players={orderedPlayers}
         starEvents={session.starEvents}
       />
 
@@ -210,7 +223,7 @@ export default function SessionPage() {
           </h2>
           <ScoreEvolutionChart
             games={allGames}
-            players={session.players}
+            players={orderedPlayers}
           />
         </section>
       )}
@@ -266,7 +279,7 @@ export default function SessionPage() {
         lastGameConfig={lastCompletedGame ? { contract: lastCompletedGame.contract, takerId: lastCompletedGame.taker.id } : undefined}
         onClose={() => setNewGameModalOpen(false)}
         open={newGameModalOpen}
-        players={session.players}
+        players={orderedPlayers}
       />
 
       {inProgressGame && (
@@ -277,7 +290,7 @@ export default function SessionPage() {
           onGameCompleted={handleGameCompleted}
           onGameSaved={handleGameSaved}
           open={completeModalOpen}
-          players={session.players}
+          players={orderedPlayers}
           sessionId={sessionId}
         />
       )}
@@ -287,7 +300,7 @@ export default function SessionPage() {
           game={lastCompletedGame}
           onClose={() => setEditModalOpen(false)}
           open={editModalOpen}
-          players={session.players}
+          players={orderedPlayers}
           sessionId={sessionId}
         />
       )}
@@ -302,7 +315,7 @@ export default function SessionPage() {
       )}
 
       <SwapPlayersModal
-        currentPlayerIds={session.players.map((p) => p.id)}
+        currentPlayerIds={orderedPlayers.map((p) => p.id)}
         onClose={() => setSwapModalOpen(false)}
         onSwap={(newSession) => {
           setSwapModalOpen(false);
@@ -311,6 +324,21 @@ export default function SessionPage() {
           }
         }}
         open={swapModalOpen}
+      />
+
+      <ReorderPlayersModal
+        isPending={reorderPlayers.isPending}
+        onClose={() => setReorderModalOpen(false)}
+        onConfirm={(playerIds) => {
+          reorderPlayers.mutate(playerIds, {
+            onSuccess: () => {
+              toast("Ordre des joueurs modifié");
+              setReorderModalOpen(false);
+            },
+          });
+        }}
+        open={reorderModalOpen}
+        players={orderedPlayers}
       />
 
       <AddStarModal
@@ -349,7 +377,7 @@ export default function SessionPage() {
             });
           }}
           open={changeDealerModalOpen}
-          players={session.players}
+          players={orderedPlayers}
         />
       )}
 
@@ -411,7 +439,7 @@ export default function SessionPage() {
           newBadges={badgeModalBadges}
           onClose={() => setBadgeModalBadges(null)}
           open={badgeModalBadges !== null}
-          players={session.players}
+          players={orderedPlayers}
         />
       )}
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -207,6 +207,7 @@ export interface SessionDetail {
   inProgressGame?: Game | null;
   isActive: boolean;
   playerGroup: PlayerGroup | null;
+  playerOrder: number[] | null;
   players: GamePlayer[];
   starEvents: StarEvent[];
 }

--- a/frontend/src/utils/playerOrder.ts
+++ b/frontend/src/utils/playerOrder.ts
@@ -1,0 +1,20 @@
+export function sortPlayersByOrder<T extends { id: number }>(
+  players: T[],
+  playerOrder: number[] | null,
+): T[] {
+  if (!playerOrder) {
+    return players;
+  }
+
+  const indexed = new Map(players.map((p) => [p.id, p]));
+  const ordered: T[] = [];
+
+  for (const id of playerOrder) {
+    const player = indexed.get(id);
+    if (player) {
+      ordered.push(player);
+    }
+  }
+
+  return ordered;
+}


### PR DESCRIPTION
## Summary

- Ajout d'une colonne JSON `playerOrder` sur `Session` (nullable, fallback alphabétique)
- Validateur `PlayerOrderMatchesSession` : vérifie que les IDs correspondent aux joueurs de la session (même set, pas de doublons)
- `SessionCreateProcessor` initialise `playerOrder` à la création
- `advanceDealer()` suit l'ordre personnalisé pour la rotation du donneur
- Frontend : hook `useReorderPlayers`, utilitaire `sortPlayersByOrder`, modale `ReorderPlayersModal` avec flèches haut/bas
- `SessionPage` : tous les composants enfants reçoivent `orderedPlayers` au lieu de `session.players`

## Test plan

- [x] 4 tests unitaires entity (`getOrderedPlayers`, `advanceDealer` custom order + wrap-around)
- [x] 5 tests unitaires validateur (`null` OK, valid OK, wrong count/duplicates/wrong IDs → violation)
- [x] 7 tests API (PATCH valid/invalid/duplicates/wrong count/null reset, dealer advancement, create sets initial order)
- [x] 3 tests utilitaire `sortPlayersByOrder`
- [x] 3 tests hook `useReorderPlayers`
- [x] 8 tests composant `ReorderPlayersModal`
- [x] 184 backend tests pass, 547/555 frontend tests pass (8 pré-existants en échec)

fixes #188