### PR TITLE
fix(frontend): corrige les useRef sans valeur initiale (DoomHint, KonamiHint)

### DIFF
--- a/frontend/src/components/DoomHint.tsx
+++ b/frontend/src/components/DoomHint.tsx
@@ -56,7 +56,7 @@ export default function DoomHint() {
     document.addEventListener("click", handleClick);
     return () => {
       document.removeEventListener("click", handleClick);
-      clearTimeout(timerRef.current);
+      clearTimeout(timerRef.current ?? undefined);
     };
   }, [handleClick]);
 

--- a/frontend/src/components/KonamiHint.tsx
+++ b/frontend/src/components/KonamiHint.tsx
@@ -22,7 +22,7 @@ export default function KonamiHint({ children }: KonamiHintProps) {
   }, [canShowHint, markHintShown]);
 
   useEffect(() => {
-    return () => clearTimeout(timerRef.current);
+    return () => clearTimeout(timerRef.current ?? undefined);
   }, []);
 
   return (


### PR DESCRIPTION
## Résumé
- Applique le correctif `?? undefined` sur `clearTimeout(timerRef.current)` dans `DoomHint.tsx` et `KonamiHint.tsx`
- Même pattern que #305, ces deux fichiers avaient été oubliés
- Corrige le build TypeScript cassé en prod (React 19 type `useRef<T>(null)` = `T | null`)

## Plan de test
- [x] `tsc` compile sans erreur
- [x] `vite build` réussit