### PR TITLE
fix(session): corrige le rafraîchissement en direct de la session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Rafraîchissement en direct** : corrige le rafraîchissement automatique de la session qui ne fonctionnait pas à cause d'un double préfixe `/api` dans l'URL de fraîcheur.
+
 ### Added
 
 - **Mèmes DOOM** : trois mèmes thématiques DOOM (Doomguy ensanglanté, Rip and Tear, Cacodemon) apparaissent uniquement durant la semaine du 10 décembre.

--- a/frontend/src/__tests__/hooks/useSessionFreshness.test.tsx
+++ b/frontend/src/__tests__/hooks/useSessionFreshness.test.tsx
@@ -39,8 +39,32 @@ describe("useSessionFreshness", () => {
     });
 
     await waitFor(() => expect(result.current.data).toBeDefined());
-    expect(mockedApiFetch).toHaveBeenCalledWith("/api/sessions/1/freshness");
+    expect(mockedApiFetch).toHaveBeenCalledWith("/sessions/1/freshness");
     expect(result.current.data?.updatedAt).toBe("2026-03-25T14:00:00+00:00");
+  });
+
+  it("invalidates session queries when updatedAt changes", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    mockedApiFetch.mockResolvedValue({ updatedAt: "2026-03-25T14:00:00+00:00" });
+
+    const { result, rerender } = renderHook(() => useSessionFreshness(1, true), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(invalidateSpy).not.toHaveBeenCalled();
+
+    mockedApiFetch.mockResolvedValue({ updatedAt: "2026-03-25T14:05:00+00:00" });
+    queryClient.setQueryData(["session", 1, "freshness"], { updatedAt: "2026-03-25T14:05:00+00:00" });
+    rerender();
+
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["session", 1] }));
   });
 
   it("does not fetch when disabled", () => {

--- a/frontend/src/hooks/useSessionFreshness.ts
+++ b/frontend/src/hooks/useSessionFreshness.ts
@@ -12,7 +12,7 @@ export function useSessionFreshness(sessionId: number, enabled: boolean) {
 
   const query = useQuery({
     enabled,
-    queryFn: () => apiFetch<FreshnessResponse>(`/api/sessions/${sessionId}/freshness`),
+    queryFn: () => apiFetch<FreshnessResponse>(`/sessions/${sessionId}/freshness`),
     queryKey: ["session", sessionId, "freshness"],
     refetchInterval: 5000,
     refetchIntervalInBackground: false,


### PR DESCRIPTION
## Résumé

- Corrige le double préfixe `/api` dans l'URL du hook `useSessionFreshness` qui provoquait une 404 silencieuse
- Ajoute un test de la logique d'invalidation des requêtes quand `updatedAt` change

fixes #339