### PR TITLE
fix(stats): rend le bouton VS plus visible

### DIFF
--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -58,7 +58,7 @@ export default function Stats() {
         <h1 className="text-2xl font-bold text-text-primary">Statistiques</h1>
         <div className="flex items-center gap-2">
           <button
-            className="rounded-full bg-surface-elevated px-2.5 py-1 text-xs font-medium text-text-secondary hover:bg-surface-tertiary"
+            className="rounded-full bg-accent-500 px-3 py-1 text-sm font-black text-white shadow hover:bg-accent-600"
             onClick={() => navigate("/stats/h2h")}
             type="button"
           >


### PR DESCRIPTION
## Résumé
- Remplace le style discret du bouton VS (`bg-surface-elevated text-xs text-text-secondary`) par un style accentué (`bg-accent-500 font-black text-white shadow`) cohérent avec le badge VS de la page H2H

## Plan de test
- [ ] Vérifier que le bouton VS est bien visible sur la page Statistiques
- [ ] Vérifier le hover (`bg-accent-600`)