### PR TITLE
fix(frontend): corrige les useRef sans valeur initiale (React 19)

### DIFF
--- a/frontend/src/components/DoomHint.tsx
+++ b/frontend/src/components/DoomHint.tsx
@@ -42,7 +42,7 @@ function randomTraverse(): TraverseState {
 export default function DoomHint() {
   const [traverse, setTraverse] = useState<TraverseState | null>(null);
   const { canShowHint, markHintShown } = useHintCooldown();
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
 
   const handleClick = useCallback(() => {
     if (!canShowHint() || Math.random() >= HINT_CHANCE) return;

--- a/frontend/src/components/KonamiHint.tsx
+++ b/frontend/src/components/KonamiHint.tsx
@@ -11,7 +11,7 @@ interface KonamiHintProps {
 export default function KonamiHint({ children }: KonamiHintProps) {
   const [visible, setVisible] = useState(false);
   const { canShowHint, markHintShown } = useHintCooldown();
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
 
   const handleClick = useCallback(() => {
     if (!canShowHint() || Math.random() >= HINT_CHANCE) return;


### PR DESCRIPTION
## Résumé
- Ajoute `null` comme valeur initiale aux `useRef<ReturnType<typeof setTimeout>>()` dans `DoomHint` et `KonamiHint`
- Les types React 19 exigent un argument explicite pour `useRef<T>()`

## Plan de test
- [x] `ddev exec make build` passe sans erreur TypeScript