### PR TITLE
feat(frontend): stats session glissantes (10 dernières donnes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 - **Statistiques d'étoiles** : nouvelle section « Étoiles » sur la page de statistiques joueur, avec nombre total, pénalités, ratio par donne et par session, record en une session et nombre de sessions avec étoiles.
 - **Ordre personnalisé des joueurs** : possibilité de réorganiser l'ordre des joueurs dans une session via le menu ⋮ > « Changer l'ordre ». L'ordre personnalisé s'applique au tableau des scores, au graphe d'évolution, à la sélection preneur/appelé et à la rotation automatique du donneur.
 - **Détail des scores par donne** : au clic sur une donne dans l'historique, un panneau dépliable affiche les scores individuels de chaque joueur (preneur → appelé → défense) avec le nombre de bouts et l'écart par rapport au contrat.
+- **Stats session glissantes** : le graphe d'évolution des scores n'affiche plus que les 10 dernières donnes (fenêtre glissante) pour une meilleure lisibilité sur les longues sessions.
 
 ### Changed
 

--- a/frontend/src/__tests__/components/ScoreEvolutionChart.test.tsx
+++ b/frontend/src/__tests__/components/ScoreEvolutionChart.test.tsx
@@ -7,7 +7,7 @@ import ScoreEvolutionChart, { computeScoreEvolution } from "../../components/Sco
 // Mock Recharts to avoid jsdom rendering issues
 vi.mock("recharts", () => ({
   Line: ({ dataKey }: { dataKey: string }) => <div data-testid={`line-${dataKey}`} />,
-  LineChart: ({ children }: { children: React.ReactNode }) => <div data-testid="line-chart">{children}</div>,
+  LineChart: ({ children, data }: { children: React.ReactNode; data: unknown[] }) => <div data-point-count={data.length} data-testid="line-chart">{children}</div>,
   ReferenceLine: () => <div data-testid="reference-line" />,
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   Tooltip: () => <div data-testid="tooltip" />,
@@ -149,5 +149,38 @@ describe("ScoreEvolutionChart", () => {
     const aliceChip = screen.getByText("Alice");
     // Alice has custom color #ef4444
     expect(aliceChip).toHaveStyle({ backgroundColor: "#ef4444" });
+  });
+
+  it("renders only the last 10 data points when more than 10 games", () => {
+    const games = Array.from({ length: 12 }, (_, i) =>
+      makeGame(i + 1, { Alice: 10, Bob: -5, Charlie: -5, Diana: 5, Eve: -5 }),
+    );
+
+    render(<ScoreEvolutionChart games={games} players={players} />);
+
+    const chart = screen.getByTestId("line-chart");
+    expect(chart).toHaveAttribute("data-point-count", "10");
+  });
+
+  it("renders all 10 data points when exactly 10 games", () => {
+    const games = Array.from({ length: 10 }, (_, i) =>
+      makeGame(i + 1, { Alice: 10, Bob: -5, Charlie: -5, Diana: 5, Eve: -5 }),
+    );
+
+    render(<ScoreEvolutionChart games={games} players={players} />);
+
+    const chart = screen.getByTestId("line-chart");
+    expect(chart).toHaveAttribute("data-point-count", "10");
+  });
+
+  it("renders all data points when 10 or fewer games", () => {
+    const games = Array.from({ length: 8 }, (_, i) =>
+      makeGame(i + 1, { Alice: 10, Bob: -5, Charlie: -5, Diana: 5, Eve: -5 }),
+    );
+
+    render(<ScoreEvolutionChart games={games} players={players} />);
+
+    const chart = screen.getByTestId("line-chart");
+    expect(chart).toHaveAttribute("data-point-count", "8");
   });
 });

--- a/frontend/src/components/ScoreEvolutionChart.tsx
+++ b/frontend/src/components/ScoreEvolutionChart.tsx
@@ -64,7 +64,7 @@ export default function ScoreEvolutionChart({ games, players }: ScoreEvolutionCh
     [players],
   );
 
-  const data = computeScoreEvolution(games, players);
+  const data = computeScoreEvolution(games, players).slice(-10);
 
   if (data.length < 2) {
     return null;


### PR DESCRIPTION
## Résumé

- Applique `.slice(-10)` sur les données du `ScoreEvolutionChart` pour n'afficher que les 10 dernières donnes (fenêtre glissante)
- Ajout de 2 tests : vérification du sliding window avec >10 donnes et ≤10 donnes

## Tests

- `ddev exec make test-front` — 11/11 tests ScoreEvolutionChart passent
- TypeScript clean (`tsc --noEmit`)

fixes #202