### PR TITLE
refactor(frontend): améliore la palette de couleurs PlayerAvatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Changed
 
+- **PlayerAvatar** : nouvelle palette de 10 couleurs plus distinctives, couleurs désormais en inline style (suppression des tokens CSS `avatar-0` à `avatar-9`)
 - **ErrorBoundary** : remplacement du composant custom par `react-error-boundary` avec bouton « Réessayer » (reset sans rechargement de page)
 - **ScoreDisplay** : remplacement du hook custom `useAnimatedCounter` par `react-countup` pour l'animation des scores
 - **Toast** : remplacement du système custom (`useToast`, `Toast.tsx`, `ToastContainer.tsx`) par `sonner` — meilleure accessibilité (`aria-live`), animations de sortie, API standard

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -28,7 +28,7 @@ Définis dans `frontend/src/index.css` via `@theme`. Utilisables directement com
 | **Texte** | `text-primary`, `text-secondary`, `text-muted`, `text-inverse` | `text-text-primary` |
 | **Score** | `score-positive`, `score-negative` | `text-score-positive` |
 | **Contrat** | `contract-petite`, `contract-garde`, `contract-garde-sans`, `contract-garde-contre` | `bg-contract-garde` |
-| **Avatar** | `avatar-0` à `avatar-9` | `bg-avatar-3` |
+| **Avatar** | — | 10 couleurs en inline style (palette dans `PlayerAvatar.tsx`) |
 
 ### Mode sombre
 
@@ -1612,13 +1612,13 @@ import { ContractBadge, EmptyState, FAB, MetricCard, Modal, OverflowMenu, Player
 
 **Fichier** : `components/ui/PlayerAvatar.tsx`
 
-Affiche un cercle coloré avec les initiales du joueur.
+Affiche un cercle coloré avec les initiales du joueur. Palette de 10 couleurs appliquées en inline style.
 
 | Prop | Type | Défaut | Description |
 |------|------|--------|-------------|
 | `name` | `string` | *requis* | Nom du joueur (initiales = 2 premières lettres) |
 | `playerId` | `number?` | — | Prioritaire pour la couleur palette (`playerId % 10`) |
-| `color` | `string \| null` | — | Couleur personnalisée (hex). Si fournie, remplace la couleur palette par un `backgroundColor` inline. |
+| `color` | `string \| null` | — | Couleur personnalisée (hex). Si fournie, remplace la couleur palette. |
 | `size` | `"sm" \| "md" \| "lg"` | `"md"` | 32px / 40px / 56px |
 | `className` | `string?` | — | Classes CSS supplémentaires |
 

--- a/frontend/src/__tests__/components/ui/PlayerAvatar.test.tsx
+++ b/frontend/src/__tests__/components/ui/PlayerAvatar.test.tsx
@@ -42,8 +42,8 @@ describe("PlayerAvatar", () => {
       <PlayerAvatar name="Different" playerId={3} />,
     );
 
-    const bg1 = c1.querySelector("[role=img]")?.className;
-    const bg2 = c2.querySelector("[role=img]")?.className;
+    const bg1 = c1.querySelector("[role=img]")?.getAttribute("style");
+    const bg2 = c2.querySelector("[role=img]")?.getAttribute("style");
     expect(bg1).toBe(bg2);
   });
 
@@ -55,8 +55,8 @@ describe("PlayerAvatar", () => {
       <PlayerAvatar name="Alice" />,
     );
 
-    const bg1 = c1.querySelector("[role=img]")?.className;
-    const bg2 = c2.querySelector("[role=img]")?.className;
+    const bg1 = c1.querySelector("[role=img]")?.getAttribute("style");
+    const bg2 = c2.querySelector("[role=img]")?.getAttribute("style");
     expect(bg1).toBe(bg2);
   });
 
@@ -86,8 +86,6 @@ describe("PlayerAvatar", () => {
 
     const avatar = screen.getByRole("img", { name: "Alice" });
     expect(avatar.style.backgroundColor).toBe("rgb(239, 68, 68)");
-    // Should NOT have a bg-avatar-* class
-    expect(avatar.className).not.toMatch(/bg-avatar-/);
   });
 
   it("falls back to palette color when color is null", () => {
@@ -96,7 +94,6 @@ describe("PlayerAvatar", () => {
     );
 
     const avatar = screen.getByRole("img", { name: "Alice" });
-    expect(avatar.className).toMatch(/bg-avatar-/);
-    expect(avatar.style.backgroundColor).toBe("");
+    expect(avatar.style.backgroundColor).toBeTruthy();
   });
 });

--- a/frontend/src/components/ui/PlayerAvatar.tsx
+++ b/frontend/src/components/ui/PlayerAvatar.tsx
@@ -12,17 +12,17 @@ const sizeClasses = {
   sm: "size-8 text-xs",
 } as const;
 
-const avatarColors = [
-  "bg-avatar-0",
-  "bg-avatar-1",
-  "bg-avatar-2",
-  "bg-avatar-3",
-  "bg-avatar-4",
-  "bg-avatar-5",
-  "bg-avatar-6",
-  "bg-avatar-7",
-  "bg-avatar-8",
-  "bg-avatar-9",
+const palette = [
+  "#264653",
+  "#2a9d8f",
+  "#e9c46a",
+  "#f4a261",
+  "#e76f51",
+  "#6d597a",
+  "#b56576",
+  "#355070",
+  "#52796f",
+  "#bc6c25",
 ] as const;
 
 function hashCode(str: string): number {
@@ -33,6 +33,13 @@ function hashCode(str: string): number {
   return Math.abs(hash);
 }
 
+function getInitials(name: string): string {
+  const parts = name.split(/[\s-]+/);
+  return parts.length > 1
+    ? (parts[0][0] + parts[1][0]).toUpperCase()
+    : name.slice(0, 2).toUpperCase();
+}
+
 export default function PlayerAvatar({
   className = "",
   color,
@@ -40,25 +47,19 @@ export default function PlayerAvatar({
   playerId,
   size = "md",
 }: PlayerAvatarProps) {
-  const parts = name.split(/[\s-]+/);
-  const initials =
-    parts.length > 1
-      ? (parts[0][0] + parts[1][0]).toUpperCase()
-      : name.slice(0, 2).toUpperCase();
   const useCustomColor = !!color;
   const colorIndex =
-    playerId !== undefined ? playerId % 10 : hashCode(name) % 10;
-  const colorClass = useCustomColor ? "" : avatarColors[colorIndex];
-  const inlineStyle = useCustomColor ? { backgroundColor: color } : undefined;
+    playerId !== undefined ? playerId % palette.length : hashCode(name) % palette.length;
+  const backgroundColor = useCustomColor ? color : palette[colorIndex];
 
   return (
     <div
       aria-label={name}
-      className={`${colorClass} ${sizeClasses[size]} inline-flex items-center justify-center rounded-full font-semibold text-white ${className}`.trim()}
+      className={`${sizeClasses[size]} inline-flex items-center justify-center rounded-full font-semibold text-white ${className}`.trim()}
       role="img"
-      style={inlineStyle}
+      style={{ backgroundColor: backgroundColor! }}
     >
-      {initials}
+      {getInitials(name)}
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,17 +17,6 @@
   --color-accent-800: #11233d;
   --color-accent-900: #0d1b31;
 
-  --color-avatar-0: #ef4444;
-  --color-avatar-1: #f97316;
-  --color-avatar-2: #eab308;
-  --color-avatar-3: #22c55e;
-  --color-avatar-4: #14b8a6;
-  --color-avatar-5: #3b82f6;
-  --color-avatar-6: #6366f1;
-  --color-avatar-7: #a855f7;
-  --color-avatar-8: #ec4899;
-  --color-avatar-9: #78716c;
-
   --color-contract-garde: #2563eb;
   --color-contract-garde-contre: #dc2626;
   --color-contract-garde-sans: #ea580c;


### PR DESCRIPTION
## Résumé

- Remplace les tokens CSS (`bg-avatar-0` à `bg-avatar-9`) par une palette inline de 10 couleurs plus distinctives dans `PlayerAvatar.tsx`
- Supprime les custom properties `--color-avatar-*` inutilisées dans `index.css`
- Conserve les initiales, les tailles et la personnalisation de couleur par joueur

> **Note** : `boring-avatars` a été évalué (beam, marble, ring, sunset) mais les variantes SVG ne sont pas lisibles avec des initiales superposées. L'approche retenue est une amélioration de la palette existante.

fixes #260

## Plan de test

- [x] 820 tests frontend passent
- [x] Lint propre (PHPStan + PHP CS Fixer + TypeScript)
- [x] Couleur personnalisée du joueur toujours respectée
- [x] Palette par défaut plus distinctive

🤖 Generated with [Claude Code](https://claude.com/claude-code)