### PR TITLE
fix(frontend): corrige layout bouton VS et ajoute doc aide H2H

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -384,11 +384,11 @@ L'écran principal des statistiques affiche :
 
 Appuyer sur un joueur dans le classement pour voir ses statistiques détaillées.
 
-Un bouton **« Comparer »** à côté du titre permet d'accéder à la page de comparaison face à face.
+Un bouton **« VS »** à côté du titre permet d'accéder à la page de comparaison face à face.
 
 ### Comparaison face à face
 
-Accessible via le bouton **Comparer** sur l'écran des statistiques globales, ou directement via l'URL `/stats/h2h`.
+Accessible via le bouton **VS** sur l'écran des statistiques globales, ou directement via l'URL `/stats/h2h`.
 
 Cette page permet de comparer deux joueurs sur leurs sessions communes :
 

--- a/frontend/src/pages/HeadToHead.tsx
+++ b/frontend/src/pages/HeadToHead.tsx
@@ -49,7 +49,10 @@ export default function HeadToHead() {
 
   const playerOptions = [
     { label: "Choisir…", value: "" },
-    ...players.map((p) => ({ label: p.name, value: String(p.id) })),
+    ...players
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((p) => ({ label: p.name, value: String(p.id) })),
   ];
 
   const setPlayer = (key: "p1" | "p2", value: string) => {

--- a/frontend/src/pages/Help.tsx
+++ b/frontend/src/pages/Help.tsx
@@ -343,6 +343,17 @@ export default function Help() {
         </p>
 
         <h3 className="mt-3 font-medium text-text-primary">
+          Comparaison face à face
+        </h3>
+        <p className="mt-1">
+          Appuyer sur le bouton <strong>« VS »</strong> en haut de la page
+          Statistiques pour accéder à la comparaison. Sélectionner deux
+          joueurs pour voir leurs statistiques sur les sessions communes :
+          victoires en tant que preneur, confrontations directes,
+          partenariats et scores moyens.
+        </p>
+
+        <h3 className="mt-3 font-medium text-text-primary">
           Statistiques par joueur
         </h3>
         <p className="mt-1">

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -55,17 +55,17 @@ export default function Stats() {
   return (
     <div className="flex flex-col gap-6 p-4 lg:p-8">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-bold text-text-primary">Statistiques</h1>
+        <h1 className="text-2xl font-bold text-text-primary">Statistiques</h1>
+        <div className="flex items-center gap-2">
           <button
-            className="rounded-full bg-surface-elevated px-3 py-1 text-sm font-medium text-text-secondary hover:bg-surface-tertiary"
+            className="rounded-full bg-surface-elevated px-2.5 py-1 text-xs font-medium text-text-secondary hover:bg-surface-tertiary"
             onClick={() => navigate("/stats/h2h")}
             type="button"
           >
-            Comparer
+            VS
           </button>
+          <GroupFilter onChange={setGroupId} value={groupId} />
         </div>
-        <GroupFilter onChange={setGroupId} value={groupId} />
       </div>
 
       <DateRangeFilter


### PR DESCRIPTION
## Summary
- Renomme le bouton "Comparer" en "VS" compact, placé à côté du filtre groupe pour ne plus le décaler à la ligne
- Ajoute la section "Comparaison face à face" dans la page d'aide in-app
- Trie les joueurs par ordre alphabétique dans les menus déroulants de la page H2H
- Met à jour les docs (user-guide)

fixes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)