### PR TITLE
feat(scores): permet de saisir les points défense ou attaque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ### Added
 
+- **Points attaque / défense** : choix du côté (attaque ou défense) lors de la saisie des points, avec conversion automatique. Compatible avec la saisie vocale.
 - **Rafraîchissement automatique** : la page session se met à jour automatiquement toutes les 5 secondes lorsqu'un autre joueur saisit une donne, sans rechargement manuel.
 - **Nouvelle donne** : possibilité de compléter une donne directement depuis la modal de création via un accordéon « Résultat (optionnel) », évitant le passage par deux modales séparées.
 

--- a/frontend/src/__tests__/components/CompleteGameModal.test.tsx
+++ b/frontend/src/__tests__/components/CompleteGameModal.test.tsx
@@ -824,6 +824,21 @@ describe("CompleteGameModal", () => {
       expect(screen.getByRole("button", { name: "Seul" })).toHaveClass("ring-2");
     });
 
+    it("pré-remplit le côté défense depuis le résultat vocal", () => {
+      setupMock();
+      setupVoiceMock({
+        isSupported: true,
+        parsedResult: { playerName: "Bob", pointsSide: "defense", points: 46 },
+        status: "result",
+      });
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      expect(screen.getByPlaceholderText("Points")).toHaveValue("46");
+      expect(screen.getByRole("button", { name: "Déf." })).toHaveClass("bg-accent-500");
+    });
+
     it("ne masque pas le bouton micro en mode édition", () => {
       setupMock();
       setupVoiceMock({ isSupported: true });
@@ -883,6 +898,108 @@ describe("CompleteGameModal", () => {
       );
 
       expect(screen.getByPlaceholderText("Points")).toHaveValue("72");
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Choix côté points (attaque / défense)
+  // ---------------------------------------------------------------
+
+  describe("choix côté points", () => {
+    it("affiche les boutons Attaque / Défense près du champ Points", () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      expect(screen.getByRole("button", { name: "Att." })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Déf." })).toBeInTheDocument();
+    });
+
+    it("sélectionne Attaque par défaut", () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      expect(screen.getByRole("button", { name: "Att." })).toHaveClass("bg-accent-500");
+      expect(screen.getByRole("button", { name: "Déf." })).not.toHaveClass("bg-accent-500");
+    });
+
+    it("convertit les points défense en points attaque à la soumission (91 - pts)", async () => {
+      const { mutate } = setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.click(screen.getByRole("button", { name: "Déf." }));
+      await userEvent.type(screen.getByPlaceholderText("Points"), "46");
+      await userEvent.click(screen.getByRole("button", { name: "Valider" }));
+
+      // 91 - 46 = 45 attack points
+      expect(mutate).toHaveBeenCalledWith(
+        expect.objectContaining({ points: 45 }),
+        expect.anything(),
+      );
+    });
+
+    it("affiche l'aperçu des scores avec les points convertis en mode défense", async () => {
+      setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      // 3 oudlers → requis 36
+      await userEvent.click(screen.getByRole("button", { name: "Augmenter" }));
+      await userEvent.click(screen.getByRole("button", { name: "Augmenter" }));
+      await userEvent.click(screen.getByRole("button", { name: "Augmenter" }));
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.click(screen.getByRole("button", { name: "Déf." }));
+      // 46 defense points → 45 attack points → 45 >= 36 → rempli
+      await userEvent.type(screen.getByPlaceholderText("Points"), "46");
+
+      await waitFor(() => {
+        expect(screen.getByText(/Contrat rempli/)).toBeInTheDocument();
+      });
+    });
+
+    it("soumet les points attaque directement sans conversion", async () => {
+      const { mutate } = setupMock();
+      renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      // Attaque est déjà sélectionné par défaut
+      await userEvent.type(screen.getByPlaceholderText("Points"), "45");
+      await userEvent.click(screen.getByRole("button", { name: "Valider" }));
+
+      expect(mutate).toHaveBeenCalledWith(
+        expect.objectContaining({ points: 45 }),
+        expect.anything(),
+      );
+    });
+
+    it("réinitialise le côté à Attaque à la réouverture", async () => {
+      setupMock();
+      const { rerender } = renderWithProviders(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Déf." }));
+      expect(screen.getByRole("button", { name: "Déf." })).toHaveClass("bg-accent-500");
+
+      // Close and reopen
+      rerender(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open={false} players={mockPlayers} sessionId={1} />,
+      );
+      rerender(
+        <CompleteGameModal game={inProgressGame} onClose={vi.fn()} open players={mockPlayers} sessionId={1} />,
+      );
+
+      expect(screen.getByRole("button", { name: "Att." })).toHaveClass("bg-accent-500");
+      expect(screen.getByRole("button", { name: "Déf." })).not.toHaveClass("bg-accent-500");
     });
   });
 

--- a/frontend/src/__tests__/components/NewGameModal.test.tsx
+++ b/frontend/src/__tests__/components/NewGameModal.test.tsx
@@ -585,6 +585,42 @@ describe("NewGameModal", () => {
       });
     });
 
+    it("affiche les boutons Att. / Déf. dans l'accordéon de complétion", async () => {
+      renderModal();
+
+      await userEvent.click(screen.getByRole("button", { name: /résultat/i }));
+
+      expect(screen.getByRole("button", { name: "Att." })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Déf." })).toBeInTheDocument();
+    });
+
+    it("convertit les points défense en points attaque au PATCH (91 - pts)", async () => {
+      mockApiFetch.mockResolvedValueOnce(mockCompletedGame);
+      const mutate = vi.fn((_data: unknown, opts: { onSuccess?: (data: Game) => void }) => {
+        opts.onSuccess?.(mockCreatedGame);
+      });
+      const onClose = vi.fn();
+      renderModal({ mutate: mutate as ReturnType<typeof useCreateGame>["mutate"], onClose });
+
+      await userEvent.click(screen.getByRole("img", { name: "Alice" }).closest("button")!);
+      await userEvent.click(screen.getByRole("button", { name: "Garde" }));
+      await userEvent.click(screen.getByRole("button", { name: /résultat/i }));
+      await userEvent.click(screen.getByRole("button", { name: "Seul" }));
+      await userEvent.click(screen.getByRole("button", { name: "Déf." }));
+      await userEvent.type(screen.getByPlaceholderText("Points"), "40");
+      await userEvent.click(screen.getByRole("button", { name: "Valider" }));
+
+      // 91 - 40 = 51 attack points sent to API
+      await waitFor(() => {
+        expect(mockApiFetch).toHaveBeenCalledWith(
+          "/games/42",
+          expect.objectContaining({
+            body: expect.stringContaining('"points":51'),
+          }),
+        );
+      });
+    });
+
     it("les champs de complétion se réinitialisent à la réouverture", async () => {
       const createGame = createMockCreateGame();
       const { rerender } = renderWithProviders(

--- a/frontend/src/__tests__/services/voiceScoreParser.test.ts
+++ b/frontend/src/__tests__/services/voiceScoreParser.test.ts
@@ -5,6 +5,7 @@ import {
   extractOudlers,
   extractPlayerReference,
   extractPoints,
+  extractPointsSide,
   frenchWordToNumber,
   normalizeTranscript,
   parseVoiceScore,
@@ -410,6 +411,28 @@ describe("extractBonuses", () => {
   });
 });
 
+describe("extractPointsSide", () => {
+  it("retourne 'defense' pour 'defense 45 points'", () => {
+    expect(extractPointsSide("defense 45 points")).toBe("defense");
+  });
+
+  it("retourne 'defense' pour '45 points defense'", () => {
+    expect(extractPointsSide("45 points defense")).toBe("defense");
+  });
+
+  it("retourne 'attack' pour 'attaque 45 points'", () => {
+    expect(extractPointsSide("attaque 45 points")).toBe("attack");
+  });
+
+  it("retourne 'attack' pour '45 points attaque'", () => {
+    expect(extractPointsSide("45 points attaque")).toBe("attack");
+  });
+
+  it("retourne null quand pas de côté mentionné", () => {
+    expect(extractPointsSide("garde 45 points")).toBeNull();
+  });
+});
+
 describe("parseVoiceScore", () => {
   const players = ["Pierre", "Jean", "Marie", "Paul"];
 
@@ -529,5 +552,22 @@ describe("parseVoiceScore", () => {
     const result = parseVoiceScore("garde 56 points zéro bout appelé Pierre", players);
     expect(result.points).toBe(56);
     expect(result.oudlers).toBe(0);
+  });
+
+  it("parse 'défense 46 points' avec pointsSide", () => {
+    const result = parseVoiceScore("garde défense 46 points appelé Pierre", players);
+    expect(result.points).toBe(46);
+    expect(result.pointsSide).toBe("defense");
+  });
+
+  it("parse '45 points attaque' avec pointsSide", () => {
+    const result = parseVoiceScore("garde 45 points attaque appelé Pierre", players);
+    expect(result.points).toBe(45);
+    expect(result.pointsSide).toBe("attack");
+  });
+
+  it("n'inclut pas pointsSide quand pas de côté mentionné", () => {
+    const result = parseVoiceScore("garde 56 points appelé Pierre", players);
+    expect(result.pointsSide).toBeUndefined();
   });
 });

--- a/frontend/src/components/CompleteGameModal.tsx
+++ b/frontend/src/components/CompleteGameModal.tsx
@@ -59,6 +59,7 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
   const [poignee, setPoignee] = useState<PoigneeType>(Poignee.None);
   const [poigneeOwner, setPoigneeOwner] = useState<SideType>(Side.None);
   const [points, setPoints] = useState("");
+  const [pointsSide, setPointsSide] = useState<"attack" | "defense">("attack");
   const [selfCall, setSelfCall] = useState(false);
 
   const voiceApplied = useRef(false);
@@ -76,6 +77,7 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
       setPoignee(game.poignee);
       setPoigneeOwner(game.poigneeOwner);
       setPoints(game.points !== null ? String(game.points) : "");
+      setPointsSide("attack");
       setSelfCall(game.partner === null);
     } else {
       setBonusesOpen(false);
@@ -86,6 +88,7 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
       setPoignee(Poignee.None);
       setPoigneeOwner(Side.None);
       setPoints("");
+      setPointsSide("attack");
       setSelfCall(false);
     }
   });
@@ -143,6 +146,9 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
       setChelem(result.chelem);
       setBonusesOpen(true);
     }
+    if (result.pointsSide) {
+      setPointsSide(result.pointsSide);
+    }
 
     setVoiceHighlight(filled);
     const timer = setTimeout(() => setVoiceHighlight(new Set()), 3000);
@@ -151,11 +157,12 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
 
   const pointsNum = points === "" ? null : Number(points.replace(",", "."));
   const pointsValid = pointsNum !== null && !isNaN(pointsNum) && pointsNum >= 0 && pointsNum <= 91 && (pointsNum % 1 === 0 || pointsNum % 1 === 0.5);
+  const attackPoints = pointsValid && pointsNum !== null ? (pointsSide === "defense" ? 91 - pointsNum : pointsNum) : null;
   const hasPartner = selfCall || partnerId !== null;
   const canSubmit = pointsValid && hasPartner && !completeGame.isPending;
 
   const scoreResult = useMemo(() => {
-    if (!pointsValid) return null;
+    if (!pointsValid || attackPoints === null) return null;
     return calculateScore({
       chelem,
       contract: game.contract,
@@ -163,9 +170,9 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
       partnerId: selfCall ? null : partnerId,
       petitAuBout,
       poignee,
-      points: pointsNum!,
+      points: attackPoints,
     });
-  }, [chelem, game.contract, oudlers, partnerId, petitAuBout, poignee, pointsNum, pointsValid, selfCall]);
+  }, [attackPoints, chelem, game.contract, oudlers, partnerId, petitAuBout, poignee, pointsValid, selfCall]);
 
   const otherPlayers = players.filter((p) => p.id !== game.taker.id);
   const selectedPartner = partnerId !== null ? players.find((p) => p.id === partnerId) ?? null : null;
@@ -190,7 +197,7 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
         petitAuBout,
         poignee,
         poigneeOwner: poignee !== Poignee.None ? poigneeOwner : Side.None,
-        points: pointsNum!,
+        points: attackPoints!,
         status: GameStatus.Completed,
       },
       {
@@ -205,7 +212,7 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
               isSelfCall: selfCall,
               oudlers,
               petitAuBout,
-              points: pointsNum!,
+              points: attackPoints!,
               previousScore: null,
               takerScore: scoreResult.takerScore,
             });
@@ -311,9 +318,13 @@ export default function CompleteGameModal({ game, onBadgesUnlocked, onClose, onG
         </div>
 
         {/* Points */}
-        <div>
+        <div className="flex gap-2">
+          <div className="flex flex-col gap-1">
+            <ToggleButton label="Att." onClick={() => setPointsSide("attack")} selected={pointsSide === "attack"} />
+            <ToggleButton label="Déf." onClick={() => setPointsSide("defense")} selected={pointsSide === "defense"} />
+          </div>
           <input
-            className={`w-full rounded-xl border border-surface-border bg-surface-primary px-4 py-3 text-center text-lg font-semibold tabular-nums text-text-primary placeholder:text-text-muted focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 ${voiceHighlight.has("points") ? "ring-2 ring-green-500" : ""}`}
+            className={`min-w-0 flex-1 rounded-xl border border-surface-border bg-surface-primary px-4 py-3 text-center text-lg font-semibold tabular-nums text-text-primary placeholder:text-text-muted focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 ${voiceHighlight.has("points") ? "ring-2 ring-green-500" : ""}`}
             inputMode="decimal"
             onChange={(e) => setPoints(e.target.value)}
             placeholder="Points"

--- a/frontend/src/components/NewGameModal.tsx
+++ b/frontend/src/components/NewGameModal.tsx
@@ -68,6 +68,7 @@ export default function NewGameModal({ createGame, currentDealerName, lastGameCo
   const [poignee, setPoignee] = useState<PoigneeType>(Poignee.None);
   const [poigneeOwner, setPoigneeOwner] = useState<SideType>(Side.None);
   const [points, setPoints] = useState("");
+  const [pointsSide, setPointsSide] = useState<"attack" | "defense">("attack");
   const [selfCall, setSelfCall] = useState(false);
 
   useResetOnOpen(open, () => {
@@ -83,12 +84,14 @@ export default function NewGameModal({ createGame, currentDealerName, lastGameCo
     setPoignee(Poignee.None);
     setPoigneeOwner(Side.None);
     setPoints("");
+    setPointsSide("attack");
     setSelfCall(false);
     createGame.reset();
   });
 
   const pointsNum = points === "" ? null : Number(points.replace(",", "."));
   const pointsValid = pointsNum !== null && !isNaN(pointsNum) && pointsNum >= 0 && pointsNum <= 91 && (pointsNum % 1 === 0 || pointsNum % 1 === 0.5);
+  const attackPoints = pointsValid && pointsNum !== null ? (pointsSide === "defense" ? 91 - pointsNum : pointsNum) : null;
   const hasPartner = selfCall || partnerId !== null;
   const completionIntended = points !== "";
   const completionValid = pointsValid && hasPartner;
@@ -102,7 +105,7 @@ export default function NewGameModal({ createGame, currentDealerName, lastGameCo
   const otherPlayers = players.filter((p) => p.id !== selectedTakerId);
 
   const scoreResult = useMemo(() => {
-    if (!pointsValid || !selectedContract) return null;
+    if (!pointsValid || !selectedContract || attackPoints === null) return null;
     return calculateScore({
       chelem,
       contract: selectedContract,
@@ -110,9 +113,9 @@ export default function NewGameModal({ createGame, currentDealerName, lastGameCo
       partnerId: selfCall ? null : partnerId,
       petitAuBout,
       poignee,
-      points: pointsNum!,
+      points: attackPoints,
     });
-  }, [chelem, selectedContract, oudlers, partnerId, petitAuBout, poignee, pointsNum, pointsValid, selfCall]);
+  }, [attackPoints, chelem, selectedContract, oudlers, partnerId, petitAuBout, poignee, pointsValid, selfCall]);
 
   async function completeCreatedGame(game: Game) {
     if (!completionIntended || !completionValid || !sessionId) return;
@@ -127,7 +130,7 @@ export default function NewGameModal({ createGame, currentDealerName, lastGameCo
           petitAuBout,
           poignee,
           poigneeOwner: poignee !== Poignee.None ? poigneeOwner : Side.None,
-          points: pointsNum!,
+          points: attackPoints!,
           status: GameStatus.Completed,
         }),
         headers: { "Content-Type": "application/merge-patch+json" },
@@ -144,7 +147,7 @@ export default function NewGameModal({ createGame, currentDealerName, lastGameCo
           isSelfCall: selfCall,
           oudlers,
           petitAuBout,
-          points: pointsNum!,
+          points: attackPoints!,
           previousScore: null,
           takerScore: scoreResult.takerScore,
         });
@@ -309,9 +312,13 @@ export default function NewGameModal({ createGame, currentDealerName, lastGameCo
               </div>
 
               {/* Points */}
-              <div>
+              <div className="flex gap-2">
+                <div className="flex flex-col gap-1">
+                  <ToggleButton label="Att." onClick={() => setPointsSide("attack")} selected={pointsSide === "attack"} />
+                  <ToggleButton label="Déf." onClick={() => setPointsSide("defense")} selected={pointsSide === "defense"} />
+                </div>
                 <input
-                  className="w-full rounded-xl border border-surface-border bg-surface-primary px-4 py-3 text-center text-lg font-semibold tabular-nums text-text-primary placeholder:text-text-muted focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500"
+                  className="min-w-0 flex-1 rounded-xl border border-surface-border bg-surface-primary px-4 py-3 text-center text-lg font-semibold tabular-nums text-text-primary placeholder:text-text-muted focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500"
                   inputMode="decimal"
                   onChange={(e) => setPoints(e.target.value)}
                   placeholder="Points"

--- a/frontend/src/services/voiceScoreParser.ts
+++ b/frontend/src/services/voiceScoreParser.ts
@@ -9,6 +9,7 @@ export interface VoiceScoreResult {
   playerName?: string;
   poignee?: PoigneeType;
   points?: number;
+  pointsSide?: "attack" | "defense";
 }
 
 const FILLER_WORDS = /\b(euh|heu|donc|alors|ben|bah|hein|voila|voilà)\b/g;
@@ -326,6 +327,15 @@ export function extractBonuses(text: string): BonusResult {
 }
 
 /**
+ * Extract which side the points belong to: "attack", "defense", or null if not mentioned.
+ */
+export function extractPointsSide(text: string): "attack" | "defense" | null {
+  if (/\bdefense\b/.test(text)) return "defense";
+  if (/\battaque\b/.test(text)) return "attack";
+  return null;
+}
+
+/**
  * Main parser: takes a raw transcript and player names, returns a partial score form result.
  * Never throws. Returns empty object for unparseable input.
  */
@@ -350,6 +360,9 @@ export function parseVoiceScore(
 
     const oudlers = extractOudlers(normalized);
     if (oudlers !== null) result.oudlers = oudlers;
+
+    const pointsSide = extractPointsSide(normalized);
+    if (pointsSide) result.pointsSide = pointsSide;
 
     const bonuses = extractBonuses(normalized);
     if (bonuses.petitAuBout) result.petitAuBout = true;


### PR DESCRIPTION
## Résumé

- Ajoute un sélecteur **Att. / Déf.** à côté du champ de points dans les modales de création et complétion de donne
- Les points défense sont convertis en points attaque (91 − pts) avant le calcul et l'envoi à l'API
- La saisie vocale reconnaît les mots « attaque » et « défense »

Fixes #327

## Plan de test

- [x] Toggle Att./Déf. visible dans CompleteGameModal
- [x] Toggle Att./Déf. visible dans NewGameModal (accordéon Résultat)
- [x] Défaut sur « Att. » — comportement inchangé
- [x] Points défense convertis (91 − pts) à la soumission
- [x] Aperçu des scores utilise les points convertis
- [x] Réinitialisation du côté à la réouverture de la modale
- [x] Saisie vocale « défense 46 points » pré-remplit le côté
- [x] 1049 tests frontend passent, 394 tests backend passent, lint clean