### PR TITLE
fix(frontend): améliore la distinction visuelle du contrat sélectionné (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Fixed
 
+- **Sélection du contrat** : le contrat sélectionné dans la modale de création de donne est désormais clairement distingué (anneau plus épais, léger zoom, ombre portée, contrats non sélectionnés plus atténués)
 - **Modale complétion** : le bouton « Valider » est désormais toujours visible sans scroll sur les petits écrans (fixé en bas de la modale, seul le contenu défile)
 - **Dictée vocale** : le bouton « Dicter le résultat » ne réagissait pas au clic sur mobile (Android & iPhone) — la promesse de `startListening` n'était pas attendue et les erreurs étaient silencieusement ignorées. Un message d'erreur s'affiche désormais sous le bouton en cas d'échec.
 

--- a/frontend/src/__tests__/components/NewGameModal.test.tsx
+++ b/frontend/src/__tests__/components/NewGameModal.test.tsx
@@ -73,7 +73,7 @@ describe("NewGameModal", () => {
     expect(aliceAvatar.closest("button")).toHaveClass("ring-2");
   });
 
-  it("highlights selected contract with ring", async () => {
+  it("highlights selected contract with strong visual cues", async () => {
     const createGame = createMockCreateGame();
     renderWithProviders(
       <NewGameModal createGame={createGame} onClose={vi.fn()} open players={mockPlayers} />,
@@ -82,7 +82,21 @@ describe("NewGameModal", () => {
     const gardeButton = screen.getByRole("button", { name: "Garde" });
     await userEvent.click(gardeButton);
 
-    expect(gardeButton).toHaveClass("ring-2");
+    expect(gardeButton).toHaveClass("ring-3");
+    expect(gardeButton).toHaveClass("scale-105");
+  });
+
+  it("dims unselected contracts when one is selected", async () => {
+    const createGame = createMockCreateGame();
+    renderWithProviders(
+      <NewGameModal createGame={createGame} onClose={vi.fn()} open players={mockPlayers} />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Garde" }));
+
+    expect(screen.getByRole("button", { name: "Petite" })).toHaveClass("opacity-50");
+    expect(screen.getByRole("button", { name: "Garde Sans" })).toHaveClass("opacity-50");
+    expect(screen.getByRole("button", { name: "Garde Contre" })).toHaveClass("opacity-50");
   });
 
   it("disables validate button when no player selected", () => {
@@ -204,8 +218,9 @@ describe("NewGameModal", () => {
       const bobAvatar = screen.getByRole("img", { name: "Bob" });
       expect(bobAvatar.closest("button")).toHaveClass("ring-2");
 
-      // Garde should be selected → ring-2 on contract button
-      expect(screen.getByRole("button", { name: "Garde" })).toHaveClass("ring-2");
+      // Garde should be selected → ring-3 + scale-105 on contract button
+      expect(screen.getByRole("button", { name: "Garde" })).toHaveClass("ring-3");
+      expect(screen.getByRole("button", { name: "Garde" })).toHaveClass("scale-105");
 
       // Valider should be enabled
       expect(screen.getByRole("button", { name: "Valider" })).toBeEnabled();
@@ -226,7 +241,7 @@ describe("NewGameModal", () => {
 
       // Override contract: select Petite instead of Garde
       await userEvent.click(screen.getByRole("button", { name: "Petite" }));
-      expect(screen.getByRole("button", { name: "Petite" })).toHaveClass("ring-2");
+      expect(screen.getByRole("button", { name: "Petite" })).toHaveClass("ring-3");
     });
   });
 });

--- a/frontend/src/components/NewGameModal.tsx
+++ b/frontend/src/components/NewGameModal.tsx
@@ -106,7 +106,7 @@ export default function NewGameModal({ createGame, currentDealerName, lastGameCo
             {contracts.map(({ colorClass, label, value }) => (
               <button
                 className={`${colorClass} rounded-xl px-4 py-3 text-sm font-semibold text-white transition-all ${
-                  selectedContract === value ? "ring-2 ring-offset-2 ring-offset-surface-primary ring-white" : "opacity-80"
+                  selectedContract === value ? "ring-3 ring-offset-2 ring-offset-surface-primary ring-white scale-105 shadow-lg" : selectedContract !== null ? "opacity-50" : "opacity-80"
                 }`}
                 key={value}
                 onClick={() => setSelectedContract(value)}


### PR DESCRIPTION
## Résumé

- Anneau plus épais (`ring-3`), léger zoom (`scale-105`) et ombre portée (`shadow-lg`) sur le contrat sélectionné
- Les contrats non sélectionnés sont davantage atténués (`opacity-50` au lieu de `opacity-80`) quand un contrat est choisi
- Tests mis à jour pour valider la nouvelle distinction visuelle

fixes #296