### PR TITLE
fix(frontend): remplace le cheat code IDDQD par détection du nom joueur pour le mode Doom mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Thème Doom mobile** : le cheat code IDDQD (keydown) ne fonctionnait pas sur smartphone ; remplacé par la détection du nom « Doomguy » ou « Doom Guy » dans les champs joueur (recherche/création)
+
 ## [1.6.0] - 2026-02-22
 
 ### Added

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -42,12 +42,12 @@ L'application est wrappée dans `<ThemeProvider>` de `next-themes` (dans `App.ts
 
 **Fichier** : `frontend/src/services/themeRegistry.ts`
 
-Toute la configuration d'un thème custom (avatars, sons, icônes, splash, cheat code, style toast, etc.) est centralisée dans un registre `CUSTOM_THEMES: Record<string, ThemeConfig>`. Les composants consomment ce registre via `getThemeConfig(resolvedTheme)` au lieu de hardcoder des checks `=== "doom"`.
+Toute la configuration d'un thème custom (avatars, sons, icônes, splash, trigger names, style toast, etc.) est centralisée dans un registre `CUSTOM_THEMES: Record<string, ThemeConfig>`. Les composants consomment ce registre via `getThemeConfig(resolvedTheme)` au lieu de hardcoder des checks `=== "doom"`.
 
 Pour ajouter un nouveau thème custom :
 1. Ajouter une entrée dans `CUSTOM_THEMES` avec toute la `ThemeConfig`
 2. Ajouter les CSS variables et la classe du thème dans `index.css`
-3. Le cheat code, les sons, le splash, le toggle et les avatars fonctionnent automatiquement
+3. Les trigger names (noms de joueur déclencheurs), les sons, le splash, le toggle et les avatars fonctionnent automatiquement
 
 ### Error Boundary
 
@@ -170,7 +170,7 @@ const { resolvedTheme, setTheme, themes } = useTheme();
 
 **Prérequis** : composant dans un `<ThemeProvider>` (configuré dans `App.tsx`).
 
-**Thème Doom** : thème caché activé par le cheat code IDDQD. Palette rouge/noir, police AmazDooMLeft sur les titres, sons Doom contextuels. Les CSS custom properties sont définies dans le bloc `.doom` de `index.css`. Le variant Tailwind `doom:` permet de cibler ce thème.
+**Thème Doom** : thème caché activé en tapant « Doomguy » ou « Doom Guy » dans un champ joueur (recherche ou création). Palette rouge/noir, police AmazDooMLeft sur les titres, sons Doom contextuels. Les CSS custom properties sont définies dans le bloc `.doom` de `index.css`. Le variant Tailwind `doom:` permet de cibler ce thème.
 
 ### Toasts (sonner)
 
@@ -458,10 +458,10 @@ mutation.mutate(undefined, {
 
 **Fichier** : `hooks/useCheatCode.ts`
 
-Hook générique détectant une séquence de touches clavier sur `document`. Réinitialisation sur mauvaise touche ou timeout de 3 secondes. Case-insensitive.
+Hook détectant des noms déclencheurs dans les champs `<input>` marqués `data-cheat-target`. Écoute les événements `input` sur `document`, comparaison case-insensitive avec trim.
 
 ```ts
-useCheatCode("iddqd", () => { /* séquence complète */ });
+useCheatCode(["doomguy", "doom guy"], () => { /* nom détecté */ });
 ```
 
 ### `useThemeSounds`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,7 +48,7 @@ function ThemeCheatCodeHandler({ config }: { config: ThemeConfig }) {
     toast(config.toastMessage, { style: config.toastStyle });
   }, [config, setTheme]);
 
-  useCheatCode(config.cheatCode, handleActivate);
+  useCheatCode(config.triggerNames, handleActivate);
 
   return <ThemeSplash imageSrc={config.splashImage} onDone={handleSplashDone} visible={showSplash} />;
 }

--- a/frontend/src/__tests__/hooks/useCheatCode.test.ts
+++ b/frontend/src/__tests__/hooks/useCheatCode.test.ts
@@ -1,79 +1,82 @@
 import { renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useCheatCode } from "../../hooks/useCheatCode";
 
-function pressKey(key: string) {
-  document.dispatchEvent(new KeyboardEvent("keydown", { key }));
+function simulateInput(value: string, hasAttribute = true) {
+  const input = document.createElement("input");
+  if (hasAttribute) input.setAttribute("data-cheat-target", "");
+  document.body.appendChild(input);
+  input.value = value;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  document.body.removeChild(input);
 }
 
 describe("useCheatCode", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
   afterEach(() => {
-    vi.useRealTimers();
+    vi.clearAllMocks();
   });
 
-  it("detects the sequence 'iddqd'", () => {
+  it("active quand la valeur correspond à un trigger name", () => {
     const onActivate = vi.fn();
-    renderHook(() => useCheatCode("iddqd", onActivate));
+    renderHook(() => useCheatCode(["doomguy"], onActivate));
 
-    for (const key of ["i", "d", "d", "q", "d"]) {
-      pressKey(key);
-    }
+    simulateInput("Doomguy");
 
     expect(onActivate).toHaveBeenCalledOnce();
   });
 
-  it("is case-insensitive", () => {
+  it("est insensible à la casse", () => {
     const onActivate = vi.fn();
-    renderHook(() => useCheatCode("iddqd", onActivate));
+    renderHook(() => useCheatCode(["doomguy"], onActivate));
 
-    for (const key of ["I", "D", "D", "Q", "D"]) {
-      pressKey(key);
-    }
+    simulateInput("DOOMGUY");
 
     expect(onActivate).toHaveBeenCalledOnce();
   });
 
-  it("resets after a wrong key", () => {
+  it("ignore les espaces autour de la valeur", () => {
     const onActivate = vi.fn();
-    renderHook(() => useCheatCode("iddqd", onActivate));
+    renderHook(() => useCheatCode(["doomguy"], onActivate));
 
-    pressKey("i");
-    pressKey("d");
-    pressKey("x"); // wrong key
-    pressKey("d");
-    pressKey("q");
-    pressKey("d");
+    simulateInput("  Doomguy  ");
+
+    expect(onActivate).toHaveBeenCalledOnce();
+  });
+
+  it("matche n'importe quel trigger name de la liste", () => {
+    const onActivate = vi.fn();
+    renderHook(() => useCheatCode(["doomguy", "doom guy"], onActivate));
+
+    simulateInput("Doom Guy");
+
+    expect(onActivate).toHaveBeenCalledOnce();
+  });
+
+  it("ne se déclenche pas sur un match partiel", () => {
+    const onActivate = vi.fn();
+    renderHook(() => useCheatCode(["doomguy"], onActivate));
+
+    simulateInput("doom");
 
     expect(onActivate).not.toHaveBeenCalled();
   });
 
-  it("resets after 3s timeout between keypresses", () => {
+  it("ignore les inputs sans data-cheat-target", () => {
     const onActivate = vi.fn();
-    renderHook(() => useCheatCode("iddqd", onActivate));
+    renderHook(() => useCheatCode(["doomguy"], onActivate));
 
-    pressKey("i");
-    pressKey("d");
-    vi.advanceTimersByTime(3001);
-    pressKey("d");
-    pressKey("q");
-    pressKey("d");
+    simulateInput("Doomguy", false);
 
     expect(onActivate).not.toHaveBeenCalled();
   });
 
-  it("cleans up on unmount", () => {
+  it("nettoie le listener au démontage", () => {
     const onActivate = vi.fn();
-    const { unmount } = renderHook(() => useCheatCode("iddqd", onActivate));
+    const { unmount } = renderHook(() => useCheatCode(["doomguy"], onActivate));
 
     unmount();
 
-    for (const key of ["i", "d", "d", "q", "d"]) {
-      pressKey(key);
-    }
+    simulateInput("Doomguy");
 
     expect(onActivate).not.toHaveBeenCalled();
   });

--- a/frontend/src/__tests__/services/themeRegistry.test.ts
+++ b/frontend/src/__tests__/services/themeRegistry.test.ts
@@ -7,7 +7,7 @@ describe("themeRegistry", () => {
 
     expect(config).toBeDefined();
     expect(config?.name).toBe("doom");
-    expect(config?.cheatCode).toBe("iddqd");
+    expect(config?.triggerNames).toEqual(["doomguy", "doom guy"]);
     expect(config?.starIcons.length).toBeGreaterThan(0);
     expect(config?.avatars.icons.length).toBeGreaterThan(0);
   });

--- a/frontend/src/components/PlayerSelector.tsx
+++ b/frontend/src/components/PlayerSelector.tsx
@@ -257,6 +257,7 @@ export default function PlayerSelector({
                 : undefined,
               "aria-controls": dropdownVisible ? "player-dropdown" : undefined,
               "aria-expanded": dropdownVisible,
+              "data-cheat-target": "",
               role: "combobox",
             }}
             onKeyDown={handleKeyDown}
@@ -302,6 +303,7 @@ export default function PlayerSelector({
           <div>
             <input
               className="w-full rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-text-primary placeholder:text-text-muted focus:border-accent-400 focus:outline-none focus:ring-1 focus:ring-accent-400"
+              data-cheat-target=""
               onChange={(e) => setNewName(e.target.value)}
               placeholder="Nom du joueur"
               required

--- a/frontend/src/components/ui/SearchInput.tsx
+++ b/frontend/src/components/ui/SearchInput.tsx
@@ -6,7 +6,7 @@ interface SearchInputProps {
   className?: string;
   clearKey?: number;
   debounceMs?: number;
-  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement> & Record<`data-${string}`, string>;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   onSearch: (value: string) => void;
   placeholder?: string;

--- a/frontend/src/hooks/useCheatCode.ts
+++ b/frontend/src/hooks/useCheatCode.ts
@@ -1,36 +1,21 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
-export function useCheatCode(code: string, onActivate: () => void): void {
-  const indexRef = useRef(0);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const chars = code.toLowerCase().split("");
-
+export function useCheatCode(triggerNames: string[], onActivate: () => void): void {
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
+    const normalized = triggerNames.map((n) => n.toLowerCase().trim());
 
-      if (e.key.toLowerCase() === chars[indexRef.current]) {
-        indexRef.current++;
-        if (indexRef.current === chars.length) {
-          indexRef.current = 0;
-          onActivate();
-          return;
-        }
-        timerRef.current = setTimeout(() => {
-          indexRef.current = 0;
-        }, 3000);
-      } else {
-        indexRef.current = 0;
+    const handleInput = (e: Event) => {
+      const target = e.target;
+      if (!(target instanceof HTMLInputElement)) return;
+      if (!target.hasAttribute("data-cheat-target")) return;
+
+      const value = target.value.toLowerCase().trim();
+      if (normalized.includes(value)) {
+        onActivate();
       }
     };
 
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, [chars, onActivate]);
+    document.addEventListener("input", handleInput);
+    return () => document.removeEventListener("input", handleInput);
+  }, [triggerNames, onActivate]);
 }

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -137,6 +137,7 @@ export default function Players() {
       </header>
 
       <SearchInput
+        inputProps={{ "data-cheat-target": "" }}
         onSearch={setSearch}
         placeholder="Rechercher un joueur…"
       />
@@ -216,6 +217,7 @@ export default function Players() {
           <div>
             <input
               className="w-full rounded-lg border border-surface-border bg-surface-primary px-3 py-2 text-text-primary placeholder:text-text-muted focus:border-accent-400 focus:outline-none focus:ring-1 focus:ring-accent-400"
+              data-cheat-target=""
               onChange={(e) => setNewName(e.target.value)}
               placeholder="Nom du joueur"
               required

--- a/frontend/src/services/themeRegistry.ts
+++ b/frontend/src/services/themeRegistry.ts
@@ -15,7 +15,7 @@ export interface SoundEffect {
 export interface ThemeConfig {
   activationSound: string;
   avatars: ThemeAvatarConfig;
-  cheatCode: string;
+  triggerNames: string[];
   dealerIcon: string;
   logo: string;
   name: string;
@@ -87,7 +87,7 @@ export const CUSTOM_THEMES: Record<string, ThemeConfig> = {
       ],
       initialsPosition: "hidden",
     },
-    cheatCode: "iddqd",
+    triggerNames: ["doomguy", "doom guy"],
     dealerIcon: "/images/doom/doomguy-face-512.png",
     logo: "/images/doom/doom-logo-256x256.png",
     name: "doom",


### PR DESCRIPTION
## Résumé

- Le hook `useCheatCode` écoutait uniquement les événements `keydown`, inopérants sur smartphone (pas de clavier physique)
- Remplacé par la détection du nom « Doomguy » ou « Doom Guy » dans les champs joueur marqués `data-cheat-target` (recherche + création)
- `ThemeConfig.cheatCode: string` → `ThemeConfig.triggerNames: string[]`

fixes #276