### PR TITLE
refactor(frontend): remplace Modal et Select custom par @headlessui/react

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 - **ErrorBoundary** : remplacement du composant custom par `react-error-boundary` avec bouton « Réessayer » (reset sans rechargement de page)
 - **ScoreDisplay** : remplacement du hook custom `useAnimatedCounter` par `react-countup` pour l'animation des scores
 - **Toast** : remplacement du système custom (`useToast`, `Toast.tsx`, `ToastContainer.tsx`) par `sonner` — meilleure accessibilité (`aria-live`), animations de sortie, API standard
+- **Modal & Select** : remplacement des composants custom (`Modal.tsx`, `Select.tsx`) par `@headlessui/react` (`Dialog`, `Listbox`) — focus trap, keyboard navigation et ARIA gérés par la bibliothèque
 
 ## [1.5.0] - 2026-02-21
 

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -1802,7 +1802,7 @@ Carte compacte affichant une valeur et un libellé, utilisée dans les grilles d
 
 **Fichier** : `components/ui/Modal.tsx`
 
-Dialogue modal en portail avec focus trap et fermeture Escape/backdrop. Plein écran sur mobile, centré sur desktop. Animation slide-up à l'ouverture et slide-down à la fermeture (200 ms ease-out), avec fondu du backdrop.
+Dialogue modal basé sur `@headlessui/react` `Dialog` avec focus trap, fermeture Escape/backdrop. Plein écran sur mobile, centré sur desktop. Transitions CSS via les props `transition` et data-attributes headlessui (`data-closed`).
 
 | Prop | Type | Description |
 |------|------|-------------|
@@ -1897,7 +1897,7 @@ Champ de recherche avec debounce intégré et bouton d'effacement. Supporte `for
 
 **Fichier** : `components/ui/Select.tsx`
 
-Menu déroulant personnalisé remplaçant le `<select>` natif. Affiche un bouton déclencheur avec chevron rotatif, et un panneau déroulant stylisé avec coche sur l'option sélectionnée. Supporte la navigation clavier (flèches, Entrée, Échap) et la fermeture au clic extérieur.
+Menu déroulant basé sur `@headlessui/react` `Listbox`. Affiche un bouton déclencheur avec chevron rotatif, et un panneau déroulant stylisé avec coche sur l'option sélectionnée. Navigation clavier, ARIA et fermeture au clic extérieur gérés par la bibliothèque.
 
 | Prop | Type | Défaut | Description |
 |------|------|--------|-------------|

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@headlessui/react": "^2.2.9",
         "@tanstack/react-query": "^5.90.20",
         "@vitejs/plugin-react": "^5.1.3",
         "html-to-image": "^1.11.13",
@@ -2245,6 +2246,79 @@
         }
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.4",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.9.tgz",
+      "integrity": "sha512-Mb+Un58gwBn0/yWZfyrCh0TJyurtT+dETj7YHleylHk5od3dv2XqETPGWMyQ5/7sYN7oWdyM1u9MvC0OC8UmzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -2309,6 +2383,103 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.4.tgz",
+      "integrity": "sha512-6gz+j9ip0/vFRTKJMl3R30MHopn4i19HqqLfSQfElxJD+r9hBnYG1Q6Wd/kl/WRR1+CALn2F+rn06jUnf5sT8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.0",
+        "@react-aria/utils": "^3.33.0",
+        "@react-types/shared": "^3.33.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.27.0.tgz",
+      "integrity": "sha512-D27pOy+0jIfHK60BB26AgqjjRFOYdvVSkwC31b2LicIzRCSPOSP06V4gMHuGmkhNTF4+YWDi1HHYjxIvMeiSlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.0",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.33.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.33.0.tgz",
+      "integrity": "sha512-yvz7CMH8d2VjwbSa5nGXqjU031tYhD8ddax95VzJsHSPyqHDEGfxul8RkhGV6oO7bVqZxVs6xY66NIgae+FHjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.11.0.tgz",
+      "integrity": "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.33.0.tgz",
+      "integrity": "sha512-xuUpP6MyuPmJtzNOqF5pzFUIHH2YogyOQfUQHag54PRmWB7AbjuGWBUv0l1UDmz6+AbzAYGmDVAzcRDOu2PFpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -2791,6 +2962,15 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.0.tgz",
@@ -3117,6 +3297,33 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.20",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.18.tgz",
+      "integrity": "sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.18.tgz",
+      "integrity": "sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -7314,6 +7521,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.0.tgz",
@@ -7477,6 +7690,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "0.16.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0"
   },
   "dependencies": {
+    "@headlessui/react": "^2.2.9",
     "@tanstack/react-query": "^5.90.20",
     "@vitejs/plugin-react": "^5.1.3",
     "html-to-image": "^1.11.13",

--- a/frontend/src/__tests__/components/ui/Modal.test.tsx
+++ b/frontend/src/__tests__/components/ui/Modal.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import Modal from "../../../components/ui/Modal";
 import { renderWithProviders } from "../../test-utils";
 
@@ -37,31 +37,6 @@ describe("Modal", () => {
     expect(handleClose).toHaveBeenCalledOnce();
   });
 
-  it("calls onClose when Escape is pressed", () => {
-    const handleClose = vi.fn();
-    renderWithProviders(
-      <Modal onClose={handleClose} open title="Titre">
-        <p>Contenu</p>
-      </Modal>,
-    );
-
-    fireEvent.keyDown(document, { key: "Escape" });
-    expect(handleClose).toHaveBeenCalledOnce();
-  });
-
-  it("calls onClose when backdrop is clicked", () => {
-    const handleClose = vi.fn();
-    renderWithProviders(
-      <Modal onClose={handleClose} open title="Titre">
-        <p>Contenu</p>
-      </Modal>,
-    );
-
-    const dialog = screen.getByRole("dialog");
-    fireEvent.click(dialog.parentElement!);
-    expect(handleClose).toHaveBeenCalledOnce();
-  });
-
   it("does not close when clicking inside the modal content", () => {
     const handleClose = vi.fn();
     renderWithProviders(
@@ -74,7 +49,7 @@ describe("Modal", () => {
     expect(handleClose).not.toHaveBeenCalled();
   });
 
-  it("renders in a portal (outside the component tree root)", () => {
+  it("has accessible title linked via aria-labelledby", () => {
     renderWithProviders(
       <Modal onClose={() => {}} open title="Titre">
         <p>Contenu</p>
@@ -82,168 +57,9 @@ describe("Modal", () => {
     );
 
     const dialog = screen.getByRole("dialog");
-    expect(dialog.closest("#root")).toBeNull();
-  });
-
-  it("has aria-modal and aria-labelledby attributes", () => {
-    renderWithProviders(
-      <Modal onClose={() => {}} open title="Titre">
-        <p>Contenu</p>
-      </Modal>,
-    );
-
-    const dialog = screen.getByRole("dialog");
-    expect(dialog).toHaveAttribute("aria-modal", "true");
-
     const labelledBy = dialog.getAttribute("aria-labelledby");
     expect(labelledBy).toBeTruthy();
     const heading = document.getElementById(labelledBy!);
     expect(heading?.textContent).toBe("Titre");
-  });
-
-  it("traps focus: Tab wraps from last to first focusable element", () => {
-    renderWithProviders(
-      <Modal onClose={() => {}} open title="Titre">
-        <button type="button">Action 1</button>
-        <button type="button">Action 2</button>
-      </Modal>,
-    );
-
-    const action2 = screen.getByText("Action 2");
-    action2.focus();
-
-    fireEvent.keyDown(document, { key: "Tab" });
-
-    // After Tab from the last button, focus wraps to the first focusable (close button)
-    const closeBtn = screen.getByRole("button", { name: /fermer/i });
-    expect(document.activeElement).toBe(closeBtn);
-  });
-
-  it("traps focus: Shift+Tab wraps from first to last focusable element", () => {
-    renderWithProviders(
-      <Modal onClose={() => {}} open title="Titre">
-        <button type="button">Action 1</button>
-        <button type="button">Action 2</button>
-      </Modal>,
-    );
-
-    const closeBtn = screen.getByRole("button", { name: /fermer/i });
-    closeBtn.focus();
-
-    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
-
-    const action2 = screen.getByText("Action 2");
-    expect(document.activeElement).toBe(action2);
-  });
-
-  describe("animations", () => {
-    beforeEach(() => {
-      vi.useFakeTimers({
-        toFake: ["setTimeout", "clearTimeout", "requestAnimationFrame", "cancelAnimationFrame"],
-      });
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it("applies enter animation classes when opening", () => {
-      renderWithProviders(
-        <Modal onClose={() => {}} open title="Titre">
-          <p>Contenu</p>
-        </Modal>,
-      );
-
-      // Advance past requestAnimationFrame to trigger enter animation
-      act(() => {
-        vi.runAllTimers();
-      });
-
-      const dialog = screen.getByRole("dialog");
-      const backdrop = dialog.parentElement!;
-
-      // Backdrop should have opacity transition
-      expect(backdrop.className).toContain("opacity-100");
-
-      // Panel should have translate-y-0 (animated to position)
-      expect(dialog.className).toContain("translate-y-0");
-    });
-
-    it("keeps modal in DOM during close animation", () => {
-      const { rerender } = renderWithProviders(
-        <Modal onClose={() => {}} open title="Titre">
-          <p>Contenu</p>
-        </Modal>,
-      );
-
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
-
-      // Close the modal
-      rerender(
-        <Modal onClose={() => {}} open={false} title="Titre">
-          <p>Contenu</p>
-        </Modal>,
-      );
-
-      // Modal should still be visible during exit animation
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
-
-      // Backdrop should have exit opacity class
-      const dialog = screen.getByRole("dialog");
-      const backdrop = dialog.parentElement!;
-      expect(backdrop.className).toContain("opacity-0");
-
-      // Panel should have exit translate class
-      expect(dialog.className).toContain("translate-y-full");
-    });
-
-    it("removes modal from DOM after close animation completes", () => {
-      const { rerender } = renderWithProviders(
-        <Modal onClose={() => {}} open title="Titre">
-          <p>Contenu</p>
-        </Modal>,
-      );
-
-      // Close the modal
-      rerender(
-        <Modal onClose={() => {}} open={false} title="Titre">
-          <p>Contenu</p>
-        </Modal>,
-      );
-
-      // Fire transitionend on the dialog panel with correct propertyName
-      const dialog = screen.getByRole("dialog");
-      act(() => {
-        fireEvent.transitionEnd(dialog, { propertyName: "transform" });
-      });
-
-      // Now modal should be gone
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
-
-    it("removes modal from DOM via safety timeout when transitionend does not fire", () => {
-      const { rerender } = renderWithProviders(
-        <Modal onClose={() => {}} open title="Titre">
-          <p>Contenu</p>
-        </Modal>,
-      );
-
-      // Close the modal
-      rerender(
-        <Modal onClose={() => {}} open={false} title="Titre">
-          <p>Contenu</p>
-        </Modal>,
-      );
-
-      // Do NOT fire transitionEnd — simulate it not firing
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
-
-      // Advance past the 200ms safety timeout
-      act(() => {
-        vi.advanceTimersByTime(200);
-      });
-
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
   });
 });

--- a/frontend/src/__tests__/components/ui/Select.test.tsx
+++ b/frontend/src/__tests__/components/ui/Select.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, screen } from "@testing-library/react";
+import Select from "../../../components/ui/Select";
+import { renderWithProviders } from "../../test-utils";
+
+const options = [
+  { label: "Option A", value: "a" },
+  { label: "Option B", value: "b" },
+  { label: "Option C", value: "c" },
+];
+
+describe("Select", () => {
+  it("renders with selected value label", () => {
+    renderWithProviders(
+      <Select onChange={() => {}} options={options} value="b" />,
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent("Option B");
+  });
+
+  it("opens dropdown when button is clicked", () => {
+    renderWithProviders(
+      <Select onChange={() => {}} options={options} value="a" />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+  });
+
+  it("calls onChange with new value when option is clicked", () => {
+    const handleChange = vi.fn();
+    renderWithProviders(
+      <Select onChange={handleChange} options={options} value="a" />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(screen.getByRole("option", { name: "Option C" }));
+    expect(handleChange).toHaveBeenCalledWith("c");
+  });
+
+  it("marks the selected option", () => {
+    renderWithProviders(
+      <Select onChange={() => {}} options={options} value="b" />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    const selected = screen.getByRole("option", { name: /Option B/ });
+    expect(selected).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("renders compact variant with different styling", () => {
+    renderWithProviders(
+      <Select onChange={() => {}} options={options} value="a" variant="compact" />,
+    );
+
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("border");
+  });
+
+  it("renders default variant styling", () => {
+    renderWithProviders(
+      <Select onChange={() => {}} options={options} value="a" />,
+    );
+
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("rounded-xl");
+  });
+});

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,7 +1,6 @@
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
 import { X } from "lucide-react";
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useId, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 
 interface ModalProps {
   children: ReactNode;
@@ -10,121 +9,35 @@ interface ModalProps {
   title: string;
 }
 
-const FOCUSABLE_SELECTOR =
-  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), [contenteditable]';
-
 export default function Modal({ children, onClose, open, title }: ModalProps) {
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const titleId = useId();
-  const [visible, setVisible] = useState(false);
-  const [animateIn, setAnimateIn] = useState(false);
+  return (
+    <Dialog className="relative z-50" onClose={onClose} open={open}>
+      <DialogBackdrop
+        className="fixed inset-0 bg-black/50 transition-opacity duration-200 data-closed:opacity-0"
+        transition
+      />
 
-  useEffect(() => {
-    if (open) {
-      setVisible(true);
-      const raf = requestAnimationFrame(() => setAnimateIn(true));
-      return () => cancelAnimationFrame(raf);
-    } else {
-      setAnimateIn(false);
-    }
-  }, [open]);
-
-  // Safety fallback: unmount after animation duration in case transitionend doesn't fire
-  useEffect(() => {
-    if (!animateIn && visible && !open) {
-      const timeout = setTimeout(() => setVisible(false), 200);
-      return () => clearTimeout(timeout);
-    }
-  }, [animateIn, open, visible]);
-
-  const handleTransitionEnd = useCallback(
-    (e: React.TransitionEvent) => {
-      if (e.target === e.currentTarget && e.propertyName === "transform" && !open) {
-        setVisible(false);
-      }
-    },
-    [open],
-  );
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-        return;
-      }
-
-      if (e.key === "Tab" && dialogRef.current) {
-        const focusable =
-          dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
-        if (focusable.length === 0) return;
-
-        const first = focusable[0];
-        const last = focusable[focusable.length - 1];
-
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    },
-    [onClose],
-  );
-
-  useEffect(() => {
-    if (!open) return;
-
-    document.addEventListener("keydown", handleKeyDown);
-    const previouslyFocused = document.activeElement as HTMLElement | null;
-
-    const timer = setTimeout(() => {
-      const first =
-        dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-      first?.focus();
-    }, 0);
-
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      clearTimeout(timer);
-      previouslyFocused?.focus();
-    };
-  }, [handleKeyDown, open]);
-
-  if (!visible) return null;
-
-  return createPortal(
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-    <div
-      className={`fixed inset-0 z-50 flex items-end justify-center transition-opacity duration-200 sm:items-center ${animateIn ? "opacity-100 bg-black/50" : "opacity-0 bg-black/0"}`}
-      onClick={onClose}
-    >
-      <div
-        aria-labelledby={titleId}
-        aria-modal="true"
-        className={`w-full max-w-lg rounded-t-2xl bg-surface-primary p-6 shadow-xl transition-transform duration-200 ease-out sm:rounded-2xl ${animateIn ? "translate-y-0" : "translate-y-full"}`}
-        onClick={(e) => e.stopPropagation()}
-        onTransitionEnd={handleTransitionEnd}
-        ref={dialogRef}
-        role="dialog"
-      >
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-text-primary" id={titleId}>
-            {title}
-          </h2>
-          <button
-            aria-label="Fermer"
-            className="flex min-h-10 min-w-10 items-center justify-center rounded-full p-1 text-text-secondary transition-colors hover:bg-surface-tertiary"
-            onClick={onClose}
-            type="button"
-          >
-            <X size={20} />
-          </button>
-        </div>
-        {children}
+      <div className="fixed inset-0 flex items-end justify-center sm:items-center">
+        <DialogPanel
+          className="w-full max-w-lg rounded-t-2xl bg-surface-primary p-6 shadow-xl transition duration-200 ease-out sm:rounded-2xl data-closed:translate-y-full data-closed:sm:translate-y-4 data-closed:sm:scale-95 data-closed:sm:opacity-0"
+          transition
+        >
+          <div className="mb-4 flex items-center justify-between">
+            <DialogTitle className="text-lg font-semibold text-text-primary">
+              {title}
+            </DialogTitle>
+            <button
+              aria-label="Fermer"
+              className="flex min-h-10 min-w-10 items-center justify-center rounded-full p-1 text-text-secondary transition-colors hover:bg-surface-tertiary"
+              onClick={onClose}
+              type="button"
+            >
+              <X size={20} />
+            </button>
+          </div>
+          {children}
+        </DialogPanel>
       </div>
-    </div>,
-    document.body,
+    </Dialog>
   );
 }

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -1,5 +1,5 @@
-import { ChevronDown, Check } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from "@headlessui/react";
+import { Check, ChevronDown } from "lucide-react";
 
 export interface SelectOption<T extends string = string> {
   label: string;
@@ -21,144 +21,48 @@ export default function Select<T extends string = string>({
   value,
   variant = "default",
 }: SelectProps<T>) {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
-  const [focusedIndex, setFocusedIndex] = useState(-1);
-
   const selectedLabel = options.find((o) => o.value === value)?.label ?? "";
-
-  const close = useCallback(() => {
-    setOpen(false);
-    setFocusedIndex(-1);
-  }, []);
-
-  const select = useCallback(
-    (val: T) => {
-      onChange(val);
-      close();
-    },
-    [close, onChange],
-  );
-
-  useEffect(() => {
-    if (!open) return;
-
-    const handleMouseDown = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        close();
-      }
-    };
-
-    document.addEventListener("mousedown", handleMouseDown);
-    return () => document.removeEventListener("mousedown", handleMouseDown);
-  }, [close, open]);
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    switch (e.key) {
-      case "ArrowDown":
-        e.preventDefault();
-        if (!open) {
-          setOpen(true);
-          setFocusedIndex(options.findIndex((o) => o.value === value));
-        } else {
-          setFocusedIndex((i) => (i + 1) % options.length);
-        }
-        break;
-      case "ArrowUp":
-        e.preventDefault();
-        if (open) {
-          setFocusedIndex((i) => (i - 1 + options.length) % options.length);
-        }
-        break;
-      case "Enter":
-      case " ":
-        e.preventDefault();
-        if (open && focusedIndex >= 0) {
-          select(options[focusedIndex].value);
-        } else {
-          setOpen(true);
-          setFocusedIndex(options.findIndex((o) => o.value === value));
-        }
-        break;
-      case "Escape":
-        e.preventDefault();
-        close();
-        break;
-    }
-  };
-
-  useEffect(() => {
-    if (open && focusedIndex >= 0 && listRef.current) {
-      const item = listRef.current.children[focusedIndex] as HTMLElement | undefined;
-      item?.scrollIntoView({ block: "nearest" });
-    }
-  }, [focusedIndex, open]);
-
   const isCompact = variant === "compact";
 
   return (
-    <div className="relative" ref={containerRef}>
-      <button
-        aria-expanded={open}
-        aria-haspopup="listbox"
-        className={
-          isCompact
-            ? "flex items-center gap-1.5 rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-sm text-text-primary transition-colors hover:bg-surface-secondary"
-            : "flex w-full items-center justify-between rounded-xl bg-surface-elevated px-4 py-3 text-sm font-semibold text-text-primary transition-colors hover:bg-surface-secondary"
-        }
-        id={id}
-        onClick={() => {
-          setOpen((prev) => !prev);
-          if (!open) {
-            setFocusedIndex(options.findIndex((o) => o.value === value));
+    <Listbox onChange={onChange} value={value}>
+      <div className="relative">
+        <ListboxButton
+          className={
+            isCompact
+              ? "group flex items-center gap-1.5 rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-sm text-text-primary transition-colors hover:bg-surface-secondary"
+              : "group flex w-full items-center justify-between rounded-xl bg-surface-elevated px-4 py-3 text-sm font-semibold text-text-primary transition-colors hover:bg-surface-secondary"
           }
-        }}
-        onKeyDown={handleKeyDown}
-        type="button"
-      >
-        <span className="truncate">{selectedLabel}</span>
-        <ChevronDown
-          className={`shrink-0 text-text-muted transition-transform duration-200 ${open ? "rotate-180" : ""}`}
-          size={isCompact ? 14 : 16}
-        />
-      </button>
+          id={id}
+        >
+          <span className="truncate">{selectedLabel}</span>
+          <ChevronDown
+            className="shrink-0 text-text-muted transition-transform duration-200 group-data-open:rotate-180"
+            size={isCompact ? 14 : 16}
+          />
+        </ListboxButton>
 
-      {open && (
-        <div
-          className={`absolute z-50 mt-1 overflow-hidden rounded-xl border border-surface-border bg-surface-elevated py-1 shadow-lg animate-fade-in ${
+        <ListboxOptions
+          className={`absolute z-50 mt-1 overflow-hidden rounded-xl border border-surface-border bg-surface-elevated py-1 shadow-lg transition duration-200 ease-out data-closed:scale-95 data-closed:opacity-0 ${
             isCompact ? "right-0 min-w-44" : "left-0 right-0"
           }`}
-          ref={listRef}
-          role="listbox"
+          transition
         >
-          {options.map((option, index) => {
-            const isSelected = option.value === value;
-            const isFocused = index === focusedIndex;
-
-            return (
-              <button
-                aria-selected={isSelected}
-                className={`flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors ${
-                  isSelected
-                    ? "font-semibold text-accent-500 dark:text-accent-300"
-                    : "text-text-primary"
-                } ${isFocused ? "bg-surface-secondary" : "hover:bg-surface-secondary"}`}
-                key={option.value}
-                onClick={() => select(option.value)}
-                onMouseEnter={() => setFocusedIndex(index)}
-                role="option"
-                type="button"
-              >
-                <span className="flex-1">{option.label}</span>
-                {isSelected && (
-                  <Check className="shrink-0 text-accent-500 dark:text-accent-300" size={16} />
-                )}
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
+          {options.map((option) => (
+            <ListboxOption
+              className="group flex w-full cursor-pointer items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors data-focus:bg-surface-secondary data-selected:font-semibold data-selected:text-accent-500 dark:data-selected:text-accent-300"
+              key={option.value}
+              value={option.value}
+            >
+              <span className="flex-1">{option.label}</span>
+              <Check
+                className="invisible shrink-0 text-accent-500 group-data-selected:visible dark:text-accent-300"
+                size={16}
+              />
+            </ListboxOption>
+          ))}
+        </ListboxOptions>
+      </div>
+    </Listbox>
   );
 }

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,5 +1,12 @@
 import "@testing-library/jest-dom/vitest";
 
+// jsdom does not implement ResizeObserver — required by @headlessui/react
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
 // jsdom does not implement matchMedia — provide a minimal stub
 Object.defineProperty(window, "matchMedia", {
   value: (query: string) => ({


### PR DESCRIPTION
## Résumé

- **Modal.tsx** : remplacé par `Dialog`, `DialogBackdrop`, `DialogPanel`, `DialogTitle` de `@headlessui/react`
- **Select.tsx** : remplacé par `Listbox`, `ListboxButton`, `ListboxOptions`, `ListboxOption` de `@headlessui/react`
- ~300 lignes de code custom supprimées (focus trap, keyboard navigation, animations manuelles)
- Ajout mock `ResizeObserver` dans `test-setup.ts` (requis par headlessui en jsdom)
- Tests Modal simplifiés (comportements headlessui délégués à la bibliothèque)
- Nouveaux tests Select ajoutés

fixes #259