### PR TITLE
fix(ui): corrige le décalage de la navbar au scroll vers le haut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Fixed
 
+- **Navbar** : corrige le décalage de la barre de navigation au scroll vers le haut sur mobile (`min-h-dvh` remplace `min-h-screen`).
 - **Badges** : les badges ne se déclenchent plus rétroactivement sur des donnes antérieures à leur date d'introduction (`availableSince`).
 - **Sécurité** : corrige la vulnérabilité RCE serialize-javascript via override npm (GHSA-5c6j-r48x-rmvq).
 

--- a/frontend/src/__tests__/components/Layout.test.tsx
+++ b/frontend/src/__tests__/components/Layout.test.tsx
@@ -16,6 +16,14 @@ describe("Layout", () => {
     expect(wrapper?.className).toMatch(/bg-surface-secondary/);
   });
 
+  it("uses dynamic viewport height instead of 100vh to prevent mobile scroll shift", () => {
+    const { container } = renderWithProviders(<Layout />);
+
+    const wrapper = container.querySelector("div");
+    expect(wrapper?.className).toMatch(/min-h-dvh/);
+    expect(wrapper?.className).not.toMatch(/min-h-screen/);
+  });
+
   it("does not render a help icon link", () => {
     renderWithProviders(<Layout />);
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import BottomNav from "./BottomNav";
 
 export default function Layout() {
   return (
-    <div className="min-h-screen bg-surface-secondary pb-16 text-text-primary lg:pb-20">
+    <div className="min-h-dvh bg-surface-secondary pb-16 text-text-primary lg:pb-20">
       <main className="animate-fade-in lg:mx-auto lg:max-w-4xl">
         <Outlet />
       </main>


### PR DESCRIPTION
## Résumé

- Remplace `min-h-screen` (`100vh`) par `min-h-dvh` (`100dvh`) dans le Layout pour que la hauteur s'adapte dynamiquement à la barre d'adresse mobile
- Ajoute un test de régression vérifiant l'utilisation de `min-h-dvh`

fixes #324