### PR TITLE
feat(frontend): ajoute zoom et scroll horizontal sur le graphe Elo global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **Zoom graphe Elo** : zoom et scroll horizontal sur le graphe d'évolution Elo global (molette, pinch-to-zoom, drag/swipe pour naviguer), double-clic/tap pour réinitialiser
+
 ## [1.6.1] - 2026-02-24
 
 ### Added

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -518,6 +518,31 @@ Hook détectant si le téléphone est retourné à l'envers via l'API `DeviceOri
 const isUpsideDown = useUpsideDown({ enabled: true });
 ```
 
+### `usePinchZoom`
+
+**Fichier** : `hooks/usePinchZoom.ts`
+
+Hook gérant le zoom et le scroll horizontal sur un conteneur HTML : molette (desktop), pinch-to-zoom (mobile), drag/swipe pour naviguer, Shift+molette pour scroller, double-clic/tap pour réinitialiser. Retourne un callback ref à poser sur le conteneur, un domain `[min, max]` pour l'axe X Recharts, et le niveau de zoom.
+
+```ts
+const { chartRef, domain, resetZoom, zoomLevel } = usePinchZoom({
+  dataLength: chartData.length,
+  enabled: true,
+});
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `dataLength` | `number` | Nombre de points sur l'axe X |
+| `enabled` | `boolean` | Activer/désactiver les listeners (défaut `true`) |
+
+| Retour | Type | Description |
+|--------|------|-------------|
+| `chartRef` | `(node: HTMLDivElement \| null) => void` | Callback ref pour le conteneur |
+| `domain` | `[number, number]` | Bornes `[min, max]` pour `XAxis domain` |
+| `resetZoom` | `() => void` | Réinitialiser le zoom à 1 |
+| `zoomLevel` | `number` | Niveau de zoom courant (1 = pas de zoom, max 20) |
+
 ### `useVoiceScoring`
 
 **Fichier** : `hooks/useVoiceScoring.ts`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -463,7 +463,7 @@ où **K** règle la vitesse à laquelle le rating évolue (plus K est grand, plu
 
 ### Où le trouver
 
-- **Page Statistiques** : une section **« Classement ELO »** affiche tous les joueurs triés par rating décroissant, avec un code couleur (vert > 1500, rouge < 1500). En dessous, un graphique **« Évolution ELO »** montre les courbes de tous les joueurs sur un même graphique, avec un menu déroulant « Joueurs » pour masquer/afficher chaque joueur. La ligne de référence à 1500 sert de repère.
+- **Page Statistiques** : une section **« Classement ELO »** affiche tous les joueurs triés par rating décroissant, avec un code couleur (vert > 1500, rouge < 1500). En dessous, un graphique **« Évolution ELO »** montre les courbes de tous les joueurs sur un même graphique, avec un menu déroulant « Joueurs » pour masquer/afficher chaque joueur. La ligne de référence à 1500 sert de repère. Le graphique supporte le **zoom** (molette ou pinch) et le **scroll horizontal** (Shift+molette, drag ou swipe) pour naviguer dans les données. Double-clic ou double-tap pour réinitialiser.
 - **Statistiques d'un joueur** : la carte « ELO » affiche le rating actuel, et un graphique **« Évolution ELO »** montre la courbe au fil des donnes
 
 ### Recalcul et suppression

--- a/frontend/src/__tests__/components/GlobalEloEvolutionChart.test.tsx
+++ b/frontend/src/__tests__/components/GlobalEloEvolutionChart.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { EloEvolutionPlayer } from "../../types/api";
 import GlobalEloEvolutionChart, {
   buildChartData,
 } from "../../components/GlobalEloEvolutionChart";
+import { resetCapturedProps, xAxisProps } from "../mocks/recharts";
 
 vi.mock("recharts", () => import("../mocks/recharts"));
 
@@ -81,6 +82,10 @@ describe("buildChartData", () => {
 });
 
 describe("GlobalEloEvolutionChart", () => {
+  beforeEach(() => {
+    resetCapturedProps();
+  });
+
   it("renders chart with player lines", () => {
     render(<GlobalEloEvolutionChart data={sampleData} />);
 
@@ -157,5 +162,77 @@ describe("GlobalEloEvolutionChart", () => {
     const container = screen.getByTestId("responsive-container");
     expect(container).toHaveAttribute("data-min-width", "0");
     expect(container).toHaveAttribute("data-min-height", "0");
+  });
+
+  it("passes XAxis domain from zoom hook", () => {
+    render(<GlobalEloEvolutionChart data={sampleData} />);
+
+    // Initial domain = full range
+    expect(xAxisProps.domain).toEqual([1, 2]);
+    expect(xAxisProps.type).toBe("number");
+    expect(xAxisProps.allowDataOverflow).toBe(true);
+  });
+
+  it("changes XAxis domain on wheel zoom", () => {
+    const manyPointsData: EloEvolutionPlayer[] = [
+      {
+        history: Array.from({ length: 20 }, (_, i) => ({
+          date: `2026-01-${String(i + 1).padStart(2, "0")}T12:00:00+00:00`,
+          gameId: i + 1,
+          ratingAfter: 1500 + i * 10,
+        })),
+        playerColor: "#ef4444",
+        playerId: 1,
+        playerName: "Alice",
+      },
+    ];
+
+    render(<GlobalEloEvolutionChart data={manyPointsData} />);
+
+    expect(xAxisProps.domain).toEqual([1, 20]);
+
+    const chartWrapper = screen.getByTestId("zoom-container");
+    act(() => {
+      chartWrapper.dispatchEvent(
+        new WheelEvent("wheel", { bubbles: true, deltaY: -100 }),
+      );
+    });
+
+    // Domain should be narrower after zoom in
+    const [min, max] = xAxisProps.domain as [number, number];
+    expect(max - min).toBeLessThan(19);
+  });
+
+  it("resets zoom on double-click", () => {
+    const manyPointsData: EloEvolutionPlayer[] = [
+      {
+        history: Array.from({ length: 20 }, (_, i) => ({
+          date: `2026-01-${String(i + 1).padStart(2, "0")}T12:00:00+00:00`,
+          gameId: i + 1,
+          ratingAfter: 1500 + i * 10,
+        })),
+        playerColor: "#ef4444",
+        playerId: 1,
+        playerName: "Alice",
+      },
+    ];
+
+    render(<GlobalEloEvolutionChart data={manyPointsData} />);
+
+    const chartWrapper = screen.getByTestId("zoom-container");
+
+    // Zoom in
+    act(() => {
+      chartWrapper.dispatchEvent(
+        new WheelEvent("wheel", { bubbles: true, deltaY: -100 }),
+      );
+    });
+
+    // Double-click to reset
+    act(() => {
+      chartWrapper.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+
+    expect(xAxisProps.domain).toEqual([1, 20]);
   });
 });

--- a/frontend/src/__tests__/hooks/usePinchZoom.test.ts
+++ b/frontend/src/__tests__/hooks/usePinchZoom.test.ts
@@ -1,0 +1,347 @@
+import { act, renderHook } from "@testing-library/react";
+import { usePinchZoom } from "../../hooks/usePinchZoom";
+
+function createWheelEvent(deltaY: number, shiftKey = false): WheelEvent {
+  return new WheelEvent("wheel", { bubbles: true, deltaY, shiftKey });
+}
+
+function createTouchEvent(
+  type: string,
+  touches: Array<{ clientX: number; clientY: number }>,
+): TouchEvent {
+  const touchList = touches.map(
+    (t) =>
+      ({
+        clientX: t.clientX,
+        clientY: t.clientY,
+      }) as Touch,
+  );
+  return new TouchEvent(type, {
+    bubbles: true,
+    touches: type === "touchend" ? [] : touchList,
+  });
+}
+
+describe("usePinchZoom", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    // Give container a width for pan calculations
+    Object.defineProperty(container, "clientWidth", { configurable: true, value: 400 });
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  function attachRef(result: { current: ReturnType<typeof usePinchZoom> }) {
+    act(() => {
+      result.current.chartRef(container);
+    });
+  }
+
+  it("returns initial state: zoomLevel=1, domain=[1, dataLength]", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 20 }),
+    );
+
+    expect(result.current.zoomLevel).toBe(1);
+    expect(result.current.domain).toEqual([1, 20]);
+  });
+
+  it("zooms in on wheel deltaY < 0", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 20 }),
+    );
+    attachRef(result);
+
+    act(() => {
+      container.dispatchEvent(createWheelEvent(-100));
+    });
+
+    expect(result.current.zoomLevel).toBeGreaterThan(1);
+    const [min, max] = result.current.domain;
+    expect(max - min).toBeLessThan(19);
+  });
+
+  it("zooms out on wheel deltaY > 0 (min 1)", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 20 }),
+    );
+    attachRef(result);
+
+    act(() => {
+      container.dispatchEvent(createWheelEvent(-100));
+      container.dispatchEvent(createWheelEvent(-100));
+    });
+    const zoomAfterIn = result.current.zoomLevel;
+
+    act(() => {
+      container.dispatchEvent(createWheelEvent(100));
+    });
+
+    expect(result.current.zoomLevel).toBeLessThan(zoomAfterIn);
+    expect(result.current.zoomLevel).toBeGreaterThanOrEqual(1);
+  });
+
+  it("clamps zoom to [1, 20]", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 100 }),
+    );
+    attachRef(result);
+
+    act(() => {
+      for (let i = 0; i < 200; i++) {
+        container.dispatchEvent(createWheelEvent(-100));
+      }
+    });
+    expect(result.current.zoomLevel).toBe(20);
+
+    act(() => {
+      for (let i = 0; i < 200; i++) {
+        container.dispatchEvent(createWheelEvent(100));
+      }
+    });
+    expect(result.current.zoomLevel).toBe(1);
+  });
+
+  it("clamps domain to data bounds", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 10 }),
+    );
+    attachRef(result);
+
+    act(() => {
+      container.dispatchEvent(createWheelEvent(-100));
+    });
+
+    const [min, max] = result.current.domain;
+    expect(min).toBeGreaterThanOrEqual(1);
+    expect(max).toBeLessThanOrEqual(10);
+  });
+
+  it("zooms in on pinch (fingers spreading apart)", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 20 }),
+    );
+    attachRef(result);
+
+    act(() => {
+      container.dispatchEvent(
+        createTouchEvent("touchstart", [
+          { clientX: 100, clientY: 100 },
+          { clientX: 120, clientY: 100 },
+        ]),
+      );
+    });
+
+    act(() => {
+      container.dispatchEvent(
+        createTouchEvent("touchmove", [
+          { clientX: 50, clientY: 100 },
+          { clientX: 170, clientY: 100 },
+        ]),
+      );
+    });
+
+    expect(result.current.zoomLevel).toBeGreaterThan(1);
+  });
+
+  it("zooms out on pinch (fingers coming together)", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 20 }),
+    );
+    attachRef(result);
+
+    act(() => {
+      for (let i = 0; i < 10; i++) {
+        container.dispatchEvent(createWheelEvent(-100));
+      }
+    });
+    const zoomAfterIn = result.current.zoomLevel;
+
+    act(() => {
+      container.dispatchEvent(
+        createTouchEvent("touchstart", [
+          { clientX: 50, clientY: 100 },
+          { clientX: 170, clientY: 100 },
+        ]),
+      );
+    });
+
+    act(() => {
+      container.dispatchEvent(
+        createTouchEvent("touchmove", [
+          { clientX: 100, clientY: 100 },
+          { clientX: 120, clientY: 100 },
+        ]),
+      );
+    });
+
+    expect(result.current.zoomLevel).toBeLessThan(zoomAfterIn);
+  });
+
+  it("resets zoom on double-tap", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 20 }),
+    );
+    attachRef(result);
+
+    act(() => {
+      container.dispatchEvent(createWheelEvent(-100));
+      container.dispatchEvent(createWheelEvent(-100));
+    });
+    expect(result.current.zoomLevel).toBeGreaterThan(1);
+
+    act(() => {
+      container.dispatchEvent(createTouchEvent("touchend", []));
+    });
+    act(() => {
+      container.dispatchEvent(createTouchEvent("touchend", []));
+    });
+
+    expect(result.current.zoomLevel).toBe(1);
+    expect(result.current.domain).toEqual([1, 20]);
+  });
+
+  it("resets zoom on double-click", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 20 }),
+    );
+    attachRef(result);
+
+    act(() => {
+      container.dispatchEvent(createWheelEvent(-100));
+    });
+    expect(result.current.zoomLevel).toBeGreaterThan(1);
+
+    act(() => {
+      container.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+
+    expect(result.current.zoomLevel).toBe(1);
+  });
+
+  it("pans with shift+wheel when zoomed", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 40 }),
+    );
+    attachRef(result);
+
+    // Zoom in first
+    act(() => {
+      for (let i = 0; i < 10; i++) {
+        container.dispatchEvent(createWheelEvent(-100));
+      }
+    });
+    const domainBefore = [...result.current.domain];
+
+    // Shift+wheel to pan right
+    act(() => {
+      container.dispatchEvent(createWheelEvent(100, true));
+    });
+
+    const domainAfter = result.current.domain;
+    // Domain should have shifted right
+    expect(domainAfter[0]).toBeGreaterThan(domainBefore[0]);
+    expect(domainAfter[1]).toBeGreaterThan(domainBefore[1]);
+  });
+
+  it("pans with mouse drag when zoomed", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 40 }),
+    );
+    attachRef(result);
+
+    // Zoom in
+    act(() => {
+      for (let i = 0; i < 10; i++) {
+        container.dispatchEvent(createWheelEvent(-100));
+      }
+    });
+    const domainBefore = [...result.current.domain];
+
+    // Mouse drag right (drag start → move left = pan right)
+    act(() => {
+      container.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 200 }));
+      document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: 100 }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    });
+
+    const domainAfter = result.current.domain;
+    expect(domainAfter[0]).toBeGreaterThan(domainBefore[0]);
+  });
+
+  it("does not pan with mouse drag when not zoomed", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 20 }),
+    );
+    attachRef(result);
+
+    const domainBefore = [...result.current.domain];
+
+    act(() => {
+      container.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 200 }));
+      document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: 100 }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    });
+
+    expect(result.current.domain).toEqual(domainBefore);
+  });
+
+  it("pans with single-touch drag when zoomed", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 40 }),
+    );
+    attachRef(result);
+
+    // Zoom in
+    act(() => {
+      for (let i = 0; i < 10; i++) {
+        container.dispatchEvent(createWheelEvent(-100));
+      }
+    });
+    const domainBefore = [...result.current.domain];
+
+    // Touch drag
+    act(() => {
+      container.dispatchEvent(
+        createTouchEvent("touchstart", [{ clientX: 200, clientY: 100 }]),
+      );
+      container.dispatchEvent(
+        createTouchEvent("touchmove", [{ clientX: 100, clientY: 100 }]),
+      );
+    });
+
+    const domainAfter = result.current.domain;
+    expect(domainAfter[0]).toBeGreaterThan(domainBefore[0]);
+  });
+
+  it("does not attach listeners when enabled=false", () => {
+    const { result } = renderHook(() =>
+      usePinchZoom({ dataLength: 20, enabled: false }),
+    );
+    attachRef(result);
+
+    act(() => {
+      container.dispatchEvent(createWheelEvent(-100));
+    });
+
+    expect(result.current.zoomLevel).toBe(1);
+  });
+
+  it("cleans up listeners on unmount", () => {
+    const { result, unmount } = renderHook(() =>
+      usePinchZoom({ dataLength: 20 }),
+    );
+    attachRef(result);
+
+    unmount();
+
+    act(() => {
+      container.dispatchEvent(createWheelEvent(-100));
+    });
+  });
+});

--- a/frontend/src/__tests__/mocks/recharts.tsx
+++ b/frontend/src/__tests__/mocks/recharts.tsx
@@ -7,13 +7,15 @@
  *   vi.mock("recharts", () => import("../../mocks/recharts"));
  */
 
-/** Captured props from Tooltip / Legend — tests can read formatter functions from these. */
+/** Captured props from Tooltip / Legend / XAxis — tests can read formatter functions from these. */
 export const tooltipProps: Record<string, unknown> = {};
 export const legendProps: Record<string, unknown> = {};
+export const xAxisProps: Record<string, unknown> = {};
 
 export function resetCapturedProps(): void {
   for (const k of Object.keys(tooltipProps)) delete tooltipProps[k];
   for (const k of Object.keys(legendProps)) delete legendProps[k];
+  for (const k of Object.keys(xAxisProps)) delete xAxisProps[k];
 }
 
 export const Cell = ({ fill }: { fill: string }) => <div data-fill={fill} data-testid="cell" />;
@@ -39,5 +41,8 @@ export const Tooltip = (props: Record<string, unknown>) => {
   Object.assign(tooltipProps, props);
   return <div data-testid="tooltip" />;
 };
-export const XAxis = () => <div data-testid="x-axis" />;
+export const XAxis = (props: Record<string, unknown>) => {
+  Object.assign(xAxisProps, props);
+  return <div data-testid="x-axis" />;
+};
 export const YAxis = () => <div data-testid="y-axis" />;

--- a/frontend/src/components/GlobalEloEvolutionChart.tsx
+++ b/frontend/src/components/GlobalEloEvolutionChart.tsx
@@ -9,6 +9,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { usePinchZoom } from "../hooks/usePinchZoom";
 import type { EloEvolutionPlayer } from "../types/api";
 import { PLAYER_PALETTE } from "./ui/PlayerAvatar";
 
@@ -98,6 +99,11 @@ export default function GlobalEloEvolutionChart({
 
   const chartData = useMemo(() => buildChartData(data), [data]);
 
+  const { chartRef, domain, zoomLevel } = usePinchZoom({
+    dataLength: chartData.length,
+    enabled: chartData.length > 0,
+  });
+
   if (data.length === 0) return null;
 
   const visiblePlayers = data.filter((p) => !hiddenPlayers.has(p.playerId));
@@ -153,15 +159,27 @@ export default function GlobalEloEvolutionChart({
           </div>
         )}
       </div>
-      <div className="h-64 lg:h-96">
+      <div
+        className="h-64 touch-none lg:h-96"
+        data-testid="zoom-container"
+        ref={chartRef}
+      >
+        {zoomLevel > 1 && (
+          <p className="mb-1 text-center text-xs text-text-muted">
+            Zoom {zoomLevel.toFixed(1)}x — double-clic pour réinitialiser
+          </p>
+        )}
         <ResponsiveContainer height="100%" minHeight={0} minWidth={0} width="100%">
           <LineChart
             data={chartData}
             margin={{ bottom: 0, left: 0, right: 16, top: 8 }}
           >
             <XAxis
+              allowDataOverflow
               dataKey="gameIndex"
+              domain={domain}
               tick={{ fill: "var(--color-text-muted)", fontSize: 11 }}
+              type="number"
             />
             <YAxis
               domain={["dataMin - 50", "dataMax + 50"]}

--- a/frontend/src/hooks/usePinchZoom.ts
+++ b/frontend/src/hooks/usePinchZoom.ts
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UsePinchZoomOptions {
+  dataLength: number;
+  enabled?: boolean;
+}
+
+interface UsePinchZoomResult {
+  chartRef: (node: HTMLDivElement | null) => void;
+  domain: [number, number];
+  resetZoom: () => void;
+  zoomLevel: number;
+}
+
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 20;
+const WHEEL_STEP = 0.2;
+const DOUBLE_TAP_DELAY = 300;
+
+function clampCenter(center: number, dataLength: number, windowSize: number): number {
+  const half = windowSize / 2;
+  return Math.max(1 + half, Math.min(dataLength - half, center));
+}
+
+function computeDomain(
+  dataLength: number,
+  zoomLevel: number,
+  centerIndex: number,
+): [number, number] {
+  if (zoomLevel <= 1) return [1, dataLength];
+
+  const windowSize = dataLength / zoomLevel;
+  const clamped = clampCenter(centerIndex, dataLength, windowSize);
+  const min = Math.max(1, Math.round(clamped - windowSize / 2));
+  const max = Math.min(dataLength, Math.round(clamped + windowSize / 2));
+
+  return [min, max];
+}
+
+function getTouchDistance(touches: TouchList): number {
+  const dx = touches[0].clientX - touches[1].clientX;
+  const dy = touches[0].clientY - touches[1].clientY;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+export function usePinchZoom({
+  dataLength,
+  enabled = true,
+}: UsePinchZoomOptions): UsePinchZoomResult {
+  const [node, setNode] = useState<HTMLDivElement | null>(null);
+  const [zoomLevel, setZoomLevel] = useState(MIN_ZOOM);
+  const [centerIndex, setCenterIndex] = useState((dataLength + 1) / 2);
+
+  const lastTapRef = useRef(0);
+  const basePinchZoomRef = useRef(MIN_ZOOM);
+  const basePinchDistanceRef = useRef(0);
+  const zoomLevelRef = useRef(zoomLevel);
+  zoomLevelRef.current = zoomLevel;
+  const centerRef = useRef(centerIndex);
+  centerRef.current = centerIndex;
+
+  // Drag state
+  const isDraggingRef = useRef(false);
+  const hasDraggedRef = useRef(false);
+  const dragStartXRef = useRef(0);
+  const dragStartCenterRef = useRef(0);
+
+  const chartRef = useCallback((el: HTMLDivElement | null) => {
+    setNode(el);
+  }, []);
+
+  const resetZoom = useCallback(() => {
+    setZoomLevel(MIN_ZOOM);
+    setCenterIndex((dataLength + 1) / 2);
+  }, [dataLength]);
+
+  const panBy = useCallback(
+    (deltaPixels: number) => {
+      if (!node || zoomLevelRef.current <= 1) return;
+      const containerWidth = node.clientWidth;
+      if (containerWidth <= 0) return;
+      const windowSize = dataLength / zoomLevelRef.current;
+      const deltaData = (deltaPixels / containerWidth) * windowSize;
+      setCenterIndex((prev) => clampCenter(prev + deltaData, dataLength, windowSize));
+    },
+    [dataLength, node],
+  );
+
+  useEffect(() => {
+    if (!node || !enabled) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      if (e.shiftKey && zoomLevelRef.current > 1) {
+        // Shift+wheel = horizontal scroll
+        const direction = e.deltaY > 0 ? 1 : -1;
+        const windowSize = dataLength / zoomLevelRef.current;
+        const step = windowSize * 0.1;
+        setCenterIndex((prev) => clampCenter(prev + direction * step, dataLength, windowSize));
+      } else {
+        setZoomLevel((prev) => {
+          const direction = e.deltaY < 0 ? 1 : -1;
+          return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, prev + direction * WHEEL_STEP));
+        });
+      }
+    };
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (zoomLevelRef.current <= 1) return;
+      isDraggingRef.current = true;
+      hasDraggedRef.current = false;
+      dragStartXRef.current = e.clientX;
+      dragStartCenterRef.current = centerRef.current;
+      node.style.cursor = "grabbing";
+    };
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDraggingRef.current) return;
+      hasDraggedRef.current = true;
+      const deltaX = dragStartXRef.current - e.clientX;
+      const containerWidth = node.clientWidth;
+      if (containerWidth <= 0) return;
+      const windowSize = dataLength / zoomLevelRef.current;
+      const deltaData = (deltaX / containerWidth) * windowSize;
+      setCenterIndex(clampCenter(dragStartCenterRef.current + deltaData, dataLength, windowSize));
+    };
+
+    const handleMouseUp = () => {
+      if (isDraggingRef.current) {
+        isDraggingRef.current = false;
+        node.style.cursor = zoomLevelRef.current > 1 ? "grab" : "";
+      }
+    };
+
+    const handleTouchStart = (e: TouchEvent) => {
+      if (e.touches.length === 2) {
+        basePinchDistanceRef.current = getTouchDistance(e.touches);
+        basePinchZoomRef.current = zoomLevelRef.current;
+        isDraggingRef.current = false;
+      } else if (e.touches.length === 1 && zoomLevelRef.current > 1) {
+        isDraggingRef.current = true;
+        hasDraggedRef.current = false;
+        dragStartXRef.current = e.touches[0].clientX;
+        dragStartCenterRef.current = centerRef.current;
+      }
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (e.touches.length === 2 && basePinchDistanceRef.current > 0) {
+        isDraggingRef.current = false;
+        const currentDistance = getTouchDistance(e.touches);
+        const ratio = currentDistance / basePinchDistanceRef.current;
+        setZoomLevel(Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, basePinchZoomRef.current * ratio)));
+      } else if (e.touches.length === 1 && isDraggingRef.current) {
+        hasDraggedRef.current = true;
+        const deltaX = dragStartXRef.current - e.touches[0].clientX;
+        const containerWidth = node.clientWidth;
+        if (containerWidth <= 0) return;
+        const windowSize = dataLength / zoomLevelRef.current;
+        const deltaData = (deltaX / containerWidth) * windowSize;
+        setCenterIndex(clampCenter(dragStartCenterRef.current + deltaData, dataLength, windowSize));
+      }
+    };
+
+    const handleTouchEnd = () => {
+      const wasDragging = hasDraggedRef.current;
+      isDraggingRef.current = false;
+      basePinchDistanceRef.current = 0;
+      if (wasDragging) return;
+      const now = Date.now();
+      if (now - lastTapRef.current < DOUBLE_TAP_DELAY) {
+        resetZoom();
+        lastTapRef.current = 0;
+      } else {
+        lastTapRef.current = now;
+      }
+    };
+
+    const handleDblClick = () => {
+      resetZoom();
+    };
+
+    node.addEventListener("wheel", handleWheel, { passive: false });
+    node.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    node.addEventListener("touchstart", handleTouchStart);
+    node.addEventListener("touchmove", handleTouchMove);
+    node.addEventListener("touchend", handleTouchEnd);
+    node.addEventListener("dblclick", handleDblClick);
+
+    return () => {
+      node.removeEventListener("wheel", handleWheel);
+      node.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      node.removeEventListener("touchstart", handleTouchStart);
+      node.removeEventListener("touchmove", handleTouchMove);
+      node.removeEventListener("touchend", handleTouchEnd);
+      node.removeEventListener("dblclick", handleDblClick);
+    };
+  }, [dataLength, enabled, node, panBy, resetZoom]);
+
+  // Update cursor when zoom changes
+  useEffect(() => {
+    if (!node) return;
+    node.style.cursor = zoomLevel > 1 ? "grab" : "";
+  }, [node, zoomLevel]);
+
+  const domain = computeDomain(dataLength, zoomLevel, centerIndex);
+
+  return { chartRef, domain, resetZoom, zoomLevel };
+}


### PR DESCRIPTION
## Résumé

- **Hook `usePinchZoom`** : zoom (molette desktop, pinch-to-zoom mobile), scroll horizontal (Shift+molette, drag souris, swipe tactile 1 doigt), double-clic/double-tap pour réinitialiser
- **Intégration `GlobalEloEvolutionChart`** : domain XAxis dynamique, indicateur de zoom, `touch-none` pour empêcher le zoom navigateur natif
- **29 tests** : 15 tests hook (zoom in/out, clamp, pinch, pan, double-tap/click, cleanup) + 14 tests composant (XAxis domain, reset, existants)

fixes #245

## Test plan

- [ ] Vérifier zoom molette sur desktop (page Stats → graphe Elo)
- [ ] Vérifier Shift+molette pour scroll horizontal quand zoomé
- [ ] Vérifier drag souris pour scroll horizontal quand zoomé
- [ ] Vérifier double-clic pour reset du zoom
- [ ] Vérifier pinch-to-zoom sur mobile
- [ ] Vérifier swipe 1 doigt pour scroll quand zoomé sur mobile
- [ ] Vérifier double-tap pour reset sur mobile
- [ ] Vérifier que le clic simple ne déclenche plus de dezoom
- [ ] `ddev exec make test-front` — 942 tests passent
- [ ] `ddev exec make lint` — aucune erreur