### PR TITLE
feat(frontend): afficher le numéro de la donne dans l'historique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Numéro de donne** : chaque donne dans l'historique affiche désormais son numéro séquentiel (#1, #2, #3…) pour une identification rapide.
 - **Logs Symfony (Monolog)** : ajout de `symfony/monolog-bundle` avec fichiers rotatifs en production (14 jours de rétention dans `var/log/`), pour diagnostiquer les erreurs 500.
 - **Statistiques d'étoiles** : nouvelle section « Étoiles » sur la page de statistiques joueur, avec nombre total, pénalités, ratio par donne et par session, record en une session et nombre de sessions avec étoiles.
 - **Ordre personnalisé des joueurs** : possibilité de réorganiser l'ordre des joueurs dans une session via le menu ⋮ > « Changer l'ordre ». L'ordre personnalisé s'applique au tableau des scores, au graphe d'évolution, à la sélection preneur/appelé et à la rotation automatique du donneur.

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -964,7 +964,7 @@ Liste des donnes terminées en ordre anti-chronologique (position décroissante)
 | `onLoadMore` | `() => void` | *requis* — action pour charger la page suivante |
 
 **Fonctionnalités** :
-- Chaque carte : avatar preneur, nom, badge contrat, durée de la donne (si `completedAt` disponible), « avec [partenaire] » ou « Seul », donneur, score du preneur
+- Chaque carte : numéro de donne (`#position`), avatar preneur, nom, badge contrat, durée de la donne (si `completedAt` disponible), « avec [partenaire] » ou « Seul », donneur, score du preneur
 - Boutons « Modifier » et « Supprimer » uniquement sur la dernière donne (position la plus élevée) et uniquement si la session est en cours (`isSessionActive`)
 - Bouton « Voir plus » quand `hasNextPage` est vrai, affichant « Chargement… » pendant le fetch
 - État vide : « Aucune donne jouée »

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -167,6 +167,7 @@ Si une donne est en cours (étape 1 validée, étape 2 en attente), un bandeau b
 
 Liste paginée des donnes jouées (les 10 plus récentes en premier, avec un bouton « Voir plus » pour charger la suite), montrant pour chaque donne :
 
+- Le **numéro de la donne** (#1, #2, #3…)
 - Le preneur et son partenaire
 - Le donneur de la donne
 - Le contrat (badge coloré) et la **durée de la donne** (si disponible)

--- a/frontend/src/__tests__/components/GameList.test.tsx
+++ b/frontend/src/__tests__/components/GameList.test.tsx
@@ -71,6 +71,17 @@ describe("GameList", () => {
     expect(items[1]).toHaveTextContent("Garde");
   });
 
+  it("displays the deal number (position) for each game", () => {
+    renderWithProviders(
+      <GameList games={games} {...defaultProps} />,
+    );
+
+    const items = screen.getAllByRole("listitem");
+    // Game at position 2 should display "#2", position 1 should display "#1"
+    expect(items[0]).toHaveTextContent("#2");
+    expect(items[1]).toHaveTextContent("#1");
+  });
+
   it("shows taker name for each game", () => {
     renderWithProviders(
       <GameList games={games} {...defaultProps} />,

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -82,6 +82,9 @@ export default function GameList({
               onClick={() => setExpandedId(isExpanded ? null : game.id)}
             >
               <div className="flex items-center gap-3">
+                <span className="w-6 text-center text-xs font-semibold text-text-muted">
+                  #{game.position}
+                </span>
                 <PlayerAvatar
                   color={game.taker.color}
                   name={game.taker.name}


### PR DESCRIPTION
## Summary

- Affiche le numéro séquentiel de chaque donne (#1, #2, #3…) dans l'historique de la session, basé sur le champ `position` du game
- Ajout d'un test vérifiant l'affichage des numéros
- Mise à jour du CHANGELOG, user-guide et frontend-usage

fixes #181