### PR TITLE
feat(session): plus de distinctions récap session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 - **Easter egg gyroscope inversé** : retourner le téléphone à l'envers (détection via l'API DeviceOrientation) inverse les scores affichés (positifs ↔ négatifs) dans le tableau des scores, avec une icône de feedback visuel
 - **Easter egg "To infinity and beyond!"** : affiche le mème Buzz l'Éclair (Toy Story) lorsqu'un score individuel sur une donne dépasse ±200 points
+- **Distinctions récap session** : 5 nouvelles distinctions humoristiques sur la page récapitulatif de session — Le Kamikaze (pire winrate preneur), Le Solitaire (moins appelé comme partenaire), Le Paratonnerre (plus d'étoiles reçues), Le Yo-Yo (scores les plus imprévisibles), Le Régulier (scores les plus constants)
 
 ## [1.3.0] - 2026-02-21
 

--- a/backend/src/Repository/GameRepository.php
+++ b/backend/src/Repository/GameRepository.php
@@ -52,6 +52,58 @@ final class GameRepository extends ServiceEntityRepository
     }
 
     /**
+     * @return array<int, int> playerId => partner appearance count
+     */
+    public function countPartnerAppearancesPerPlayerForSession(Session $session): array
+    {
+        /** @var list<array{count: int|string, playerId: int|string}> $results */
+        $results = $this->createQueryBuilder('g')
+            ->select('IDENTITY(g.partner) AS playerId', 'COUNT(g.id) AS count')
+            ->andWhere('g.session = :session')
+            ->andWhere('g.status = :status')
+            ->andWhere('g.partner IS NOT NULL')
+            ->setParameter('session', $session)
+            ->setParameter('status', GameStatus::Completed)
+            ->groupBy('g.partner')
+            ->getQuery()
+            ->getResult();
+
+        $countMap = [];
+        foreach ($results as $row) {
+            $countMap[(int) $row['playerId']] = (int) $row['count'];
+        }
+
+        return $countMap;
+    }
+
+    /**
+     * @return array<int, int> playerId => win count as taker
+     */
+    public function countTakerWinsPerPlayerForSession(Session $session): array
+    {
+        /** @var list<array{count: int|string, playerId: int|string}> $results */
+        $results = $this->createQueryBuilder('g')
+            ->select('IDENTITY(g.taker) AS playerId', 'COUNT(g.id) AS count')
+            ->join('g.scoreEntries', 'se')
+            ->andWhere('g.session = :session')
+            ->andWhere('g.status = :status')
+            ->andWhere('se.player = g.taker')
+            ->andWhere('se.score > 0')
+            ->setParameter('session', $session)
+            ->setParameter('status', GameStatus::Completed)
+            ->groupBy('g.taker')
+            ->getQuery()
+            ->getResult();
+
+        $countMap = [];
+        foreach ($results as $row) {
+            $countMap[(int) $row['playerId']] = (int) $row['count'];
+        }
+
+        return $countMap;
+    }
+
+    /**
      * @return array<int, int> playerId => count
      */
     public function countTakerGamesPerPlayerForSession(Session $session): array

--- a/backend/src/Repository/ScoreEntryRepository.php
+++ b/backend/src/Repository/ScoreEntryRepository.php
@@ -111,6 +111,31 @@ final class ScoreEntryRepository extends ServiceEntityRepository
         return $scoreMap;
     }
 
+    /**
+     * @return array<int, list<int>> playerId => ordered list of game scores
+     */
+    public function getOrderedGameScoresPerPlayerForSession(Session $session): array
+    {
+        /** @var list<array{playerId: int|string, score: int|string}> $results */
+        $results = $this->createQueryBuilder('se')
+            ->select('IDENTITY(se.player) AS playerId', 'se.score AS score')
+            ->join('se.game', 'g')
+            ->andWhere('g.session = :session')
+            ->andWhere('g.status = :status')
+            ->setParameter('session', $session)
+            ->setParameter('status', GameStatus::Completed)
+            ->orderBy('g.position', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        $map = [];
+        foreach ($results as $row) {
+            $map[(int) $row['playerId']][] = (int) $row['score'];
+        }
+
+        return $map;
+    }
+
     public function getTotalTakerScoreByPlayerForSession(Session $session): ?TotalTakerScoreDto
     {
         /** @var list<TotalTakerScoreDto> $results */

--- a/backend/src/Service/SessionSummaryService.php
+++ b/backend/src/Service/SessionSummaryService.php
@@ -21,9 +21,14 @@ use App\Repository\StarEventRepository;
  * - highlights  : faits marquants (MVP, dernier, meilleure/pire donne, contrat favori,
  *                 durée totale, nombre de donnes et d'étoiles)
  * - awards      : récompenses humoristiques attribuées si >= 3 donnes jouées :
- *     • Le Boucher      — preneur ayant infligé le plus de points aux défenseurs
+ *     • Le Boucher          — preneur ayant infligé le plus de points aux défenseurs
  *     • L'Éternel Défenseur — joueur ayant le moins pris
- *     • Le Flambeur      — joueur ayant tenté le plus de Garde Sans / Garde Contre
+ *     • Le Flambeur         — joueur ayant tenté le plus de Garde Sans / Garde Contre
+ *     • Le Kamikaze         — preneur avec le pire taux de réussite (min 2 prises)
+ *     • Le Solitaire        — joueur le moins appelé comme partenaire
+ *     • Le Paratonnerre     — joueur ayant reçu le plus d'étoiles
+ *     • Le Yo-Yo            — joueur avec la plus grande variance de scores
+ *     • Le Régulier         — joueur avec les scores les plus constants
  */
 final readonly class SessionSummaryService
 {
@@ -253,6 +258,35 @@ final readonly class SessionSummaryService
             $awards[] = $flambeur;
         }
 
+        // 4. Le Kamikaze: worst taker win rate (min 2 takes, at least 1 loss)
+        $kamikaze = $this->computeKamikaze($session);
+        if (null !== $kamikaze) {
+            $awards[] = $kamikaze;
+        }
+
+        // 5. Le Solitaire: least called as partner
+        $solitaire = $this->computeSolitaire($session);
+        if (null !== $solitaire) {
+            $awards[] = $solitaire;
+        }
+
+        // 6. Le Paratonnerre: most stars received
+        $paratonnerre = $this->computeParatonnerre($session);
+        if (null !== $paratonnerre) {
+            $awards[] = $paratonnerre;
+        }
+
+        // 7 & 8. Le Yo-Yo + Le Régulier: highest / lowest score variance
+        $scoresMap = $this->scoreEntryRepository->getOrderedGameScoresPerPlayerForSession($session);
+        $yoyo = $this->computeYoYo($session, $scoresMap);
+        if (null !== $yoyo) {
+            $awards[] = $yoyo;
+        }
+        $regulier = $this->computeRegulier($session, $scoresMap, $yoyo['playerId'] ?? null);
+        if (null !== $regulier) {
+            $awards[] = $regulier;
+        }
+
         return $awards;
     }
 
@@ -345,5 +379,253 @@ final readonly class SessionSummaryService
             'playerName' => $result->playerName,
             'title' => 'Le Flambeur',
         ];
+    }
+
+    /**
+     * « Le Kamikaze » : preneur avec le pire taux de réussite (min 2 prises, au moins 1 échec).
+     *
+     * @return array{description: string, playerColor: string|null, playerId: int, playerName: string, title: string}|null
+     */
+    private function computeKamikaze(Session $session): ?array
+    {
+        $takerCounts = $this->gameRepository->countTakerGamesPerPlayerForSession($session);
+        $takerWins = $this->gameRepository->countTakerWinsPerPlayerForSession($session);
+
+        $worstRate = -1.0;
+        $winner = null;
+
+        foreach ($session->getPlayers() as $player) {
+            /** @var int $playerId */
+            $playerId = $player->getId();
+            $takes = $takerCounts[$playerId] ?? 0;
+
+            if ($takes < 2) {
+                continue;
+            }
+
+            $wins = $takerWins[$playerId] ?? 0;
+            $losses = $takes - $wins;
+
+            if (0 === $losses) {
+                continue;
+            }
+
+            $loseRate = $losses / $takes;
+
+            if ($loseRate > $worstRate) {
+                $worstRate = $loseRate;
+                $winner = $player;
+            }
+        }
+
+        if (null === $winner) {
+            return null;
+        }
+
+        /** @var int $winnerId */
+        $winnerId = $winner->getId();
+
+        return [
+            'description' => 'Échoue le plus souvent en tant que preneur',
+            'playerColor' => $winner->getColor(),
+            'playerId' => $winnerId,
+            'playerName' => $winner->getName(),
+            'title' => 'Le Kamikaze',
+        ];
+    }
+
+    /**
+     * « Le Solitaire » : joueur le moins souvent appelé comme partenaire.
+     *
+     * Non attribué si aucune donne avec appel dans la session.
+     *
+     * @return array{description: string, playerColor: string|null, playerId: int, playerName: string, title: string}|null
+     */
+    private function computeSolitaire(Session $session): ?array
+    {
+        $partnerCounts = $this->gameRepository->countPartnerAppearancesPerPlayerForSession($session);
+
+        if ([] === $partnerCounts) {
+            return null;
+        }
+
+        $minCount = \PHP_INT_MAX;
+        $winner = null;
+
+        foreach ($session->getPlayers() as $player) {
+            /** @var int $playerId */
+            $playerId = $player->getId();
+            $count = $partnerCounts[$playerId] ?? 0;
+
+            if ($count < $minCount) {
+                $minCount = $count;
+                $winner = $player;
+            }
+        }
+
+        if (null === $winner) {
+            return null;
+        }
+
+        /** @var int $winnerId */
+        $winnerId = $winner->getId();
+
+        return [
+            'description' => 'Le moins appelé comme partenaire',
+            'playerColor' => $winner->getColor(),
+            'playerId' => $winnerId,
+            'playerName' => $winner->getName(),
+            'title' => 'Le Solitaire',
+        ];
+    }
+
+    /**
+     * « Le Paratonnerre » : joueur ayant reçu le plus d'étoiles dans la session.
+     *
+     * Non attribué si aucune étoile dans la session.
+     *
+     * @return array{description: string, playerColor: string|null, playerId: int, playerName: string, title: string}|null
+     */
+    private function computeParatonnerre(Session $session): ?array
+    {
+        $maxStars = 0;
+        $winner = null;
+
+        foreach ($session->getPlayers() as $player) {
+            $count = $this->starEventRepository->countBySessionAndPlayer($session, $player);
+
+            if ($count > $maxStars) {
+                $maxStars = $count;
+                $winner = $player;
+            }
+        }
+
+        if (null === $winner || 0 === $maxStars) {
+            return null;
+        }
+
+        /** @var int $winnerId */
+        $winnerId = $winner->getId();
+
+        return [
+            'description' => 'A attiré le plus d\'étoiles',
+            'playerColor' => $winner->getColor(),
+            'playerId' => $winnerId,
+            'playerName' => $winner->getName(),
+            'title' => 'Le Paratonnerre',
+        ];
+    }
+
+    /**
+     * « Le Yo-Yo » : joueur avec la plus grande variance de scores.
+     *
+     * @param array<int, list<int>> $scoresMap
+     *
+     * @return array{description: string, playerColor: string|null, playerId: int, playerName: string, title: string}|null
+     */
+    private function computeYoYo(Session $session, array $scoresMap): ?array
+    {
+        $maxVariance = -1.0;
+        $winner = null;
+
+        foreach ($session->getPlayers() as $player) {
+            /** @var int $playerId */
+            $playerId = $player->getId();
+            $scores = $scoresMap[$playerId] ?? [];
+
+            if (\count($scores) < 3) {
+                continue;
+            }
+
+            $variance = $this->computeVariance($scores);
+
+            if ($variance > $maxVariance) {
+                $maxVariance = $variance;
+                $winner = $player;
+            }
+        }
+
+        if (null === $winner) {
+            return null;
+        }
+
+        /** @var int $winnerId */
+        $winnerId = $winner->getId();
+
+        return [
+            'description' => 'Les scores les plus imprévisibles',
+            'playerColor' => $winner->getColor(),
+            'playerId' => $winnerId,
+            'playerName' => $winner->getName(),
+            'title' => 'Le Yo-Yo',
+        ];
+    }
+
+    /**
+     * « Le Régulier » : joueur avec les scores les plus constants (plus petite variance).
+     *
+     * Exclut le gagnant du Yo-Yo pour éviter qu'un même joueur reçoive les deux.
+     *
+     * @param array<int, list<int>> $scoresMap
+     *
+     * @return array{description: string, playerColor: string|null, playerId: int, playerName: string, title: string}|null
+     */
+    private function computeRegulier(Session $session, array $scoresMap, ?int $excludePlayerId): ?array
+    {
+        $minVariance = \PHP_FLOAT_MAX;
+        $winner = null;
+
+        foreach ($session->getPlayers() as $player) {
+            /** @var int $playerId */
+            $playerId = $player->getId();
+
+            if ($playerId === $excludePlayerId) {
+                continue;
+            }
+
+            $scores = $scoresMap[$playerId] ?? [];
+
+            if (\count($scores) < 3) {
+                continue;
+            }
+
+            $variance = $this->computeVariance($scores);
+
+            if ($variance < $minVariance) {
+                $minVariance = $variance;
+                $winner = $player;
+            }
+        }
+
+        if (null === $winner) {
+            return null;
+        }
+
+        /** @var int $winnerId */
+        $winnerId = $winner->getId();
+
+        return [
+            'description' => 'Les scores les plus réguliers',
+            'playerColor' => $winner->getColor(),
+            'playerId' => $winnerId,
+            'playerName' => $winner->getName(),
+            'title' => 'Le Régulier',
+        ];
+    }
+
+    /**
+     * @param list<int> $scores
+     */
+    private function computeVariance(array $scores): float
+    {
+        $n = \count($scores);
+        $mean = \array_sum($scores) / $n;
+        $sumSquares = 0.0;
+
+        foreach ($scores as $score) {
+            $sumSquares += ($score - $mean) ** 2;
+        }
+
+        return $sumSquares / $n;
     }
 }

--- a/backend/tests/Service/SessionSummaryServiceTest.php
+++ b/backend/tests/Service/SessionSummaryServiceTest.php
@@ -189,6 +189,27 @@ class SessionSummaryServiceTest extends ApiTestCase
         $flambeur = $this->findAwardByTitle($summary['awards'], 'Le Flambeur');
         self::assertNotNull($flambeur);
         self::assertSame($alice->getId(), $flambeur['playerId']);
+
+        // Le Kamikaze: NOT awarded (Alice 2 takes, 2 wins; Bob 1 take only)
+        self::assertNull($this->findAwardByTitle($summary['awards'], 'Le Kamikaze'));
+
+        // Le Solitaire: NOT awarded (no partner calls in any game)
+        self::assertNull($this->findAwardByTitle($summary['awards'], 'Le Solitaire'));
+
+        // Le Paratonnerre: Alice (only player with stars: 1 star)
+        $paratonnerre = $this->findAwardByTitle($summary['awards'], 'Le Paratonnerre');
+        self::assertNotNull($paratonnerre);
+        self::assertSame($alice->getId(), $paratonnerre['playerId']);
+
+        // Le Yo-Yo: Alice (highest score variance — wild swings between taker and defender roles)
+        $yoyo = $this->findAwardByTitle($summary['awards'], 'Le Yo-Yo');
+        self::assertNotNull($yoyo);
+        self::assertSame($alice->getId(), $yoyo['playerId']);
+
+        // Le Régulier: Bob (lowest score variance)
+        $regulier = $this->findAwardByTitle($summary['awards'], 'Le Régulier');
+        self::assertNotNull($regulier);
+        self::assertSame($bob->getId(), $regulier['playerId']);
     }
 
     public function testSummaryWithFewerThanThreeGamesHasNoAwards(): void
@@ -208,6 +229,184 @@ class SessionSummaryServiceTest extends ApiTestCase
 
         self::assertSame([], $summary['awards']);
         self::assertSame(2, $summary['highlights']['totalGames']);
+    }
+
+    public function testKamikazeAwardedToWorstTakerWinRate(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+        /** @var Player $alice */
+        $alice = $players[0];
+        /** @var Player $bob */
+        $bob = $players[1];
+        $calculator = new ScoreCalculator();
+
+        // Alice takes 1 game, wins
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $alice, null, Contract::Garde, 2, 50));
+
+        // Bob takes 2 games, loses both → 0% win rate
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $bob, null, Contract::Petite, 0, 40));
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $bob, null, Contract::Petite, 0, 35));
+
+        $summary = $this->service->getSummary($session);
+
+        $kamikaze = $this->findAwardByTitle($summary['awards'], 'Le Kamikaze');
+        self::assertNotNull($kamikaze);
+        self::assertSame($bob->getId(), $kamikaze['playerId']);
+        self::assertSame('Bob', $kamikaze['playerName']);
+    }
+
+    public function testKamikazeNotAwardedWhenNoPlayerHasTwoTakes(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+        $calculator = new ScoreCalculator();
+
+        // 3 different takers, each takes once
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $players[0], null, Contract::Garde, 2, 50));
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $players[1], null, Contract::Petite, 0, 40));
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $players[2], null, Contract::Petite, 0, 35));
+
+        $summary = $this->service->getSummary($session);
+
+        self::assertNull($this->findAwardByTitle($summary['awards'], 'Le Kamikaze'));
+    }
+
+    public function testSolitaireAwardedToLeastCalledPartner(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+        /** @var Player $alice */
+        $alice = $players[0];
+        /** @var Player $bob */
+        $bob = $players[1];
+        /** @var Player $charlie */
+        $charlie = $players[2];
+        /** @var Player $diana */
+        $diana = $players[3];
+        /** @var Player $eve */
+        $eve = $players[4];
+        $calculator = new ScoreCalculator();
+
+        // Game 1: Alice takes, calls Bob
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $alice, $bob, Contract::Garde, 2, 50));
+        // Game 2: Charlie takes, calls Diana
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $charlie, $diana, Contract::Petite, 1, 52));
+        // Game 3: Bob takes, calls Charlie
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $bob, $charlie, Contract::Garde, 2, 50));
+        // Game 4: Diana takes, calls Alice
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $diana, $alice, Contract::Petite, 2, 42));
+
+        // Partners: Bob=1, Diana=1, Charlie=1, Alice=1, Eve=0
+        $summary = $this->service->getSummary($session);
+
+        $solitaire = $this->findAwardByTitle($summary['awards'], 'Le Solitaire');
+        self::assertNotNull($solitaire);
+        self::assertSame($eve->getId(), $solitaire['playerId']);
+        self::assertSame('Eve', $solitaire['playerName']);
+    }
+
+    public function testSolitaireNotAwardedWithoutPartners(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+        $calculator = new ScoreCalculator();
+
+        // All games are self-call (no partner)
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $players[0], null, Contract::Garde, 2, 50));
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $players[1], null, Contract::Petite, 0, 40));
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $players[2], null, Contract::Petite, 0, 35));
+
+        $summary = $this->service->getSummary($session);
+
+        self::assertNull($this->findAwardByTitle($summary['awards'], 'Le Solitaire'));
+    }
+
+    public function testParatonnerreAwardedToMostStarredPlayer(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+        /** @var Player $alice */
+        $alice = $players[0];
+        /** @var Player $bob */
+        $bob = $players[1];
+        /** @var Player $eve */
+        $eve = $players[4];
+        $calculator = new ScoreCalculator();
+
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $alice, null, Contract::Garde, 2, 50));
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $bob, null, Contract::Petite, 0, 40));
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $alice, null, Contract::Petite, 1, 52));
+
+        // Eve gets 3 stars, Alice gets 1 star
+        foreach ([$eve, $eve, $eve, $alice] as $player) {
+            $star = new StarEvent();
+            $star->setPlayer($player);
+            $star->setSession($session);
+            $this->em->persist($star);
+        }
+        $this->em->flush();
+
+        $summary = $this->service->getSummary($session);
+
+        $paratonnerre = $this->findAwardByTitle($summary['awards'], 'Le Paratonnerre');
+        self::assertNotNull($paratonnerre);
+        self::assertSame($eve->getId(), $paratonnerre['playerId']);
+    }
+
+    public function testYoYoAndRegulierAwards(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+        /** @var Player $alice */
+        $alice = $players[0];
+        /** @var Player $bob */
+        $bob = $players[1];
+        $calculator = new ScoreCalculator();
+
+        // Game 1: Alice takes Garde, big win (3 oudlers, 60 pts → base=98, taker=392)
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $alice, null, Contract::Garde, 3, 60));
+        // Game 2: Alice takes Petite, big loss (0 oudlers, 40 pts → base=-41, taker=-164)
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $alice, null, Contract::Petite, 0, 40));
+        // Game 3: Bob takes Petite, small win (2 oudlers, 42 pts → base=26, taker=104)
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $bob, null, Contract::Petite, 2, 42));
+
+        // Alice has wild swings [392, -164, -26] → highest variance
+        // Bob: [-98, 41, 104] → moderate variance
+        // Charlie/Diana/Eve: [-98, 41, -26] → lowest variance (pure defenders)
+        $summary = $this->service->getSummary($session);
+
+        $yoyo = $this->findAwardByTitle($summary['awards'], 'Le Yo-Yo');
+        self::assertNotNull($yoyo);
+        self::assertSame($alice->getId(), $yoyo['playerId']);
+
+        // Régulier excludes Yo-Yo winner (Alice), so Bob or a pure defender wins.
+        // Bob stddev ≈ 84.4, defenders stddev ≈ 56.8 → a defender wins
+        $regulier = $this->findAwardByTitle($summary['awards'], 'Le Régulier');
+        self::assertNotNull($regulier);
+        self::assertNotSame($alice->getId(), $regulier['playerId']);
+        // Must be one of Charlie/Diana/Eve (pure defenders, lowest variance)
+        self::assertContains($regulier['playerId'], [
+            $players[2]->getId(),
+            $players[3]->getId(),
+            $players[4]->getId(),
+        ]);
+    }
+
+    public function testYoYoAndRegulierNotAwardedWithFewerThanThreeGames(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+        $calculator = new ScoreCalculator();
+
+        // Only 2 games — below the 3-game threshold for awards
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $players[0], null, Contract::Garde, 2, 50));
+        $this->computeAndPersistScores($calculator, $this->createCompletedGame($session, $players[1], null, Contract::Petite, 0, 40));
+
+        $summary = $this->service->getSummary($session);
+
+        // Awards empty because < 3 completed games
+        self::assertSame([], $summary['awards']);
     }
 
     private function createCompletedGame(

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -285,6 +285,11 @@ Il affiche :
   - « Le Boucher » : a infligé le plus de points aux défenseurs
   - « L'Éternel Défenseur » : a le moins pris
   - « Le Flambeur » : a tenté le plus de Garde Sans/Contre
+  - « Le Kamikaze » : échoue le plus souvent en tant que preneur (min 2 prises)
+  - « Le Solitaire » : le moins appelé comme partenaire
+  - « Le Paratonnerre » : a attiré le plus d'étoiles
+  - « Le Yo-Yo » : les scores les plus imprévisibles
+  - « Le Régulier » : les scores les plus réguliers
 
 ### Partager le récapitulatif
 


### PR DESCRIPTION
## Summary
- 5 nouvelles distinctions humoristiques sur la page récapitulatif de session :
  - **Le Kamikaze** : pire winrate en tant que preneur (min 2 prises, au moins 1 échec)
  - **Le Solitaire** : le moins souvent appelé comme partenaire
  - **Le Paratonnerre** : a reçu le plus d'étoiles dans la session
  - **Le Yo-Yo** : scores les plus imprévisibles (plus grande variance)
  - **Le Régulier** : scores les plus réguliers (plus petite variance)
- 3 nouvelles méthodes repository (GameRepository, ScoreEntryRepository)
- 7 nouveaux tests backend couvrant tous les cas nominaux et edge cases

fixes #205

## Test plan
- [x] Tests backend : `make test-back` — 210 tests, 710 assertions
- [x] Tests frontend : `make test-front` — 644 tests
- [x] PHPStan level max : aucune erreur
- [x] PHP CS Fixer : aucun fix nécessaire