### PR TITLE
fix(frontend): empêche le déclenchement multiple du shake easter egg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 - **Easter egg shake** : secouer le téléphone inverse les scores (×-1) pendant 12 secondes avant d'afficher la modale « Eh non, bien essayé 😏 » (remplace l'ancienne rotation 180°)
 
+### Fixed
+
+- **Easter egg shake** : ajout d'un cooldown de 30 secondes persistant entre les déclenchements et réinitialisation de la baseline d'accélération à la réactivation du listener pour empêcher les faux positifs
+
 ### Removed
 
 - **Easter egg gyroscope inversé** : retourner le téléphone ne déclenche plus rien (le comportement d'inversion des scores est désormais sur le shake)

--- a/frontend/src/__tests__/hooks/useShake.test.ts
+++ b/frontend/src/__tests__/hooks/useShake.test.ts
@@ -75,8 +75,8 @@ describe("useShake", () => {
 
     expect(onShake).toHaveBeenCalledOnce();
 
-    // After cooldown (5s), shake should work again
-    act(() => vi.advanceTimersByTime(5000));
+    // After cooldown (30s), shake should work again
+    act(() => vi.advanceTimersByTime(30000));
 
     act(() => {
       fireDeviceMotion(0, 0, 9.8);
@@ -107,5 +107,57 @@ describe("useShake", () => {
     // Should not register listener
     expect(addSpy).not.toHaveBeenCalledWith("devicemotion", expect.any(Function));
     addSpy.mockRestore();
+  });
+
+  it("cooldown persists across disable/re-enable cycles", () => {
+    const onShake = vi.fn();
+    const { rerender } = renderHook(
+      ({ enabled }) => useShake(onShake, { enabled }),
+      { initialProps: { enabled: true } },
+    );
+
+    // Trigger a shake
+    act(() => fireDeviceMotion(0, 0, 9.8));
+    act(() => fireDeviceMotion(30, 30, 9.8));
+    expect(onShake).toHaveBeenCalledOnce();
+
+    // Disable (simulates easter egg animation playing)
+    rerender({ enabled: false });
+
+    // Advance past the old cooldown duration
+    act(() => vi.advanceTimersByTime(10000));
+
+    // Re-enable (simulates animation finished)
+    rerender({ enabled: true });
+
+    // Shake again immediately — should NOT trigger (cooldown still active)
+    act(() => fireDeviceMotion(0, 0, 9.8));
+    act(() => fireDeviceMotion(30, 30, 9.8));
+
+    expect(onShake).toHaveBeenCalledOnce();
+  });
+
+  it("resets baseline after re-enabling to prevent stale data false trigger", () => {
+    const onShake = vi.fn();
+    const { rerender } = renderHook(
+      ({ enabled }) => useShake(onShake, { enabled }),
+      { initialProps: { enabled: true } },
+    );
+
+    // Establish baseline at (0, 0, 9.8)
+    act(() => fireDeviceMotion(0, 0, 9.8));
+
+    // Disable the hook
+    rerender({ enabled: false });
+
+    // Re-enable after cooldown expires
+    act(() => vi.advanceTimersByTime(30000));
+    rerender({ enabled: true });
+
+    // First event after re-enable: delta from stale lastRef would be huge
+    // but it should set a new baseline, not trigger
+    act(() => fireDeviceMotion(20, 20, 9.8));
+
+    expect(onShake).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/useShake.ts
+++ b/frontend/src/hooks/useShake.ts
@@ -6,12 +6,12 @@ interface UseShakeOptions {
 }
 
 const SHAKE_THRESHOLD = 25;
-const COOLDOWN_MS = 5000;
+const COOLDOWN_MS = 30_000;
 
 export function useShake(onShake: () => void, options?: UseShakeOptions) {
   const enabled = options?.enabled ?? true;
   const lastRef = useRef<{ x: number; y: number; z: number } | null>(null);
-  const cooldownRef = useRef(false);
+  const lastTriggerRef = useRef(0);
   const onShakeRef = useRef(onShake);
   onShakeRef.current = onShake;
 
@@ -29,12 +29,9 @@ export function useShake(onShake: () => void, options?: UseShakeOptions) {
       const dz = Math.abs(z - lastRef.current.z);
       const delta = dx + dy + dz;
 
-      if (delta > SHAKE_THRESHOLD && !cooldownRef.current) {
-        cooldownRef.current = true;
+      if (delta > SHAKE_THRESHOLD && Date.now() - lastTriggerRef.current >= COOLDOWN_MS) {
+        lastTriggerRef.current = Date.now();
         onShakeRef.current();
-        setTimeout(() => {
-          cooldownRef.current = false;
-        }, COOLDOWN_MS);
       }
     }
 
@@ -43,6 +40,9 @@ export function useShake(onShake: () => void, options?: UseShakeOptions) {
 
   useEffect(() => {
     if (!enabled) return;
+
+    // Reset baseline to prevent stale data from triggering a false shake
+    lastRef.current = null;
 
     window.addEventListener("devicemotion", handleMotion as EventListener);
     return () => {


### PR DESCRIPTION
## Résumé

- Cooldown basé sur un timestamp (`Date.now()`) de 30 secondes au lieu d'un `setTimeout` de 5 secondes — persiste entre les cycles disable/re-enable du listener
- Reset de `lastRef` (baseline d'accélération) à chaque réactivation du listener pour éviter les faux positifs liés aux données périmées
- 2 nouveaux tests : cooldown persistant + protection contre les données d'accélération périmées

fixes #291