### PR TITLE
feat(stats): ajouter les statistiques d'étoiles sur la page stats joueur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Statistiques d'étoiles** : nouvelle section « Étoiles » sur la page de statistiques joueur, avec nombre total, pénalités, ratio par donne et par session, record en une session et nombre de sessions avec étoiles.
 - **Ordre personnalisé des joueurs** : possibilité de réorganiser l'ordre des joueurs dans une session via le menu ⋮ > « Changer l'ordre ». L'ordre personnalisé s'applique au tableau des scores, au graphe d'évolution, à la sélection preneur/appelé et à la rotation automatique du donneur.
 - **Détail des scores par donne** : au clic sur une donne dans l'historique, un panneau dépliable affiche les scores individuels de chaque joueur (preneur → appelé → défense) avec le nombre de bouts et l'écart par rapport au contrat.
 

--- a/backend/src/Repository/StarEventRepository.php
+++ b/backend/src/Repository/StarEventRepository.php
@@ -97,6 +97,44 @@ final class StarEventRepository extends ServiceEntityRepository
         return (int) $qb->getQuery()->getSingleScalarResult();
     }
 
+    public function countSessionsWithStarsForPlayer(Player $player, ?int $playerGroupId = null): int
+    {
+        $qb = $this->createQueryBuilder('se')
+            ->select('COUNT(DISTINCT IDENTITY(se.session))')
+            ->andWhere('se.player = :player')
+            ->setParameter('player', $player);
+
+        if (null !== $playerGroupId) {
+            $qb->join('App\Entity\Session', 's_grp', 'WITH', 'se.session = s_grp')
+               ->andWhere('s_grp.playerGroup = :group')
+               ->setParameter('group', $playerGroupId);
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    public function getMaxStarsInSessionForPlayer(Player $player, ?int $playerGroupId = null): int
+    {
+        $qb = $this->createQueryBuilder('se')
+            ->select('COUNT(se.id) AS cnt')
+            ->andWhere('se.player = :player')
+            ->setParameter('player', $player)
+            ->groupBy('se.session')
+            ->orderBy('cnt', 'DESC')
+            ->setMaxResults(1);
+
+        if (null !== $playerGroupId) {
+            $qb->join('App\Entity\Session', 's_grp', 'WITH', 'se.session = s_grp')
+               ->andWhere('s_grp.playerGroup = :group')
+               ->setParameter('group', $playerGroupId);
+        }
+
+        /** @var array{cnt: string}|null $result */
+        $result = $qb->getQuery()->getOneOrNullResult();
+
+        return null !== $result ? (int) $result['cnt'] : 0;
+    }
+
     public function countAll(?int $playerGroupId = null): int
     {
         $qb = $this->createQueryBuilder('se')

--- a/backend/src/Service/PlayerStatisticsService.php
+++ b/backend/src/Service/PlayerStatisticsService.php
@@ -193,7 +193,7 @@ final readonly class PlayerStatisticsService
      * - Historique ELO et records personnels
      * - Durée moyenne et totale de jeu
      *
-     * @return array{badges: list<array{description: string, emoji: string, label: string, type: string, unlockedAt: string|null}>, averageGameDurationSeconds: int|null, averageScore: float, bestGameScore: int, contractDistribution: list<array{contract: string, count: int, winRate: float, wins: int}>, eloHistory: list<array{date: string, gameId: int, ratingAfter: int, ratingChange: int}>, eloRating: int, gamesAsDefender: int, gamesAsPartner: int, gamesAsTaker: int, gamesPlayed: int, player: array{id: int|null, name: string}, playerGroups: list<array{id: int|null, name: string}>, recentScores: list<array{date: string, gameId: int, score: int, sessionId: int}>, records: list<array{contract: string|null, date: string, sessionId: int|null, type: string, value: int|float}>, sessionsPlayed: int, starPenalties: int, totalPlayTimeSeconds: int, totalStars: int, winRateAsTaker: float, worstGameScore: int}
+     * @return array{badges: list<array{description: string, emoji: string, label: string, type: string, unlockedAt: string|null}>, averageGameDurationSeconds: int|null, averageScore: float, bestGameScore: int, contractDistribution: list<array{contract: string, count: int, winRate: float, wins: int}>, eloHistory: list<array{date: string, gameId: int, ratingAfter: int, ratingChange: int}>, eloRating: int, gamesAsDefender: int, gamesAsPartner: int, gamesAsTaker: int, gamesPlayed: int, maxStarsInSession: int, player: array{id: int|null, name: string}, playerGroups: list<array{id: int|null, name: string}>, recentScores: list<array{date: string, gameId: int, score: int, sessionId: int}>, records: list<array{contract: string|null, date: string, sessionId: int|null, type: string, value: int|float}>, sessionsPlayed: int, sessionsWithStars: int, starPenalties: int, starsPerGame: float, starsPerSession: float, totalPlayTimeSeconds: int, totalStars: int, winRateAsTaker: float, worstGameScore: int}
      */
     public function getPlayerStats(Player $player, ?int $playerGroupId = null): array
     {
@@ -243,6 +243,8 @@ final readonly class PlayerStatisticsService
 
         $totalStars = $this->starEventRepository->countByPlayerFiltered($player, $playerGroupId);
         $starPenalties = (int) \floor($totalStars / 3);
+        $maxStarsInSession = $this->starEventRepository->getMaxStarsInSessionForPlayer($player, $playerGroupId);
+        $sessionsWithStars = $this->starEventRepository->countSessionsWithStarsForPlayer($player, $playerGroupId);
 
         $durationStats = $this->getPlayerDurationStats($player, $playerGroupId);
 
@@ -258,6 +260,7 @@ final readonly class PlayerStatisticsService
             'gamesAsPartner' => $gamesAsPartner,
             'gamesAsTaker' => $gamesAsTaker,
             'gamesPlayed' => $gamesPlayed,
+            'maxStarsInSession' => $maxStarsInSession,
             'player' => ['id' => $playerId, 'name' => $player->getName()],
             'playerGroups' => \array_map(
                 static fn (PlayerGroup $pg) => ['id' => $pg->getId(), 'name' => $pg->getName()],
@@ -266,7 +269,10 @@ final readonly class PlayerStatisticsService
             'recentScores' => $formattedRecentScores,
             'records' => $this->getPlayerRecords($player, $playerGroupId),
             'sessionsPlayed' => $sessionsPlayed,
+            'sessionsWithStars' => $sessionsWithStars,
             'starPenalties' => $starPenalties,
+            'starsPerGame' => $gamesPlayed > 0 ? \round($totalStars / $gamesPlayed, 1) : 0.0,
+            'starsPerSession' => $sessionsPlayed > 0 ? \round($totalStars / $sessionsPlayed, 1) : 0.0,
             'totalPlayTimeSeconds' => $durationStats['totalPlayTimeSeconds'],
             'totalStars' => $totalStars,
             'winRateAsTaker' => $gamesAsTaker > 0 ? \round($winsAsTaker / $gamesAsTaker * 100, 1) : 0.0,

--- a/backend/tests/Api/StatisticsApiTest.php
+++ b/backend/tests/Api/StatisticsApiTest.php
@@ -8,6 +8,7 @@ use App\Entity\Game;
 use App\Entity\Player;
 use App\Entity\ScoreEntry;
 use App\Entity\Session;
+use App\Entity\StarEvent;
 use App\Enum\Contract;
 use App\Enum\GameStatus;
 
@@ -598,6 +599,76 @@ class StatisticsApiTest extends ApiTestCase
             ->getSingleScalarResult();
 
         $this->assertGreaterThan(0, $badgeCountAfter, 'Badges should be awarded when a game is completed via API.');
+    }
+
+    public function testPlayerStatisticsIncludesStarStats(): void
+    {
+        $alice = $this->players['Alice'];
+
+        // Create a second session
+        $session2 = new Session();
+        foreach ($this->players as $player) {
+            $session2->addPlayer($player);
+        }
+        $this->em->persist($session2);
+        $this->em->flush();
+
+        // Add 3 star events for Alice in session1 and 2 in session2
+        for ($i = 0; $i < 3; ++$i) {
+            $star = new StarEvent();
+            $star->setPlayer($alice);
+            $star->setSession($this->session);
+            $this->em->persist($star);
+        }
+        for ($i = 0; $i < 2; ++$i) {
+            $star = new StarEvent();
+            $star->setPlayer($alice);
+            $star->setSession($session2);
+            $this->em->persist($star);
+        }
+        $this->em->flush();
+
+        $response = $this->client->request('GET', '/api/statistics/players/'.$alice->getId());
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray();
+
+        // totalStars: 5
+        $this->assertSame(5, $data['totalStars']);
+        // starPenalties: floor(5/3) = 1
+        $this->assertSame(1, $data['starPenalties']);
+
+        // New fields
+        // starsPerGame: 5 / 3 = 1.7
+        $this->assertArrayHasKey('starsPerGame', $data);
+        $this->assertEqualsWithDelta(1.7, $data['starsPerGame'], 0.01);
+
+        // starsPerSession: 5 / 1 = 5.0 (only 1 session with games for Alice)
+        $this->assertArrayHasKey('starsPerSession', $data);
+        $this->assertEqualsWithDelta(5.0, $data['starsPerSession'], 0.01);
+
+        // maxStarsInSession: 3 (session1 has 3 stars)
+        $this->assertArrayHasKey('maxStarsInSession', $data);
+        $this->assertSame(3, $data['maxStarsInSession']);
+
+        // sessionsWithStars: 2 (both sessions have stars)
+        $this->assertArrayHasKey('sessionsWithStars', $data);
+        $this->assertSame(2, $data['sessionsWithStars']);
+    }
+
+    public function testPlayerStatisticsStarStatsWithNoStars(): void
+    {
+        $alice = $this->players['Alice'];
+
+        $response = $this->client->request('GET', '/api/statistics/players/'.$alice->getId());
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray();
+
+        $this->assertSame(0, $data['totalStars']);
+        $this->assertSame(0, $data['starPenalties']);
+        $this->assertEqualsWithDelta(0.0, $data['starsPerGame'], 0.01);
+        $this->assertEqualsWithDelta(0.0, $data['starsPerSession'], 0.01);
+        $this->assertSame(0, $data['maxStarsInSession']);
+        $this->assertSame(0, $data['sessionsWithStars']);
     }
 
     public function testGlobalStatisticsWithNonExistentGroup(): void

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -81,7 +81,7 @@ import type { HydraCollection, Player } from "./types/api";
 | `LeaderboardEntry` | `gamesAsTaker`, `gamesPlayed`, `playerColor: string \| null`, `playerId`, `playerName`, `totalScore`, `winRate`, `wins` |
 | `PlayerContractEntry` | `contract: Contract`, `count`, `winRate`, `wins` |
 | `PersonalRecord` | `contract: string \| null`, `date: string`, `sessionId: number \| null`, `type: string`, `value: number` |
-| `PlayerStatistics` | `badges: Badge[]`, `averageGameDurationSeconds: number \| null`, `averageScore`, `bestGameScore`, `contractDistribution`, `eloHistory: EloHistoryEntry[]`, `eloRating: number`, `gamesAsDefender`, `gamesAsPartner`, `gamesAsTaker`, `gamesPlayed`, `player`, `playerGroups: { id: number; name: string }[]`, `records: PersonalRecord[]`, `recentScores`, `sessionsPlayed`, `starPenalties`, `totalPlayTimeSeconds: number`, `totalStars`, `winRateAsTaker`, `worstGameScore` |
+| `PlayerStatistics` | `badges: Badge[]`, `averageGameDurationSeconds: number \| null`, `averageScore`, `bestGameScore`, `contractDistribution`, `eloHistory: EloHistoryEntry[]`, `eloRating: number`, `gamesAsDefender`, `gamesAsPartner`, `gamesAsTaker`, `gamesPlayed`, `maxStarsInSession`, `player`, `playerGroups: { id: number; name: string }[]`, `records: PersonalRecord[]`, `recentScores`, `sessionsPlayed`, `sessionsWithStars`, `starPenalties`, `starsPerGame`, `starsPerSession`, `totalPlayTimeSeconds: number`, `totalStars`, `winRateAsTaker`, `worstGameScore` |
 | `RecentScoreEntry` | `date: string`, `gameId: number`, `score: number`, `sessionId: number` |
 
 ### `ApiError`
@@ -759,7 +759,7 @@ Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.m
 - Filtre par groupe (`GroupFilter`) — filtre les statistiques par groupe (initialisation depuis `?group=`)
 - Métriques clés : donnes jouées, taux de victoire, score moyen, ELO, sessions, durée moyenne par donne et temps de jeu total (si disponible)
 - Groupes du joueur : badges cliquables renvoyant vers `/groups/:id`
-- **Menu déroulant de section** : les sections détaillées sont accessibles via un `<select>` (une seule visible à la fois) — Records personnels, Badges, Répartition des rôles, Contrats, Évolution des scores, Évolution ELO
+- **Menu déroulant de section** : les sections détaillées sont accessibles via un `<Select>` (une seule visible à la fois) — Records personnels, Badges, Étoiles (masquée si 0 étoiles), Répartition des rôles, Contrats, Évolution des scores, Évolution ELO
 - Bouton retour vers `/stats`
 - États : chargement, joueur introuvable
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -385,6 +385,7 @@ L'écran de détail d'un joueur affiche :
 - **Menu déroulant de section** : un sélecteur permet de choisir la section affichée parmi :
   - **Records personnels** (par défaut) : meilleur score, pire score, série de victoires consécutives (en tant que preneur), meilleure session (total de points dans une session) et plus grand écart (différence entre points réalisés et points requis). Chaque record indique la date, le contrat (si applicable) et un lien vers la session concernée.
   - **Badges** : grille des badges débloqués (verrouillés masqués par défaut, révélables via un bouton)
+  - **Étoiles** (masquée si aucune étoile) : nombre total d'étoiles, pénalités, ratio par donne et par session, record en une session et nombre de sessions avec étoiles
   - **Répartition des rôles** : barre visuelle montrant combien de fois le joueur a été preneur, partenaire ou défenseur
   - **Contrats** : graphique à barres des contrats joués en tant que preneur
   - **Évolution des scores** : graphique linéaire des 50 derniers scores
@@ -420,7 +421,7 @@ Le système d'étoiles permet de **pénaliser** un joueur en dehors du jeu de ca
 
 - Les pénalités d'étoiles sont **incluses dans les scores cumulés** de la session
 - Les pénalités apparaissent dans le **classement global** des statistiques
-- Les statistiques d'un joueur affichent le **nombre total d'étoiles** reçues et le **nombre de pénalités** subies
+- Les statistiques d'un joueur affichent une section **« Étoiles »** dédiée avec le nombre total, les pénalités, le ratio par donne/session, le record en une session et le nombre de sessions avec étoiles
 
 > **Note** : la somme des scores de pénalité est toujours nulle (−100 + 4 × 25 = 0).
 

--- a/frontend/src/__tests__/pages/PlayerStats.test.tsx
+++ b/frontend/src/__tests__/pages/PlayerStats.test.tsx
@@ -18,6 +18,9 @@ vi.mock("../../hooks/usePlayerGroups", () => ({
 
 vi.mock("../../hooks/usePlayerStats");
 
+// jsdom doesn't implement scrollIntoView
+Element.prototype.scrollIntoView = vi.fn();
+
 const mockStats = {
   averageGameDurationSeconds: 480,
   badges: [],
@@ -35,7 +38,8 @@ const mockStats = {
   gamesAsPartner: 20,
   gamesAsTaker: 35,
   gamesPlayed: 145,
-  player: { id: 1, name: "Alice" },
+  maxStarsInSession: 3,
+  player: { color: null, id: 1, name: "Alice" },
   playerGroups: [{ id: 1, name: "Mardi soir" }],
   recentScores: [
     { date: "2026-02-07T12:00:00+00:00", gameId: 3, score: 120, sessionId: 1 },
@@ -48,7 +52,10 @@ const mockStats = {
     { contract: null, date: "2026-02-07T12:00:00+00:00", sessionId: null, type: "win_streak", value: 3 },
   ],
   sessionsPlayed: 10,
+  sessionsWithStars: 0,
   starPenalties: 0,
+  starsPerGame: 0,
+  starsPerSession: 0,
   totalPlayTimeSeconds: 4800,
   totalStars: 0,
   winRateAsTaker: 57.1,
@@ -220,6 +227,65 @@ describe("PlayerStats page", () => {
     expect(screen.getByText("8min")).toBeInTheDocument();
     expect(screen.getByText("Temps de jeu total")).toBeInTheDocument();
     expect(screen.getByText("1h 20min")).toBeInTheDocument();
+  });
+
+  it("renders star section when player has stars", async () => {
+    const user = userEvent.setup();
+    const statsWithStars = {
+      ...mockStats,
+      maxStarsInSession: 3,
+      sessionsWithStars: 4,
+      starPenalties: 2,
+      starsPerGame: 0.5,
+      starsPerSession: 0.7,
+      totalStars: 7,
+    };
+    vi.mocked(usePlayerStatsModule.usePlayerStats).mockReturnValue({
+      isPending: false,
+      stats: statsWithStars,
+    } as ReturnType<typeof usePlayerStatsModule.usePlayerStats>);
+
+    renderWithProviders(<PlayerStats />);
+
+    // Open the custom Select dropdown
+    const trigger = screen.getByRole("button", { name: /records personnels/i });
+    await user.click(trigger);
+
+    // "Étoiles" option should be available
+    const starsOption = screen.getByRole("option", { name: /étoiles/i });
+    expect(starsOption).toBeInTheDocument();
+
+    // Select the star section
+    await user.click(starsOption);
+
+    // Check star stats are displayed
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText(/pénalité/i)).toBeInTheDocument();
+    expect(screen.getByText("0.5")).toBeInTheDocument();
+    expect(screen.getByText(/par donne/i)).toBeInTheDocument();
+    expect(screen.getByText("0.7")).toBeInTheDocument();
+    expect(screen.getByText(/par session/i)).toBeInTheDocument();
+    expect(screen.getByText(/max en une session/i)).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText(/sessions avec étoile/i)).toBeInTheDocument();
+  });
+
+  it("hides star section when player has no stars", async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePlayerStatsModule.usePlayerStats).mockReturnValue({
+      isPending: false,
+      stats: mockStats,
+    } as ReturnType<typeof usePlayerStatsModule.usePlayerStats>);
+
+    renderWithProviders(<PlayerStats />);
+
+    // Open the custom Select dropdown
+    const trigger = screen.getByRole("button", { name: /records personnels/i });
+    await user.click(trigger);
+
+    // "Étoiles" should NOT be in the options
+    expect(screen.queryByRole("option", { name: /étoiles/i })).not.toBeInTheDocument();
   });
 
   it("navigates back to /stats on back button click", async () => {

--- a/frontend/src/pages/PlayerStats.tsx
+++ b/frontend/src/pages/PlayerStats.tsx
@@ -11,11 +11,12 @@ import { PlayerAvatar, Select, Spinner } from "../components/ui";
 import { usePlayerStats } from "../hooks/usePlayerStats";
 import { formatDuration } from "../utils/formatDuration";
 
-type PlayerStatsSection = "badges" | "contracts" | "elo" | "records" | "roles" | "scores";
+type PlayerStatsSection = "badges" | "contracts" | "elo" | "records" | "roles" | "scores" | "stars";
 
 const ALL_SECTIONS: { label: string; value: PlayerStatsSection }[] = [
   { label: "Records personnels", value: "records" },
   { label: "Badges", value: "badges" },
+  { label: "Étoiles", value: "stars" },
   { label: "Répartition des rôles", value: "roles" },
   { label: "Contrats", value: "contracts" },
   { label: "Évolution des scores", value: "scores" },
@@ -43,6 +44,7 @@ export default function PlayerStats() {
       records: true,
       roles: rolesTotal > 0,
       scores: stats.recentScores.length > 0,
+      stars: stats.totalStars > 0,
     };
     return ALL_SECTIONS.filter((s) => hasData[s.value]);
   }, [rolesTotal, stats]);
@@ -110,27 +112,6 @@ export default function PlayerStats() {
         )}
       </div>
 
-      {stats.totalStars > 0 && (
-        <div className="flex gap-3">
-          <div className="flex-1 rounded-xl bg-surface-elevated p-3 text-center">
-            <span className="block text-lg font-bold text-yellow-400">
-              {"★".repeat(Math.min(stats.totalStars, 10))}{stats.totalStars > 10 ? "…" : ""}
-            </span>
-            <span className="text-xs text-text-muted">
-              {stats.totalStars} étoile{stats.totalStars > 1 ? "s" : ""}
-            </span>
-          </div>
-          <div className="flex-1 rounded-xl bg-surface-elevated p-3 text-center">
-            <span className="block text-lg font-bold text-score-negative">
-              {stats.starPenalties}
-            </span>
-            <span className="text-xs text-text-muted">
-              Pénalité{stats.starPenalties > 1 ? "s" : ""}
-            </span>
-          </div>
-        </div>
-      )}
-
       {stats.playerGroups.length > 0 && (
         <section>
           <h2 className="mb-2 text-sm font-semibold text-text-secondary">Groupes</h2>
@@ -154,6 +135,24 @@ export default function PlayerStats() {
         options={availableSections}
         value={selectedSection}
       />
+
+      {selectedSection === "stars" && (
+        <section>
+          <div className="mb-3 flex items-center gap-2">
+            <span className="text-lg text-yellow-400">
+              {"★".repeat(Math.min(stats.totalStars, 10))}{stats.totalStars > 10 ? "…" : ""}
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <MetricCard label="Étoiles" value={String(stats.totalStars)} />
+            <MetricCard label="Pénalités" value={String(stats.starPenalties)} />
+            <MetricCard label="Par donne" value={String(stats.starsPerGame)} />
+            <MetricCard label="Par session" value={String(stats.starsPerSession)} />
+            <MetricCard label="Max en une session" value={String(stats.maxStarsInSession)} />
+            <MetricCard label="Sessions avec étoiles" value={String(stats.sessionsWithStars)} />
+          </div>
+        </section>
+      )}
 
       {selectedSection === "records" && (
         <PersonalRecords records={stats.records} />

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -147,8 +147,8 @@ export interface PlayerContractEntry {
 
 export interface PlayerStatistics {
   averageGameDurationSeconds: number | null;
-  badges: Badge[];
   averageScore: number;
+  badges: Badge[];
   bestGameScore: number;
   contractDistribution: PlayerContractEntry[];
   eloHistory: EloHistoryEntry[];
@@ -157,12 +157,16 @@ export interface PlayerStatistics {
   gamesAsPartner: number;
   gamesAsTaker: number;
   gamesPlayed: number;
+  maxStarsInSession: number;
   player: GamePlayer;
   playerGroups: { id: number; name: string }[];
   recentScores: RecentScoreEntry[];
   records: PersonalRecord[];
   sessionsPlayed: number;
+  sessionsWithStars: number;
   starPenalties: number;
+  starsPerGame: number;
+  starsPerSession: number;
   totalPlayTimeSeconds: number;
   totalStars: number;
   winRateAsTaker: number;


### PR DESCRIPTION
## Summary

- Ajout de 4 nouvelles statistiques d'étoiles à l'API player stats : `starsPerGame`, `starsPerSession`, `maxStarsInSession`, `sessionsWithStars`
- Nouvelle section « Étoiles » dans le sélecteur de la page stats joueur, avec 6 métriques (étoiles totales, pénalités, ratio par donne/session, record en une session, sessions avec étoiles)
- La section est masquée automatiquement si le joueur n'a aucune étoile
- L'ancien affichage inline des étoiles (au-dessus des groupes) est remplacé par cette section dédiée

## Test plan

- [x] Tests backend : 2 nouveaux tests (avec/sans étoiles) vérifiant les 4 nouveaux champs
- [x] Tests frontend : 2 nouveaux tests (section visible avec étoiles, masquée sans étoiles)
- [x] Backend : 186/186 tests passent
- [x] Frontend : 549 tests passent (8 échecs pré-existants liés au Select custom)
- [x] PHPStan : pas de nouvelle erreur
- [x] PHP CS Fixer : aucun fix nécessaire
- [x] TypeScript : 0 erreurs

fixes #169