### PR TITLE
refactor(backend): réutilise maxStreak() dans checkWall()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Changed
 
+- **BadgeChecker** : refactorisation de `checkWall()` pour réutiliser `maxStreak()` au lieu d'un calcul inline dupliqué ; généralisation de `maxStreak()` avec template PHPDoc
 - **Repositories** : standardisation du mapping DTO sur `SELECT NEW` en DQL pour 4 méthodes (suppression du mapping manuel scalaire + `foreach`)
 - **PlayerAvatar** : nouvelle palette de 10 couleurs plus distinctives, couleurs désormais en inline style (suppression des tokens CSS `avatar-0` à `avatar-9`)
 - **ErrorBoundary** : remplacement du composant custom par `react-error-boundary` avec bouton « Réessayer » (reset sans rechargement de page)

--- a/backend/src/Service/BadgeChecker.php
+++ b/backend/src/Service/BadgeChecker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Dto\GameTakerScoreDto;
 use App\Dto\PlayerScoreSumDto;
 use App\Dto\ScoreEntryPositionDto;
 use App\Entity\Player;
@@ -645,23 +646,16 @@ final readonly class BadgeChecker
     private function checkWall(Player $player, BadgeCheckContext $context): bool
     {
         $playerId = $player->getId();
-        $max = 0;
-        $current = 0;
 
-        foreach ($context->gamesWithTakerScore as $game) {
-            $isDefense = $game->takerId !== $playerId
-                && (null === $game->partnerId || $game->partnerId !== $playerId);
-            $defenseWin = $isDefense && $game->takerScore < 0;
+        return $this->maxStreak(
+            $context->gamesWithTakerScore,
+            static function (GameTakerScoreDto $game) use ($playerId): bool {
+                $isDefense = $game->takerId !== $playerId
+                    && (null === $game->partnerId || $game->partnerId !== $playerId);
 
-            if ($defenseWin) {
-                ++$current;
-                $max = \max($max, $current);
-            } else {
-                $current = 0;
-            }
-        }
-
-        return $max >= 10;
+                return $isDefense && $game->takerScore < 0;
+            },
+        ) >= 10;
     }
 
     /**
@@ -679,8 +673,10 @@ final readonly class BadgeChecker
     }
 
     /**
-     * @param list<int>           $items
-     * @param callable(int): bool $condition
+     * @template T
+     *
+     * @param list<T>           $items
+     * @param callable(T): bool $condition
      */
     private function maxStreak(array $items, callable $condition): int
     {

--- a/backend/tests/Service/BadgeCheckerTest.php
+++ b/backend/tests/Service/BadgeCheckerTest.php
@@ -407,6 +407,60 @@ class BadgeCheckerTest extends ApiTestCase
         self::assertNotContains(BadgeType::Konami, $takerBadges);
     }
 
+    public function testWallBadge(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+        $defender = $players[1]; // Bob will be on defense for all games
+
+        // 10 consecutive defense wins: taker loses each time, defender is never taker/partner
+        for ($i = 0; $i < 10; ++$i) {
+            $this->completeGame($session, $players[0], points: 30, takerScore: -100);
+        }
+
+        $result = $this->checker->checkAndAward($session);
+
+        self::assertContains(BadgeType::Wall, $result[$defender->getId()]);
+    }
+
+    public function testWallBadgeNotAwardedUnder10(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+        $defender = $players[1];
+
+        // Only 9 consecutive defense wins
+        for ($i = 0; $i < 9; ++$i) {
+            $this->completeGame($session, $players[0], points: 30, takerScore: -100);
+        }
+
+        $result = $this->checker->checkAndAward($session);
+
+        $defenderBadges = $result[$defender->getId()] ?? [];
+        self::assertNotContains(BadgeType::Wall, $defenderBadges);
+    }
+
+    public function testWallBadgeStreakBrokenByTakerWin(): void
+    {
+        $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');
+        $players = $session->getPlayers()->toArray();
+        $defender = $players[1];
+
+        // 5 defense wins, then a taker win (breaks streak), then 5 more
+        for ($i = 0; $i < 5; ++$i) {
+            $this->completeGame($session, $players[0], points: 30, takerScore: -100);
+        }
+        $this->completeGame($session, $players[0], points: 56); // taker wins → defense loses
+        for ($i = 0; $i < 5; ++$i) {
+            $this->completeGame($session, $players[0], points: 30, takerScore: -100);
+        }
+
+        $result = $this->checker->checkAndAward($session);
+
+        $defenderBadges = $result[$defender->getId()] ?? [];
+        self::assertNotContains(BadgeType::Wall, $defenderBadges);
+    }
+
     public function testCatchThemAllBadge(): void
     {
         $session = $this->createSessionWithPlayers('Alice', 'Bob', 'Charlie', 'Diana', 'Eve');


### PR DESCRIPTION
## Résumé

- Refactorise `checkWall()` pour réutiliser `maxStreak()` au lieu d'un calcul inline dupliqué
- Généralise `maxStreak()` avec un `@template T` PHPDoc pour accepter tout type de liste
- Ajoute 3 tests unitaires pour le badge Wall (positif, seuil, streak cassé par une victoire du preneur)

fixes #263