### PR TITLE
fix(frontend): memoize, useResetOnOpen, console.error → toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Changed
 
+- **Nettoyage frontend** : mémoïsation du calcul `computeScoreEvolution`, extraction d'un hook `useResetOnOpen` pour supprimer les `eslint-disable react-hooks/exhaustive-deps` dans 4 modales, et remplacement du `console.error` par un toast d'erreur dans le partage du récap de session.
 - **Accessibilité OverflowMenu** : ajout de `role="menu"` / `role="menuitem"`, `aria-expanded` sur le bouton déclencheur, et navigation clavier fléchée (ArrowUp/ArrowDown) avec saut des items désactivés.
 - **Accessibilité couleurs joueur** : les boutons radio de couleur dans la modale d'édition affichent désormais des noms français (« Rouge », « Bleu », etc.) au lieu de codes hexadécimaux pour les lecteurs d'écran.
 - **Accessibilité Toast** : les toasts sont maintenant focusables au clavier (`tabIndex`) et peuvent être fermés avec Entrée ou Échap.

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -480,6 +480,19 @@ Retourne une valeur retardée qui ne se met à jour qu'après un délai sans cha
 const debouncedQuery = useDebounce(searchQuery, 300);
 ```
 
+### `useResetOnOpen`
+
+**Fichier** : `hooks/useResetOnOpen.ts`
+
+Exécute un callback lorsque `open` passe à `true`. Utilisé dans les modales pour réinitialiser l'état local à l'ouverture, sans `eslint-disable react-hooks/exhaustive-deps`.
+
+```ts
+useResetOnOpen(open, () => {
+  setSelectedContract(null);
+  mutation.reset();
+});
+```
+
 ### `useSessionGames`
 
 **Fichier** : `hooks/useSessionGames.ts`
@@ -858,7 +871,7 @@ Page d'aide in-app reprenant le contenu du guide utilisateur (`docs/user-guide.m
 - Partage en image via `html-to-image` + Web Share API (fallback : téléchargement PNG)
 - Lien retour vers la session
 
-**Hooks utilisés** : `useSessionSummary`
+**Hooks utilisés** : `useSessionSummary`, `useToast`
 
 ### Page 404 (`NotFound`)
 

--- a/frontend/src/__tests__/hooks/useResetOnOpen.test.ts
+++ b/frontend/src/__tests__/hooks/useResetOnOpen.test.ts
@@ -1,0 +1,66 @@
+import { renderHook } from "@testing-library/react";
+import { useResetOnOpen } from "../../hooks/useResetOnOpen";
+
+describe("useResetOnOpen", () => {
+  it("calls the callback when open becomes true", () => {
+    const callback = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ open }) => useResetOnOpen(open, callback),
+      { initialProps: { open: false } },
+    );
+
+    expect(callback).not.toHaveBeenCalled();
+
+    rerender({ open: true });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call the callback when open becomes false", () => {
+    const callback = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ open }) => useResetOnOpen(open, callback),
+      { initialProps: { open: true } },
+    );
+
+    // Called once on initial render (open=true)
+    callback.mockClear();
+
+    rerender({ open: false });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("calls the callback again when modal reopens", () => {
+    const callback = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ open }) => useResetOnOpen(open, callback),
+      { initialProps: { open: false } },
+    );
+
+    rerender({ open: true });
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    rerender({ open: false });
+    rerender({ open: true });
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not call callback when other props change", () => {
+    const callback = vi.fn();
+    const newCallback = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ cb, open }) => useResetOnOpen(open, cb),
+      { initialProps: { cb: callback, open: true } },
+    );
+
+    callback.mockClear();
+
+    // Change callback reference but keep open=true
+    rerender({ cb: newCallback, open: true });
+    expect(callback).not.toHaveBeenCalled();
+    expect(newCallback).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/pages/SessionSummary.test.tsx
+++ b/frontend/src/__tests__/pages/SessionSummary.test.tsx
@@ -1,5 +1,7 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import * as useSessionSummaryModule from "../../hooks/useSessionSummary";
+import * as useToastModule from "../../hooks/useToast";
 import SessionSummary from "../../pages/SessionSummary";
 import { renderWithProviders } from "../test-utils";
 
@@ -10,6 +12,10 @@ vi.mock("react-router-dom", async (importOriginal) => ({
 }));
 
 vi.mock("../../hooks/useSessionSummary");
+
+vi.mock("html-to-image", () => ({
+  toPng: vi.fn().mockRejectedValue(new Error("Share failed")),
+}));
 
 const mockSummary = {
   awards: [
@@ -139,5 +145,29 @@ describe("SessionSummary page", () => {
 
     expect(screen.getByText("Partager")).toBeInTheDocument();
     expect(screen.getByText("Retour à la session")).toBeInTheDocument();
+  });
+
+  it("shows error toast when share fails", async () => {
+    vi.mocked(useSessionSummaryModule.useSessionSummary).mockReturnValue({
+      data: mockSummary,
+      isPending: false,
+    } as ReturnType<typeof useSessionSummaryModule.useSessionSummary>);
+
+    const mockToastError = vi.fn();
+    vi.spyOn(useToastModule, "useToast").mockReturnValue({
+      dismiss: vi.fn(),
+      toast: vi.fn(),
+      toastError: mockToastError,
+      toasts: [],
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionSummary />);
+
+    await user.click(screen.getByText("Partager"));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Échec du partage");
+    });
   });
 });

--- a/frontend/src/components/CompleteGameModal.tsx
+++ b/frontend/src/components/CompleteGameModal.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useCompleteGame } from "../hooks/useCompleteGame";
+import { useResetOnOpen } from "../hooks/useResetOnOpen";
 import { useToast } from "../hooks/useToast";
 import type { GameContext } from "../services/memeSelector";
 import { calculateScore, REQUIRED_POINTS } from "../services/scoreCalculator";
@@ -55,8 +56,7 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
   const [points, setPoints] = useState("");
   const [selfCall, setSelfCall] = useState(false);
 
-  useEffect(() => {
-    if (!open) return;
+  useResetOnOpen(open, () => {
     completeGame.reset();
     if (isEditMode) {
       setBonusesOpen(game.chelem !== Chelem.None || game.petitAuBout !== Side.None || game.poignee !== Poignee.None);
@@ -79,7 +79,7 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
       setPoints("");
       setSelfCall(false);
     }
-  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+  });
 
   const pointsNum = points === "" ? null : Number(points);
   const pointsValid = pointsNum !== null && !isNaN(pointsNum) && pointsNum >= 0 && pointsNum <= 91;

--- a/frontend/src/components/DeleteGameModal.tsx
+++ b/frontend/src/components/DeleteGameModal.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
 import { useDeleteGame } from "../hooks/useDeleteGame";
+import { useResetOnOpen } from "../hooks/useResetOnOpen";
 import { useToast } from "../hooks/useToast";
 import type { Game } from "../types/api";
 import { Modal } from "./ui";
@@ -15,9 +15,7 @@ export default function DeleteGameModal({ game, onClose, open, sessionId }: Dele
   const deleteGame = useDeleteGame(game.id, sessionId);
   const { toast } = useToast();
 
-  useEffect(() => {
-    if (open) deleteGame.reset();
-  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+  useResetOnOpen(open, () => deleteGame.reset());
 
   function handleConfirm() {
     deleteGame.mutate(undefined, {

--- a/frontend/src/components/NewGameModal.tsx
+++ b/frontend/src/components/NewGameModal.tsx
@@ -1,6 +1,7 @@
 import { RotateCcw } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { useCreateGame } from "../hooks/useCreateGame";
+import { useResetOnOpen } from "../hooks/useResetOnOpen";
 import { useToast } from "../hooks/useToast";
 import type { GamePlayer } from "../types/api";
 import { Contract } from "../types/enums";
@@ -28,13 +29,11 @@ export default function NewGameModal({ createGame, currentDealerName, lastGameCo
   const [selectedTakerId, setSelectedTakerId] = useState<number | null>(null);
   const { toast } = useToast();
 
-  useEffect(() => {
-    if (open) {
-      setSelectedContract(null);
-      setSelectedTakerId(null);
-      createGame.reset();
-    }
-  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+  useResetOnOpen(open, () => {
+    setSelectedContract(null);
+    setSelectedTakerId(null);
+    createGame.reset();
+  });
 
   const canSubmit = selectedTakerId !== null && selectedContract !== null && !createGame.isPending;
 

--- a/frontend/src/components/ScoreEvolutionChart.tsx
+++ b/frontend/src/components/ScoreEvolutionChart.tsx
@@ -64,7 +64,10 @@ export default function ScoreEvolutionChart({ games, players }: ScoreEvolutionCh
     [players],
   );
 
-  const data = computeScoreEvolution(games, players).slice(-10);
+  const data = useMemo(
+    () => computeScoreEvolution(games, players).slice(-10),
+    [games, players],
+  );
 
   if (data.length < 2) {
     return null;

--- a/frontend/src/components/SwapPlayersModal.tsx
+++ b/frontend/src/components/SwapPlayersModal.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useCreateSession } from "../hooks/useCreateSession";
+import { useResetOnOpen } from "../hooks/useResetOnOpen";
 import { useToast } from "../hooks/useToast";
 import type { Session } from "../types/api";
 import PlayerSelector from "./PlayerSelector";
@@ -22,12 +23,10 @@ export default function SwapPlayersModal({
   const createSession = useCreateSession();
   const { toast } = useToast();
 
-  useEffect(() => {
-    if (open) {
-      setSelectedPlayerIds(currentPlayerIds);
-      createSession.reset();
-    }
-  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+  useResetOnOpen(open, () => {
+    setSelectedPlayerIds(currentPlayerIds);
+    createSession.reset();
+  });
 
   function handleConfirm() {
     createSession.mutate(selectedPlayerIds, {

--- a/frontend/src/hooks/useResetOnOpen.ts
+++ b/frontend/src/hooks/useResetOnOpen.ts
@@ -1,0 +1,8 @@
+import { useEffect } from "react";
+
+export function useResetOnOpen(open: boolean, callback: () => void) {
+  useEffect(() => {
+    if (open) callback();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+}

--- a/frontend/src/pages/SessionSummary.tsx
+++ b/frontend/src/pages/SessionSummary.tsx
@@ -3,6 +3,7 @@ import { useCallback, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { PlayerAvatar, ScoreDisplay, Spinner } from "../components/ui";
 import { useSessionSummary } from "../hooks/useSessionSummary";
+import { useToast } from "../hooks/useToast";
 import type {
   SessionAward,
   SessionHighlights,
@@ -310,6 +311,7 @@ export default function SessionSummary() {
   const { data: summary, isPending } = useSessionSummary(sessionId);
   const summaryRef = useRef<HTMLDivElement>(null);
   const [isSharing, setIsSharing] = useState(false);
+  const { toastError } = useToast();
 
   const handleShare = useCallback(async () => {
     if (!summaryRef.current) return;
@@ -335,12 +337,12 @@ export default function SessionSummary() {
         a.href = dataUrl;
         a.click();
       }
-    } catch (error) {
-      console.error("Échec du partage :", error);
+    } catch {
+      toastError("Échec du partage");
     } finally {
       setIsSharing(false);
     }
-  }, [sessionId]);
+  }, [sessionId, toastError]);
 
   if (isPending) {
     return (


### PR DESCRIPTION
## Résumé

- **Memoize `computeScoreEvolution`** : wrapping dans `useMemo` pour éviter le recalcul à chaque render
- **Hook `useResetOnOpen`** : extraction du pattern reset-modal avec `eslint-disable` dans un hook réutilisable, appliqué dans 4 modales (CompleteGameModal, NewGameModal, DeleteGameModal, SwapPlayersModal)
- **Toast d'erreur** : remplacement du `console.error` dans `handleShare` (SessionSummary) par un `toastError` visible par l'utilisateur

fixes #154

## Tests

- [x] Nouveau test unitaire pour `useResetOnOpen` (4 tests)
- [x] Nouveau test pour le toast d'erreur au partage dans SessionSummary
- [x] 611/611 tests frontend passent
- [x] TypeScript clean