### PR TITLE
chore(ci): ajoute le workflow CI et corrige le chemin patterns.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,122 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-backend:
+    name: Lint Backend (PHPStan + CS Fixer)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: ctype, iconv, intl
+          tools: composer:v2
+
+      - name: Install Composer dependencies
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Warm up Symfony cache (PHPStan needs container XML)
+        working-directory: backend
+        run: php bin/console cache:warmup --env=dev
+
+      - name: Run PHPStan
+        working-directory: backend
+        run: vendor/bin/phpstan analyse --no-progress
+
+      - name: Run PHP-CS-Fixer (dry-run)
+        working-directory: backend
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff
+
+  lint-frontend:
+    name: Lint Frontend (TypeScript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install npm dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run TypeScript type check
+        working-directory: frontend
+        run: npx tsc --noEmit
+
+  test-backend:
+    name: Test Backend (PHPUnit)
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_DATABASE: db_test
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_USER: app
+          MARIADB_PASSWORD: app
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      DATABASE_URL: mysql://app:app@127.0.0.1:3306/db?serverVersion=10.11.0-MariaDB&charset=utf8mb4
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: ctype, iconv, intl
+          tools: composer:v2
+
+      - name: Install Composer dependencies
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run database migrations
+        working-directory: backend
+        run: php bin/console doctrine:migrations:migrate --no-interaction --env=test
+
+      - name: Run PHPUnit
+        working-directory: backend
+        run: vendor/bin/phpunit
+
+  test-frontend:
+    name: Test Frontend (Vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install npm dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run Vitest
+        working-directory: frontend
+        run: npx vitest run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,13 @@ tarot/
 └── CHANGELOG.md
 ```
 
-> File map (entities, hooks, components, routes, API endpoints): `memory/patterns.md`
+> File map (entities, hooks, components, routes, API endpoints): `.claude/memory/patterns.md`
 
 ## Approach
 
 - Edit files when asked.
-- **No codebase exploration.** CLAUDE.md, MEMORY.md, `memory/patterns.md` have all context. Only read files you're about to edit.
-- **Keep `memory/patterns.md` up to date** when adding entities, hooks, components, pages, routes.
+- **No codebase exploration.** CLAUDE.md, MEMORY.md, `.claude/memory/patterns.md` have all context. Only read files you're about to edit.
+- **Keep `.claude/memory/patterns.md` up to date** when adding entities, hooks, components, pages, routes.
 
 ## Plans
 


### PR DESCRIPTION
## Summary
- Ajoute `.github/workflows/ci.yml` : lint backend (PHPStan + CS Fixer), lint frontend (TypeScript), test backend (PHPUnit + MariaDB), test frontend (Vitest)
- Corrige les 3 références `memory/patterns.md` → `.claude/memory/patterns.md` dans CLAUDE.md

## Test plan
- [ ] Vérifier que le workflow CI s'exécute sur une PR
- [x] Vérifier que les chemins CLAUDE.md pointent vers le bon fichier