### PR TITLE
fix(frontend): corrige le bouton dictée vocale inactif sur mobile (#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 - **Comparaison head-to-head** : nouvelle page VS (`/stats/h2h`) pour comparer deux joueurs face à face — sessions communes, victoires en tant que preneur, confrontations directes (preneur vs défenseur), partenariats, scores totaux/moyens. Accessible via le bouton « Comparer » sur la page Statistiques.
 - **Zoom graphe Elo** : zoom et scroll horizontal sur le graphe d'évolution Elo global (molette, pinch-to-zoom, drag/swipe pour naviguer), double-clic/tap pour réinitialiser
 
+### Fixed
+
+- **Dictée vocale** : le bouton « Dicter le résultat » ne réagissait pas au clic sur mobile (Android & iPhone) — la promesse de `startListening` n'était pas attendue et les erreurs étaient silencieusement ignorées. Un message d'erreur s'affiche désormais sous le bouton en cas d'échec.
+
 ### Changed
 
 - **Easter egg shake** : secouer le téléphone inverse les scores (×-1) pendant 12 secondes avant d'afficher la modale « Eh non, bien essayé 😏 » (remplace l'ancienne rotation 180°)

--- a/frontend/src/__tests__/hooks/useVoiceScoring.test.ts
+++ b/frontend/src/__tests__/hooks/useVoiceScoring.test.ts
@@ -63,16 +63,16 @@ describe("useVoiceScoring", () => {
     expect(result.current.error).toBeNull();
   });
 
-  it("appelle startListening avec fr-FR quand start() est appelé", () => {
+  it("appelle startListening avec fr-FR quand start() est appelé", async () => {
     const { result } = renderHook(() => useVoiceScoring(PLAYERS));
-    act(() => result.current.start());
+    await act(async () => result.current.start());
     expect(mockStartListening).toHaveBeenCalledWith({ language: "fr-FR" });
   });
 
-  it("start() est no-op si pas supporté", () => {
+  it("start() est no-op si pas supporté", async () => {
     mockHookReturn.browserSupportsSpeechRecognition = false;
     const { result } = renderHook(() => useVoiceScoring(PLAYERS));
-    act(() => result.current.start());
+    await act(async () => result.current.start());
     expect(mockStartListening).not.toHaveBeenCalled();
   });
 
@@ -126,5 +126,25 @@ describe("useVoiceScoring", () => {
     const { result } = renderHook(() => useVoiceScoring(PLAYERS));
     // finalTranscript is set but nothing parseable → status stays result with empty result
     expect(result.current.parsedResult).toEqual({});
+  });
+
+  it("expose l'erreur si startListening rejette", async () => {
+    mockStartListening.mockRejectedValueOnce(new Error("Microphone access denied"));
+    const { result } = renderHook(() => useVoiceScoring(PLAYERS));
+    await act(async () => result.current.start());
+    expect(result.current.error).toBe("Microphone access denied");
+    expect(result.current.status).toBe("error");
+  });
+
+  it("réinitialise l'erreur lors d'un nouveau start réussi", async () => {
+    mockStartListening.mockRejectedValueOnce(new Error("Microphone access denied"));
+    const { result } = renderHook(() => useVoiceScoring(PLAYERS));
+    await act(async () => result.current.start());
+    expect(result.current.error).toBe("Microphone access denied");
+
+    mockStartListening.mockResolvedValueOnce(undefined);
+    await act(async () => result.current.start());
+    expect(result.current.error).toBeNull();
+    expect(result.current.status).toBe("idle");
   });
 });

--- a/frontend/src/components/CompleteGameModal.tsx
+++ b/frontend/src/components/CompleteGameModal.tsx
@@ -245,7 +245,7 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
 
         {/* Saisie vocale */}
         {voice.isSupported && (
-          <div aria-live="polite" className="flex justify-center">
+          <div aria-live="polite" className="flex flex-col items-center gap-1">
             {voice.status === "listening" ? (
               <button
                 aria-label="Arrêter la dictée"
@@ -266,6 +266,9 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
                 <Mic className="size-4" />
                 Dicter le résultat
               </button>
+            )}
+            {voice.error && (
+              <p className="text-xs text-score-negative">{voice.error}</p>
             )}
           </div>
         )}

--- a/frontend/src/hooks/useVoiceScoring.ts
+++ b/frontend/src/hooks/useVoiceScoring.ts
@@ -14,6 +14,7 @@ export function useVoiceScoring(playerNames: string[]) {
     transcript,
   } = useSpeechRecognition();
 
+  const [error, setError] = useState<string | null>(null);
   const [manualReset, setManualReset] = useState(false);
 
   const parsedResult: VoiceScoreResult = useMemo(() => {
@@ -34,19 +35,24 @@ export function useVoiceScoring(playerNames: string[]) {
 
   const hasFinalResult = !manualReset && finalTranscript.length > 0;
 
-  const status: VoiceStatus = listening
-    ? "listening"
-    : hasFinalResult
-      ? "result"
-      : "idle";
+  const status: VoiceStatus = error
+    ? "error"
+    : listening
+      ? "listening"
+      : hasFinalResult
+        ? "result"
+        : "idle";
 
-  const error = null; // Errors are handled by the library gracefully
-
-  const start = useCallback(() => {
+  const start = useCallback(async () => {
     if (!browserSupportsSpeechRecognition) return;
+    setError(null);
     setManualReset(false);
     resetTranscript();
-    SpeechRecognition.startListening({ language: "fr-FR" });
+    try {
+      await SpeechRecognition.startListening({ language: "fr-FR" });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur de reconnaissance vocale");
+    }
   }, [browserSupportsSpeechRecognition, resetTranscript]);
 
   const stop = useCallback(() => {
@@ -59,6 +65,7 @@ export function useVoiceScoring(playerNames: string[]) {
   }, [resetTranscript]);
 
   const reset = useCallback(() => {
+    setError(null);
     setManualReset(true);
     resetTranscript();
   }, [resetTranscript]);


### PR DESCRIPTION
## Résumé

- Le bouton « Dicter le résultat » ne réagissait pas au clic sur mobile (Android & iPhone)
- Cause : `SpeechRecognition.startListening()` retourne une Promise qui n'était ni attendue ni catchée — les erreurs (permissions micro, API indisponible) étaient silencieusement ignorées
- `start()` est maintenant async avec try/catch, un état `error` est exposé par le hook, et le message s'affiche sous le bouton

fixes #295

## Test plan

- [x] Tests unitaires `useVoiceScoring` : erreur exposée si startListening rejette, erreur réinitialisée au prochain start réussi
- [x] Tous les 951 tests frontend passent
- [x] Lint clean (PHPStan + CS Fixer + TypeScript)