### PR TITLE
fix(frontend): corrige le warning Recharts de dimensions négatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **ScoreEvolutionChart** : ajout de `minWidth={0}` sur tous les `ResponsiveContainer` Recharts pour supprimer le warning de dimensions négatives au premier rendu
+
 ### Changed
 
 - **ErrorBoundary** : remplacement du composant custom par `react-error-boundary` avec bouton « Réessayer » (reset sans rechargement de page)

--- a/frontend/src/__tests__/components/ScoreEvolutionChart.test.tsx
+++ b/frontend/src/__tests__/components/ScoreEvolutionChart.test.tsx
@@ -102,6 +102,13 @@ describe("ScoreEvolutionChart", () => {
     expect(container.innerHTML).toBe("");
   });
 
+  it("sets minWidth={0} on ResponsiveContainer to prevent negative dimension warning", () => {
+    render(<ScoreEvolutionChart games={twoGames} players={players} />);
+
+    const container = screen.getByTestId("responsive-container");
+    expect(container).toHaveAttribute("data-min-width", "0");
+  });
+
   it("renders chart with all player lines by default", () => {
     render(<ScoreEvolutionChart games={twoGames} players={players} />);
 

--- a/frontend/src/__tests__/mocks/recharts.tsx
+++ b/frontend/src/__tests__/mocks/recharts.tsx
@@ -19,7 +19,9 @@ export const PieChart = ({ children }: { children: React.ReactNode }) => (
   <div data-testid="pie-chart">{children}</div>
 );
 export const ReferenceLine = () => <div data-testid="reference-line" />;
-export const ResponsiveContainer = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+export const ResponsiveContainer = ({ children, minWidth }: { children: React.ReactNode; minWidth?: number }) => (
+  <div data-min-width={minWidth} data-testid="responsive-container">{children}</div>
+);
 export const Tooltip = () => <div data-testid="tooltip" />;
 export const XAxis = () => <div data-testid="x-axis" />;
 export const YAxis = () => <div data-testid="y-axis" />;

--- a/frontend/src/components/ContractDistributionChart.tsx
+++ b/frontend/src/components/ContractDistributionChart.tsx
@@ -45,7 +45,7 @@ export default function ContractDistributionChart({ data }: ContractDistribution
 
   return (
     <div className="h-52 lg:h-72">
-      <ResponsiveContainer height="100%" width="100%">
+      <ResponsiveContainer height="100%" minWidth={0} width="100%">
         <PieChart>
           <Pie
             cx="50%"

--- a/frontend/src/components/EloEvolutionChart.tsx
+++ b/frontend/src/components/EloEvolutionChart.tsx
@@ -30,7 +30,7 @@ export default function EloEvolutionChart({ data }: EloEvolutionChartProps) {
 
   return (
     <div className="h-52 lg:h-96">
-      <ResponsiveContainer height="100%" width="100%">
+      <ResponsiveContainer height="100%" minWidth={0} width="100%">
         <LineChart data={chartData} margin={{ bottom: 0, left: 0, right: 16, top: 8 }}>
           <XAxis
             dataKey="index"

--- a/frontend/src/components/GlobalEloEvolutionChart.tsx
+++ b/frontend/src/components/GlobalEloEvolutionChart.tsx
@@ -166,7 +166,7 @@ export default function GlobalEloEvolutionChart({
         )}
       </div>
       <div className="h-64 lg:h-96">
-        <ResponsiveContainer height="100%" width="100%">
+        <ResponsiveContainer height="100%" minWidth={0} width="100%">
           <LineChart
             data={chartData}
             margin={{ bottom: 0, left: 0, right: 16, top: 8 }}

--- a/frontend/src/components/RoleDistributionChart.tsx
+++ b/frontend/src/components/RoleDistributionChart.tsx
@@ -50,7 +50,7 @@ export default function RoleDistributionChart({
 
   return (
     <div className="h-52 lg:h-72">
-      <ResponsiveContainer height="100%" width="100%">
+      <ResponsiveContainer height="100%" minWidth={0} width="100%">
         <PieChart>
           <Pie
             cx="50%"

--- a/frontend/src/components/ScoreEvolutionChart.tsx
+++ b/frontend/src/components/ScoreEvolutionChart.tsx
@@ -113,7 +113,7 @@ export default function ScoreEvolutionChart({ games, players }: ScoreEvolutionCh
         })}
       </div>
       <div className="h-64 lg:h-96">
-        <ResponsiveContainer height="100%" width="100%">
+        <ResponsiveContainer height="100%" minWidth={0} width="100%">
           <LineChart data={data} margin={{ bottom: 0, left: 0, right: 16, top: 8 }}>
             <XAxis
               dataKey="position"

--- a/frontend/src/components/ScoreTrendChart.tsx
+++ b/frontend/src/components/ScoreTrendChart.tsx
@@ -30,7 +30,7 @@ export default function ScoreTrendChart({ data }: ScoreTrendChartProps) {
 
   return (
     <div className="h-52 lg:h-96">
-      <ResponsiveContainer height="100%" width="100%">
+      <ResponsiveContainer height="100%" minWidth={0} width="100%">
         <LineChart data={chartData} margin={{ bottom: 0, left: 0, right: 16, top: 8 }}>
           <XAxis
             dataKey="index"


### PR DESCRIPTION
## Résumé

Ajoute `minWidth={0}` sur tous les `ResponsiveContainer` Recharts (6 composants) pour supprimer le warning console « The width(-1) and height(-1) of chart should be greater than 0 » qui apparaît au premier rendu.

Composants corrigés :
- `ScoreEvolutionChart`
- `ScoreTrendChart`
- `RoleDistributionChart`
- `ContractDistributionChart`
- `GlobalEloEvolutionChart`
- `EloEvolutionChart`

fixes #264