### PR TITLE
fix(frontend): rend le bouton Valider toujours visible dans la modale de complétion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Fixed
 
+- **Modale complétion** : le bouton « Valider » est désormais toujours visible sans scroll sur les petits écrans (fixé en bas de la modale, seul le contenu défile)
 - **Dictée vocale** : le bouton « Dicter le résultat » ne réagissait pas au clic sur mobile (Android & iPhone) — la promesse de `startListening` n'était pas attendue et les erreurs étaient silencieusement ignorées. Un message d'erreur s'affiche désormais sous le bouton en cas d'échec.
 
 ### Changed

--- a/frontend/src/__tests__/components/CompleteGameModal.test.tsx
+++ b/frontend/src/__tests__/components/CompleteGameModal.test.tsx
@@ -415,6 +415,18 @@ describe("CompleteGameModal", () => {
     expect(screen.getByRole("button", { name: "Seul" })).not.toHaveClass("ring-2");
   });
 
+  it("keeps validate button outside scrollable area", () => {
+    setupMock();
+    renderWithProviders(
+      <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+    );
+
+    const validateButton = screen.getByRole("button", { name: "Valider" });
+    // The button must NOT be inside the scrollable container (overflow-y-auto)
+    const scrollableContainer = validateButton.closest("[class*='overflow-y-auto']");
+    expect(scrollableContainer).toBeNull();
+  });
+
   it("does not render when open is false", () => {
     setupMock();
     renderWithProviders(

--- a/frontend/src/components/CompleteGameModal.tsx
+++ b/frontend/src/components/CompleteGameModal.tsx
@@ -224,7 +224,8 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
 
   return (
     <Modal onClose={onClose} open={open} title={title}>
-      <div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto">
+      <div className="flex max-h-[70vh] flex-col gap-4">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
         {/* Bandeau info preneur + appelé */}
         <div className="flex items-center gap-3 rounded-xl bg-surface-secondary p-3">
           <PlayerAvatar color={game.taker.color} name={game.taker.name} playerId={game.taker.id} size="md" />
@@ -432,6 +433,8 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
           </div>
         )}
 
+        </div>
+
         {/* Erreur */}
         {completeGame.isError && (
           <p className="text-center text-sm text-score-negative">
@@ -441,7 +444,7 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
 
         {/* Valider */}
         <button
-          className="w-full rounded-xl bg-accent-500 py-3 text-sm font-semibold text-white transition-colors disabled:opacity-40"
+          className="w-full shrink-0 rounded-xl bg-accent-500 py-3 text-sm font-semibold text-white transition-colors disabled:opacity-40"
           disabled={!canSubmit}
           onClick={handleSubmit}
           type="button"


### PR DESCRIPTION
## Résumé

- Déplace le bouton « Valider » et le message d'erreur hors du conteneur scrollable (`overflow-y-auto`) dans `CompleteGameModal`
- Le contenu du formulaire défile indépendamment, le bouton reste toujours visible en bas de la modale
- Ajout d'un test vérifiant que le bouton n'est pas dans la zone scrollable

fixes #298