### PR TITLE
feat(frontend): couleur distincte par onglet dans le menu actif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Changed
 
+- **Menu actif** : l'onglet actif dans la barre de navigation basse est désormais souligné par un trait coloré en haut, en plus du texte en gras, pour un repérage visuel immédiat de la page courante.
 - **Nettoyage frontend** : mémoïsation du calcul `computeScoreEvolution`, extraction d'un hook `useResetOnOpen` pour supprimer les `eslint-disable react-hooks/exhaustive-deps` dans 4 modales, et remplacement du `console.error` par un toast d'erreur dans le partage du récap de session.
 - **Accessibilité OverflowMenu** : ajout de `role="menu"` / `role="menuitem"`, `aria-expanded` sur le bouton déclencheur, et navigation clavier fléchée (ArrowUp/ArrowDown) avec saut des items désactivés.
 - **Accessibilité couleurs joueur** : les boutons radio de couleur dans la modale d'édition affichent désormais des noms français (« Rouge », « Bleu », etc.) au lieu de codes hexadécimaux pour les lecteurs d'écran.

--- a/frontend/src/__tests__/components/BottomNav.test.tsx
+++ b/frontend/src/__tests__/components/BottomNav.test.tsx
@@ -29,10 +29,20 @@ describe("BottomNav", () => {
     expect(screen.getByRole("link", { name: /joueurs/i })).toHaveAttribute("href", "/players");
   });
 
-  it("highlights the active link", () => {
+  it("highlights the active link with font-semibold and its own colored top border", () => {
     renderWithProviders(<BottomNav />);
 
     const homeLink = screen.getByRole("link", { name: /accueil/i });
     expect(homeLink.className).toMatch(/font-semibold/);
+    expect(homeLink.className).toMatch(/border-blue-500/);
+    expect(homeLink.className).toMatch(/text-blue-500/);
+  });
+
+  it("uses transparent top border on inactive links", () => {
+    renderWithProviders(<BottomNav />);
+
+    const statsLink = screen.getByRole("link", { name: /stats/i });
+    expect(statsLink.className).toMatch(/border-transparent/);
+    expect(statsLink.className).toMatch(/text-text-secondary/);
   });
 });

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -2,26 +2,31 @@ import { BarChart3, Home, Users, UsersRound } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { NavLink } from "react-router-dom";
 
-const tabs: ReadonlyArray<{ Icon: LucideIcon; label: string; to: string }> = [
-  { Icon: Home, label: "Accueil", to: "/" },
-  { Icon: BarChart3, label: "Stats", to: "/stats" },
-  { Icon: UsersRound, label: "Groupes", to: "/groups" },
-  { Icon: Users, label: "Joueurs", to: "/players" },
+const tabs: ReadonlyArray<{
+  Icon: LucideIcon;
+  activeClass: string;
+  label: string;
+  to: string;
+}> = [
+  { Icon: Home, activeClass: "border-blue-500 text-blue-500 dark:border-blue-400 dark:text-blue-400", label: "Accueil", to: "/" },
+  { Icon: BarChart3, activeClass: "border-emerald-500 text-emerald-500 dark:border-emerald-400 dark:text-emerald-400", label: "Stats", to: "/stats" },
+  { Icon: UsersRound, activeClass: "border-violet-500 text-violet-500 dark:border-violet-400 dark:text-violet-400", label: "Groupes", to: "/groups" },
+  { Icon: Users, activeClass: "border-amber-500 text-amber-500 dark:border-amber-400 dark:text-amber-400", label: "Joueurs", to: "/players" },
 ];
 
 export default function BottomNav() {
   return (
     <nav className="fixed bottom-0 left-0 right-0 border-t border-surface-border bg-surface-primary pb-safe lg:left-1/2 lg:max-w-4xl lg:-translate-x-1/2 lg:rounded-t-xl">
       <div className="flex justify-around">
-        {tabs.map(({ Icon, label, to }) => (
+        {tabs.map(({ Icon, activeClass, label, to }) => (
           <NavLink
             key={to}
             to={to}
             className={({ isActive }) =>
-              `flex flex-col items-center px-4 py-2 text-xs transition-colors ${
+              `flex flex-col items-center border-t-2 px-4 py-2 text-xs transition-colors ${
                 isActive
-                  ? "font-semibold text-accent-500 dark:text-accent-300"
-                  : "text-text-secondary"
+                  ? `font-semibold ${activeClass}`
+                  : "border-transparent text-text-secondary"
               }`
             }
           >


### PR DESCRIPTION
## Résumé

Chaque onglet de la barre de navigation basse a désormais sa propre couleur (bleu, émeraude, violet, ambre) avec un trait coloré en haut pour un repérage immédiat de la page courante.

- **Accueil** : bleu
- **Stats** : émeraude
- **Groupes** : violet
- **Joueurs** : ambre

fixes #204