### PR TITLE
test(frontend): ajoute tests validation entrées et edge cases scoreCalculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 - **Indices easter eggs** : indices subtils et éphémères suggérant la présence d'easter eggs cachés — logo Konami au clic sur un avatar (5%, 2s), icône Doom traversant l'écran au clic (2%, 32px). Cooldown partagé de 10 minutes.
 - **Tests edge cases PATCH /games** : 11 tests API + 1 test unitaire couvrant les validateurs, transitions de statut, champs partiels, immutabilité et cascade.
+- **Tests frontend validation & scoreCalculator** : 36 tests couvrant les bornes de points (0, 91), combinaisons de bonus extrêmes, score max/min théorique, validation des saisies (non numérique, décimale, négative, >91, espaces), interactions bonus (poignée owner, pré-remplissage édition) et flux partenaire (self-call toggle, opacité).
 
 ### Fixed
 

--- a/docs/frontend-usage.md
+++ b/docs/frontend-usage.md
@@ -1606,7 +1606,7 @@ formatDuration(7200);  // "2h"
 
 **Fichier** : `services/scoreCalculator.ts`
 
-Miroir frontend du `ScoreCalculator` backend. Calcule les scores d'une donne en temps réel pour l'aperçu. Les points sont tronqués à l'entier (`Math.trunc`) avant le calcul, comme le backend (`(int) $points`).
+Miroir frontend du `ScoreCalculator` backend. Calcule les scores d'une donne en temps réel pour l'aperçu. Supporte les demi-points (règle FFT) : le demi-point va au camp gagnant (`Math.ceil` si attaque gagne, `Math.floor` sinon).
 
 ```ts
 import { calculateScore } from "./services/scoreCalculator";

--- a/frontend/src/__tests__/components/CompleteGameModal.test.tsx
+++ b/frontend/src/__tests__/components/CompleteGameModal.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import CompleteGameModal from "../../components/CompleteGameModal";
 import * as useCompleteGameModule from "../../hooks/useCompleteGame";
@@ -434,6 +434,305 @@ describe("CompleteGameModal", () => {
     );
 
     expect(screen.queryByText("Compléter la donne")).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------
+  // Validation des points
+  // ---------------------------------------------------------------
+
+  describe("validation des points", () => {
+    it("désactive Valider pour une saisie non numérique (\"abc\")", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.type(screen.getByPlaceholderText("Points"), "abc");
+
+      expect(screen.getByRole("button", { name: "Valider" })).toBeDisabled();
+    });
+
+    it("accepte une saisie décimale .5 (\"45.5\")", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.type(screen.getByPlaceholderText("Points"), "45.5");
+
+      expect(screen.getByRole("button", { name: "Valider" })).toBeEnabled();
+    });
+
+    it("accepte une saisie décimale avec virgule (\"45,5\")", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.type(screen.getByPlaceholderText("Points"), "45,5");
+
+      expect(screen.getByRole("button", { name: "Valider" })).toBeEnabled();
+    });
+
+    it("rejette une saisie décimale non .5 (\"45.3\")", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.type(screen.getByPlaceholderText("Points"), "45.3");
+
+      expect(screen.getByRole("button", { name: "Valider" })).toBeDisabled();
+    });
+
+    it("désactive Valider pour une saisie négative (\"-5\")", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.type(screen.getByPlaceholderText("Points"), "-5");
+
+      expect(screen.getByRole("button", { name: "Valider" })).toBeDisabled();
+    });
+
+    it("désactive Valider pour une saisie > 91", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.type(screen.getByPlaceholderText("Points"), "92");
+
+      expect(screen.getByRole("button", { name: "Valider" })).toBeDisabled();
+    });
+
+    it("accepte points = 91 (borne haute)", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.type(screen.getByPlaceholderText("Points"), "91");
+
+      expect(screen.getByRole("button", { name: "Valider" })).toBeEnabled();
+    });
+
+    it("accepte points = 0 (borne basse) et calcule le score", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.type(screen.getByPlaceholderText("Points"), "0");
+
+      expect(screen.getByRole("button", { name: "Valider" })).toBeEnabled();
+      await waitFor(() => {
+        expect(screen.getByText(/Contrat chuté/)).toBeInTheDocument();
+      });
+    });
+
+    it("traite les espaces autour du nombre (\" 45 \") comme valide", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.type(screen.getByPlaceholderText("Points"), " 45 ");
+
+      // Number(" 45 ") === 45, which is valid
+      expect(screen.getByRole("button", { name: "Valider" })).toBeEnabled();
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Interactions bonus
+  // ---------------------------------------------------------------
+
+  describe("interactions bonus", () => {
+    it("affiche le sélecteur propriétaire poignée quand une poignée est sélectionnée", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: /Bonus/i }));
+      await userEvent.click(screen.getByRole("button", { name: "Simple" }));
+
+      expect(screen.getByText("Poignée montrée par")).toBeInTheDocument();
+    });
+
+    it("masque le sélecteur propriétaire quand poignée revient à Aucune", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: /Bonus/i }));
+      await userEvent.click(screen.getByRole("button", { name: "Simple" }));
+      expect(screen.getByText("Poignée montrée par")).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("button", { name: "Aucune" }));
+      expect(screen.queryByText("Poignée montrée par")).not.toBeInTheDocument();
+    });
+
+    it("pré-remplit tous les champs bonus en mode édition", () => {
+      setupMock();
+      const gameWithBonuses: Game = {
+        ...completedGame,
+        chelem: "announced_won",
+        petitAuBout: "attack",
+        poignee: "double",
+        poigneeOwner: "defense",
+      };
+      renderWithProviders(
+        <CompleteGameModal game={gameWithBonuses} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      // Bonus section should be auto-expanded
+      expect(screen.getByText("Poignée montrée par")).toBeInTheDocument();
+
+      // Poignée Double should be selected
+      const poigneeSection = screen.getByText("Poignée").closest("div")!;
+      expect(within(poigneeSection).getByRole("button", { name: "Double" })).toHaveClass("bg-accent-500");
+
+      // Petit au bout Attaque should be selected
+      const petitSection = screen.getByText("Petit au bout").closest("div")!;
+      expect(within(petitSection).getByRole("button", { name: "Attaque" })).toHaveClass("bg-accent-500");
+
+      // Chelem "Annoncé gagné" should be selected
+      expect(screen.getByRole("button", { name: "Annoncé gagné" })).toHaveClass("bg-accent-500");
+
+      // Défense should be selected for poignée owner
+      const ownerSection = screen.getByText("Poignée montrée par").closest("div")!;
+      expect(within(ownerSection).getByRole("button", { name: "Défense" })).toHaveClass("bg-accent-500");
+    });
+
+    it("auto-déplie les bonus en mode édition quand un bonus est défini", () => {
+      setupMock();
+      const gameWithPetitAuBout: Game = {
+        ...completedGame,
+        petitAuBout: "attack",
+      };
+      renderWithProviders(
+        <CompleteGameModal game={gameWithPetitAuBout} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      // Bonus section auto-expanded because petitAuBout is set
+      expect(screen.getByText("Petit au bout")).toBeInTheDocument();
+    });
+
+    it("ne déplie pas les bonus en mode édition quand aucun bonus", () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={completedGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      // completedGame has all bonuses set to "none"
+      expect(screen.queryByText("Petit au bout")).not.toBeInTheDocument();
+    });
+
+    it("réinitialise poigneeOwner à none quand poignée passe à Aucune", async () => {
+      const { mutate } = setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      // Set up valid form
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.type(screen.getByPlaceholderText("Points"), "45");
+
+      // Open bonus, select poignée simple then owner attaque
+      await userEvent.click(screen.getByRole("button", { name: /Bonus/i }));
+      await userEvent.click(screen.getByRole("button", { name: "Simple" }));
+      const ownerSection = screen.getByText("Poignée montrée par").closest("div")!;
+      await userEvent.click(within(ownerSection).getByRole("button", { name: "Attaque" }));
+
+      // Switch poignée back to Aucune
+      const poigneeSection = screen.getByText("Poignée").closest("div")!;
+      await userEvent.click(within(poigneeSection).getByRole("button", { name: "Aucune" }));
+
+      // Submit and verify poigneeOwner is "none"
+      await userEvent.click(screen.getByRole("button", { name: "Valider" }));
+
+      expect(mutate).toHaveBeenCalledWith(
+        expect.objectContaining({ poignee: "none", poigneeOwner: "none" }),
+        expect.anything(),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Flux partenaire
+  // ---------------------------------------------------------------
+
+  describe("flux partenaire", () => {
+    it("sélectionner partenaire puis cliquer Seul → partnerId = null", async () => {
+      const { mutate } = setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      // Select Bob as partner
+      await userEvent.click(screen.getByRole("img", { name: "Bob" }).closest("button")!);
+      // Then switch to self-call
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+
+      // Enter points and submit
+      await userEvent.type(screen.getByPlaceholderText("Points"), "45");
+      await userEvent.click(screen.getByRole("button", { name: "Valider" }));
+
+      expect(mutate).toHaveBeenCalledWith(
+        expect.objectContaining({ partnerId: null }),
+        expect.anything(),
+      );
+    });
+
+    it("cliquer Seul puis sélectionner partenaire → selfCall = false", async () => {
+      const { mutate } = setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      // Self-call first
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      // Then select Bob
+      await userEvent.click(screen.getByRole("img", { name: "Bob" }).closest("button")!);
+
+      // Seul should no longer be active
+      expect(screen.getByRole("button", { name: "Seul" })).not.toHaveClass("ring-2");
+
+      // Enter points and submit
+      await userEvent.type(screen.getByPlaceholderText("Points"), "45");
+      await userEvent.click(screen.getByRole("button", { name: "Valider" }));
+
+      expect(mutate).toHaveBeenCalledWith(
+        expect.objectContaining({ partnerId: 2 }),
+        expect.anything(),
+      );
+    });
+
+    it("boutons partenaire ont une opacité réduite quand selfCall est actif", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+
+      // Partner avatar buttons should have opacity-40 class
+      const bobButton = screen.getByRole("img", { name: "Bob" }).closest("button")!;
+      expect(bobButton).toHaveClass("opacity-40");
+    });
   });
 
   // Voice scoring integration tests

--- a/frontend/src/__tests__/services/scoreCalculator.test.ts
+++ b/frontend/src/__tests__/services/scoreCalculator.test.ts
@@ -262,6 +262,110 @@ describe("calculateScore", () => {
   });
 
   // ---------------------------------------------------------------
+  // Points aux bornes
+  // ---------------------------------------------------------------
+
+  it("calcule correctement avec 0 pts (borne basse)", () => {
+    // Petite, 0 oudlers, 0 pts → requis=56, base=-(56-0+25)×1=-81
+    const result = calculateScore(makeInput({ oudlers: 0, points: 0 }));
+
+    expect(result.attackWins).toBe(false);
+    expect(result.baseScore).toBe(-81);
+  });
+
+  it("calcule correctement avec 91 pts (borne haute)", () => {
+    // Petite, 0 oudlers, 91 pts → requis=56, base=(91-56+25)×1=60
+    const result = calculateScore(makeInput({ oudlers: 0, points: 91 }));
+
+    expect(result.attackWins).toBe(true);
+    expect(result.baseScore).toBe(60);
+  });
+
+  // ---------------------------------------------------------------
+  // Tous les bonus combinés
+  // ---------------------------------------------------------------
+
+  it("combine triple poignée + petit au bout + chelem annoncé gagné (attaque gagne)", () => {
+    // GardeContre, 3 oudlers, 91 pts, triple poignée, petit au bout attaque, chelem annoncé gagné
+    // base=(91-36+25)×6=480, poignée=+40, petit=+10×6=+60, chelem=+400
+    // total=480+40+60+400=980
+    const result = calculateScore(makeInput({
+      chelem: Chelem.AnnouncedWon,
+      contract: Contract.GardeContre,
+      oudlers: 3,
+      petitAuBout: Side.Attack,
+      poignee: "triple",
+      points: 91,
+    }));
+
+    expect(result.attackWins).toBe(true);
+    expect(result.baseScore).toBe(480);
+    expect(result.poigneeBonus).toBe(40);
+    expect(result.petitAuBoutBonus).toBe(60);
+    expect(result.chelemBonus).toBe(400);
+    expect(result.totalPerPlayer).toBe(980);
+  });
+
+  it("combine triple poignée + petit au bout défense + chelem annoncé perdu (attaque perd)", () => {
+    // GardeContre, 0 oudlers, 0 pts, triple poignée, petit au bout défense, chelem annoncé perdu
+    // base=-(56-0+25)×6=-486, poignée=-40, petit=-10×6=-60, chelem=-200
+    // total=-486-40-60-200=-786
+    const result = calculateScore(makeInput({
+      chelem: Chelem.AnnouncedLost,
+      contract: Contract.GardeContre,
+      oudlers: 0,
+      petitAuBout: Side.Defense,
+      poignee: "triple",
+      points: 0,
+    }));
+
+    expect(result.attackWins).toBe(false);
+    expect(result.baseScore).toBe(-486);
+    expect(result.poigneeBonus).toBe(-40);
+    expect(result.petitAuBoutBonus).toBe(-60);
+    expect(result.chelemBonus).toBe(-200);
+    expect(result.totalPerPlayer).toBe(-786);
+  });
+
+  // ---------------------------------------------------------------
+  // Score maximum et minimum théoriques
+  // ---------------------------------------------------------------
+
+  it("calcule le score maximum théorique (garde contre, 91 pts, 3 oudlers, tous bonus positifs)", () => {
+    // GardeContre, 3 oudlers, 91 pts, triple poignée, petit au bout attaque, chelem annoncé gagné
+    // base=(91-36+25)×6=480, poignée=+40, petit=+60, chelem=+400
+    // total=980, preneur=980×2=1960
+    const result = calculateScore(makeInput({
+      chelem: Chelem.AnnouncedWon,
+      contract: Contract.GardeContre,
+      oudlers: 3,
+      petitAuBout: Side.Attack,
+      poignee: "triple",
+      points: 91,
+    }));
+
+    expect(result.totalPerPlayer).toBe(980);
+    expect(result.takerScore).toBe(1960);
+  });
+
+  it("calcule le score minimum théorique (garde contre, 0 pts, 0 oudlers, tous bonus négatifs)", () => {
+    // GardeContre, 0 oudlers, 0 pts, triple poignée, petit au bout attaque (perd), chelem annoncé perdu
+    // base=-(56-0+25)×6=-486, poignée=-40, petit=-10×6=-60, chelem=-200
+    // total=-786, preneur=-786×2=-1572
+    const result = calculateScore(makeInput({
+      chelem: Chelem.AnnouncedLost,
+      contract: Contract.GardeContre,
+      oudlers: 0,
+      petitAuBout: Side.Attack,
+      poignee: "triple",
+      points: 0,
+    }));
+
+    expect(result.totalPerPlayer).toBe(-786);
+    expect(result.takerScore).toBe(-1572);
+  });
+
+  // ---------------------------------------------------------------
   // Distribution : avec partenaire
   // ---------------------------------------------------------------
 
@@ -294,6 +398,34 @@ describe("calculateScore", () => {
       petitAuBout: Side.Attack,
       poignee: "triple",
       points: 60,
+    }) },
+    { desc: "self-call + tous les bonus positifs", input: makeInput({
+      chelem: Chelem.AnnouncedWon,
+      contract: Contract.GardeContre,
+      oudlers: 3,
+      partnerId: null,
+      petitAuBout: Side.Attack,
+      poignee: "triple",
+      points: 91,
+    }) },
+    { desc: "self-call + tous les bonus négatifs", input: makeInput({
+      chelem: Chelem.AnnouncedLost,
+      contract: Contract.GardeContre,
+      oudlers: 0,
+      partnerId: null,
+      petitAuBout: Side.Attack,
+      poignee: "triple",
+      points: 0,
+    }) },
+    { desc: "borne basse 0 pts", input: makeInput({ oudlers: 0, points: 0 }) },
+    { desc: "borne haute 91 pts", input: makeInput({ oudlers: 0, points: 91 }) },
+    { desc: "garde contre + chelem non annoncé gagné + poignée double", input: makeInput({
+      chelem: Chelem.NotAnnouncedWon,
+      contract: Contract.GardeContre,
+      oudlers: 3,
+      petitAuBout: Side.Defense,
+      poignee: "double",
+      points: 91,
     }) },
   ])("somme des scores = 0 pour $desc", ({ input }) => {
     const result = calculateScore(input);


### PR DESCRIPTION
## Résumé

- **12 tests scoreCalculator** : bornes 0/91, combinaison triple poignée + petit au bout + chelem, score max/min théorique, invariant somme=0 étendu (self-call + tous bonus)
- **24 tests CompleteGameModal** : validation points (non numérique, décimale .5, virgule, négative, >91, espaces, 0), interactions bonus (poignée owner apparaît/disparaît, pré-remplissage complet en mode édition, auto-dépliage), flux partenaire (toggle self-call → partnerId null, self-call → partenaire, opacité boutons)
- **Correction doc** : `frontend-usage.md` mettait `Math.trunc`, corrigé en demi-points FFT (`Math.ceil`/`Math.floor`)

fixes #36

## Plan de test

- [x] `make test` — 1002 tests passent (94 fichiers)
- [x] `make lint` — PHPStan, CS Fixer, TypeScript OK