### PR TITLE
fix(ui): corrige le scroll des dropdowns Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Fixed
 
+- **Dropdown joueurs page VS** : corrige l'impossibilité de scroller dans les dropdowns de sélection de joueurs quand la liste est longue.
 - **Validation complétion** : retourne 422 au lieu de 500 quand on tente de compléter une donne sans oudlers ou sans points.
 - **Partner = preneur** : rejette le PATCH quand le partenaire est le preneur lui-même (auto-appel doit utiliser `partner: null`).
 

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -43,7 +43,7 @@ export default function Select<T extends string = string>({
         </ListboxButton>
 
         <ListboxOptions
-          className={`absolute z-50 mt-1 overflow-hidden rounded-xl border border-surface-border bg-surface-elevated py-1 shadow-lg transition duration-200 ease-out data-closed:scale-95 data-closed:opacity-0 ${
+          className={`absolute z-50 mt-1 max-h-60 overflow-y-auto rounded-xl border border-surface-border bg-surface-elevated py-1 shadow-lg transition duration-200 ease-out data-closed:scale-95 data-closed:opacity-0 ${
             isCompact ? "right-0 min-w-44" : "left-0 right-0"
           }`}
           transition


### PR DESCRIPTION
## Résumé

- Ajoute `max-h-60 overflow-y-auto` sur le `ListboxOptions` du composant `Select` pour permettre le défilement quand la liste d'options est longue (page VS notamment)

fixes #317